### PR TITLE
allow for flexible timesteps, don't just cut after 21 columns

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,3 +1,3 @@
-ValidationKey: '831921'
+ValidationKey: '851312'
 AutocreateReadme: yes
 allowLinterWarnings: no

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piamInterfaces: Project specific interfaces to REMIND / MAgPIE",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "<p>Project specific interfaces to REMIND / MAgPIE.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.0.43
-Date: 2022-12-21
+Version: 0.0.44
+Date: 2022-12-22
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -18,6 +18,7 @@
 #' @param iiasatemplate optional filename of xlsx or yaml file provided by IIASA
 #'        used to delete superfluous variables and adapt units
 #' @param generatePlots boolean, whether to generate plots of failing summation checks
+#' @param timesteps timesteps that are accepted in final submission
 #' @importFrom data.table :=
 #' @importFrom iamc write.reportProject
 #' @importFrom magclass getNames getNames<- mbind read.report write.report
@@ -36,17 +37,17 @@
 #' )
 #' }
 #' @export
-generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 3.0",
+generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 3.0", # nolint: cyclocomp_linter.
                                     mappingFile = NULL,
                                     removeFromScen = NULL, addToScen = NULL,
                                     outputDirectory = "output", outputPrefix = "",
                                     logFile = "output/missing.log",
                                     generateSingleOutput = TRUE,
                                     outputFilename = "submission.mif",
-                                    iiasatemplate = NULL, generatePlots = FALSE) {
-  scenario <- NULL # added to avoid no visible binding error
-  value <- NULL
-  variable <- NULL
+                                    iiasatemplate = NULL, generatePlots = FALSE,
+                                    timesteps = c(seq(2005, 2060, 5), seq(2070, 2100, 10))) {
+  value <- variable <- scenario <- period <- NULL # added to avoid no visible binding error
+  if (isTRUE(timesteps == "all")) timesteps <- seq(1, 3000)
   dir.create(outputDirectory, showWarnings = FALSE)
 
   # for each directory, include all mif files
@@ -92,6 +93,7 @@ generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 
         file = outputMif,
         missing_log = logFile,
       )
+      unlink(tmpfile)
       message("# Restore PM2.5 and poverty w.r.t. median income dots in variable names")
       command <- paste("sed -i 's/wrt median income/w\\.r\\.t\\. median income/g;s/PM2\\_5/PM2\\.5/g'", outputMif)
       system(command)
@@ -100,16 +102,12 @@ generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 
       command <- paste("sed -i 's/N\\/A//g'", outputMif)
       system(command)
 
-      message("# Remove unwanted timesteps")
-      command <- paste("cut -d ';' -f1-21 ", outputMif, " > ", tmpfile)
-      system(command)
-      file.rename(tmpfile, outputMif)
-
       message("# Read data again")
       mifdata <- read.quitte(outputMif, factors = FALSE) %>%
         mutate(model = paste(model)) %>%
-        mutate(value = ifelse(!is.finite(value) | is.na(value), 0, value)) %>%
-        mutate(scenario = gsub("^NA$", "", scenario))
+        mutate(value = ifelse(!is.finite(value) | is.na(value), NA, value)) %>%
+        mutate(scenario = gsub("^NA$", "", scenario)) %>%
+        filter(period %in% timesteps)
 
       if (! is.null(iiasatemplate) && file.exists(iiasatemplate)) {
         mifdata <- checkIIASASubmission(mifdata, iiasatemplate, logFile)
@@ -128,6 +126,9 @@ generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 
 
       unlink(outputMif)
       write.mif(mifdata, outputMif)
+      message("# Replace N/A for missing years with blanks as recommended by Ed Byers")
+      command <- paste("sed -i 's/N\\/A//g'", outputMif)
+      system(command)
 
       # perform summation checks
       for (sumFile in intersect(mapping, names(summationsNames()))) {

--- a/R/generateMappingfile.R
+++ b/R/generateMappingfile.R
@@ -44,6 +44,7 @@ generateMappingfile <- function(templates = NULL, outputDirectory = "output",
                                 factorCol = "piam_factor", weightCol = NULL, spatialCol = "spatial",
                                 model = "REMIND-MAgPIE"
                                 ) {
+  if (is.null(model)) model <- "Model"
   if (is.null(templates)) {
     templates <- chooseFromList(names(templateNames()), type = "templates",
                                 returnBoolean = FALSE, multiple = TRUE, addAllPattern = FALSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.0.43**
+R package **piamInterfaces**, version **0.0.44**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piam_interfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piam_interfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piam_interfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piam_interfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2022). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.0.43, <https://github.com/pik-piam/piam_interfaces>.
+Benke F, Richters O (2022). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.0.44, <URL: https://github.com/pik-piam/piam_interfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2022},
-  note = {R package version 0.0.43},
+  note = {R package version 0.0.44},
   url = {https://github.com/pik-piam/piam_interfaces},
 }
 ```

--- a/man/generateIIASASubmission.Rd
+++ b/man/generateIIASASubmission.Rd
@@ -17,7 +17,8 @@ generateIIASASubmission(
   generateSingleOutput = TRUE,
   outputFilename = "submission.mif",
   iiasatemplate = NULL,
-  generatePlots = FALSE
+  generatePlots = FALSE,
+  timesteps = c(seq(2005, 2060, 5), seq(2070, 2100, 10))
 )
 }
 \arguments{
@@ -49,6 +50,8 @@ if \code{generateSingleOutput} is set to TRUE (default: submission.mif)}
 used to delete superfluous variables and adapt units}
 
 \item{generatePlots}{boolean, whether to generate plots of failing summation checks}
+
+\item{timesteps}{timesteps that are accepted in final submission}
 }
 \description{
 Generates an IIASA submission from REMIND runs by applying a project-specific mapping


### PR DESCRIPTION
- `cut -d ';' -f1-21 outputMif > tmpfile` simply cuts after 21 times ";", which is fine if the mif supplied comes from a standard REMIND run, but is bad if you want to transform something anything else. So rather supply the time-steps explicitly.
- allow to leave `model` as it is by passing `model = NULL`