### PR TITLE
run two tests in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,3 +29,6 @@ Suggests:
     writexl
 Encoding: UTF-8
 RoxygenNote: 7.2.3
+Config/testthat/parallel: true
+Config/testthat/edition: 3
+Config/testthat/start-first: plotIntercomparison, checkSummations


### PR DESCRIPTION
- and prioritize those that take the longest
- reduces waiting from 25 to 14 seconds