### PR TITLE
fix inner_join warning about 'many-to-many'

### DIFF
--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -89,7 +89,8 @@ generateIIASASubmission <- function(mifs = ".", mapping = NULL, model = "REMIND 
       !!sym("unit") := str_trim(!!sym("unit"))
       ) %>%
     distinct() %>%
-    inner_join(mapData, by = c("variable" = "piam_variable", "unit" = "piam_unit"), multiple = "all") %>%
+    inner_join(mapData, by = c("variable" = "piam_variable", "unit" = "piam_unit"),
+               relationship = "many-to-many") %>%
     mutate(
       !!sym("value") := ifelse(is.na(!!sym("factor")), !!sym("value"), !!sym("factor") * !!sym("value"))
     ) %>%


### PR DESCRIPTION
- seems to be a new warning message introduced by dplyr that leads to failed test: https://github.com/pik-piam/piamInterfaces/actions/runs/4572237708/jobs/8071283648?pr=102
- See [explanation here](https://github.com/tidyverse/dplyr/commit/178d168e29334d4d35563827cfb14cc6fa0cc076): "This change unfortunately does mean that if you have set `multiple = "all"` to avoid a warning and you happened to be doing a many-to-many style join, then you will need to replace `multiple = "all"` with `relationship = "many-to-many"` to silence the new warning, but we believe this should be rare since many-to-many relationships are fairly uncommon."