### PR TITLE
don't fail tests on unnecessary columns and let them work for NAVIGATE

### DIFF
--- a/tests/testthat/test-checkSummations.R
+++ b/tests/testthat/test-checkSummations.R
@@ -2,7 +2,8 @@ for (summationFile in names(summationsNames())) {
   test_that(paste("test summationFile without errors using", summationFile), {
     vars <- NULL
     data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 2, 1, 2),
-                          names = c("Final Energy (EJ)", "Final Energy|Electricity (EJ)", "Final Energy|Liquids (EJ)"))
+                          names = c("Final Energy|Industry (EJ)", "Final Energy|Industry|Electricity (EJ)",
+                                    "Final Energy|Industry|Liquids (EJ)"))
     magclass::getSets(data)[3] <- "variable"
     data <- magclass::add_dimension(data, dim = 3.1, add = "model", nm = "REMIND")
     data <- magclass::add_dimension(data, dim = 3.1, add = "scenario", nm = "default")
@@ -21,7 +22,8 @@ for (summationFile in names(summationsNames())) {
     vars <- NULL
     data <- magclass::new.magpie(cells_and_regions = c("CAZ", "World"), years = c(2030, 2050),
                           fill = c(3, 5, 1, 2, 1, 2, 3, 5, 1, 2, 1, 2),
-                          names = c("Final Energy (EJ)", "Final Energy|Electricity (EJ)", "Final Energy|Liquids (EJ)"))
+                          names = c("Final Energy|Industry (EJ)", "Final Energy|Industry|Electricity (EJ)",
+                                    "Final Energy|Industry|Liquids (EJ)"))
     magclass::getSets(data)[3] <- "variable"
     data <- magclass::add_dimension(data, dim = 3.1, add = "model", nm = "REMIND")
     data <- magclass::add_dimension(data, dim = 3.1, add = "scenario", nm = "default")

--- a/tests/testthat/test-getTemplate.R
+++ b/tests/testthat/test-getTemplate.R
@@ -2,8 +2,8 @@ test_that("basic checks on main templates", {
   minimalLength <- list("AR6" = 1900, "NAVIGATE" = 1900)
   for (template in names(templateNames())) {
     expect_silent(templateData <- getTemplate(template))
-    expect_true(all(c("idx", "Variable", "Unit", "piam_variable", "piam_unit", "piam_factor",
-                      "internal_comment", "Comment", "Definition") %in% names(templateData)))
+    expect_true(all(c("Variable", "Unit", "piam_variable", "piam_unit", "piam_factor",
+                      "Comment") %in% names(templateData)))
     expect_true(class(templateData) == "data.frame")
     expect_true(length(templateData$Variable) > max(0, unlist(minimalLength[template])))
   }


### PR DESCRIPTION
- "idx", "internal_comment", "Definition" are not actually needed
- use for tests variables that are in NAVIGATE template