### PR TITLE
also add "bn m2" = "bn m2/yr" to identicalUnits

### DIFF
--- a/R/checkIIASASubmission.R
+++ b/R/checkIIASASubmission.R
@@ -34,6 +34,7 @@ checkIIASASubmission <- function(mifdata, iiasatemplate, logFile = NULL, failOnU
                       # for backwards compatibility with AR6 and SHAPE templates (using old incorrect unit)
                       # should only affect template variable 'Energy Service|Residential and Commercial|Floor Space'
                       "bn m2/yr" = "bn m2",
+                      "bn m2" = "bn m2/yr",
                  NULL)
 
   if (length(mifdata) == 1 && file.exists(mifdata)) {


### PR DESCRIPTION
will be fixed in some AR6-based templates as well, so better let it work all the time