### PR TITLE
add interactive mode to plotIntercomparison

### DIFF
--- a/man/plotIntercomparison.Rd
+++ b/man/plotIntercomparison.Rd
@@ -10,7 +10,9 @@ plotIntercomparison(
   outputDirectory = ".",
   summationsFile = "AR6",
   renameModels = NULL,
-  lineplotVariables = c("Temperature|Global Mean")
+  lineplotVariables = "AR6",
+  interactive = FALSE,
+  mainReg = "World"
 )
 }
 \arguments{
@@ -24,6 +26,10 @@ plotIntercomparison(
 
 \item{lineplotVariables}{vector with variable names for additional lineplots or filenames
 of files containing a 'Variable' column (or both)}
+
+\item{interactive}{boolean whether you want to select variables, regions and models to be plotted}
+
+\item{mainReg}{region name of main region to be passed to mip}
 }
 \description{
 Model intercomparison plots: area plots based on summation groups, line plots for further

--- a/tutorial.md
+++ b/tutorial.md
@@ -16,8 +16,12 @@ For a human-readable output, save the old version of the mapping and run:
   remind2::compareScenConf(fileList = c("oldfile.csv", "mappingfile.csv"), row.names = NULL)
   ```
 
-- To compare the results of different models, filter `modeldata` ([quitte](https://github.com/pik-piam/quitte/) object or csv/xlsx file) appropriately such that model regions are not too different. You get a PDF document for each scenario and each model with area plots for all the summation groups in `AR6` (or `NAVIGATE`) [summation files](https://github.com/pik-piam/piamInterfaces/tree/master/inst/summations) plus line plots for each variable in the `lineplotVariables` vector you supplied. It takes some time, better use a `slurm` job for:
+- To compare the results of different models, pass as `modeldata` a [quitte](https://github.com/pik-piam/quitte/) object or a csv/xlsx file. You get a PDF document for each scenario and each model with area plots for all the summation groups in `AR6` (or `NAVIGATE`) [summation files](https://github.com/pik-piam/piamInterfaces/tree/master/inst/summations) plus line plots for each variable in the `lineplotVariables` vector you supplied. It takes some time, better use a `slurm` job for:
   ```
   plotIntercomparison(modeldata, summationsFile = "AR6", lineplotVariables = c("Temperature|Global Mean", "Population"))
   ```
 
+- If your `modeldata` is not well filtered such that for example model regions are not too different, you can use `interactive = TRUE` which allows to select models, regions, scenarios and variables that you like in your PDF. As `lineplotVariables`, you can also specify template names.
+  ```
+  plotIntercomparison(modeldata, summationsFile = "AR6", lineplotVariables = c("AR6", "AR6_NGFS"), interactive = TRUE)
+  ```


### PR DESCRIPTION
- If your `modeldata` is not well filtered such that for example model regions are not too different, you can use `interactive = TRUE` which allows to select models, regions, scenarios and variables that you like in your PDF. As `lineplotVariables`, you can also specify template names.