### PR TITLE
exclude NAVIGATE variables from remind2 tests

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1836290'
+ValidationKey: '1856395'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.0.94
-date-released: '2023-06-27'
+version: 0.0.95
+date-released: '2023-07-03'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.0.94
-Date: 2023-06-27
+Version: 0.0.95
+Date: 2023-07-03
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.0.94**
+R package **piamInterfaces**, version **0.0.95**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.0.94, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.0.95, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -73,7 +73,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2023},
-  note = {R package version 0.0.94},
+  note = {R package version 0.0.95},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -253,7 +253,7 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 219;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Bus;Mt CO2/yr;;;;;;Fossil CO2 emissions from fuel combustion by buses;
 220;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Domestic Aviation;Mt CO2/yr;;;;;;Fossil CO2 emissions from fuel combustion by domestic aviation;
 221;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Domestic Shipping;Mt CO2/yr;;;;;;Fossil CO2 emissions from fuel combustion by domestic shipping;
-222;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|LDV;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|LDV|Demand;Mt CO2/yr;;;;Fossil CO2 emissions from fuel combustion by light duty vehicles;
+222;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|LDV;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|LDV|Demand;Mt CO2/yr;;;;Fossil CO2 emissions from fuel combustion by light duty vehicles;x
 223;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Rail;Mt CO2/yr;Emi|CO2|Transport|Rail|Demand;Mt CO2/yr;;;;Fossil CO2 emissions from fuel combustion by trains;x
 224;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Truck;Mt CO2/yr;;;;;;Fossil CO2 emissions from fuel combustion by trucks;
 225;2;emissions (CO2);Emissions|CO2|Energy|Demand|Transportation|Bus|Liquids;Mt CO2/yr;;;;;;Fossil CO2 emissions from Liquids use in the transportation sector by buses;
@@ -892,10 +892,10 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 848;2;energy (final);Final Energy|Transportation|Bus|Gases;EJ/yr;FE|Transport|Pass|Road|Bus|Gases;EJ/yr;;;;final energy consumption of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses in the transportation sector by bus;x
 849;2;energy (final);Final Energy|Transportation|Bus|Hydrogen;EJ/yr;FE|Transport|Pass|Road|Bus|Hydrogen;EJ/yr;;;;final energy consumption of hydrogen in the transportation sector by bus;x
 850;2;energy (final);Final Energy|Transportation|Bus|Liquids;EJ/yr;FE|Transport|Pass|Road|Bus|Liquids;EJ/yr;;;;final energy consumption of refined liquids (conventional & unconventional oil, biofuels, coal-to-liquids, gas-to-liquids) in the transportation sector by bus;x
-851;2;energy (final);Final Energy|Transportation|LDV|Electricity;EJ/yr;FE|Transport|LDV|Electricity;EJ/yr;;;;final energy consumption of electricity (including on-site solar PV), excluding transmission/distribution losses in the transportation sector by LDV;
-852;2;energy (final);Final Energy|Transportation|LDV|Gases;EJ/yr;FE|Transport|LDV|Gases;EJ/yr;;;;final energy consumption of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses in the transportation sector by LDV;
-853;2;energy (final);Final Energy|Transportation|LDV|Hydrogen;EJ/yr;FE|Transport|LDV|Hydrogen;EJ/yr;;;;;
-854;2;energy (final);Final Energy|Transportation|LDV|Liquids;EJ/yr;FE|Transport|LDV|Liquids;EJ/yr;;;;;
+851;2;energy (final);Final Energy|Transportation|LDV|Electricity;EJ/yr;FE|Transport|LDV|Electricity;EJ/yr;;;;final energy consumption of electricity (including on-site solar PV), excluding transmission/distribution losses in the transportation sector by LDV;x
+852;2;energy (final);Final Energy|Transportation|LDV|Gases;EJ/yr;FE|Transport|LDV|Gases;EJ/yr;;;;final energy consumption of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses in the transportation sector by LDV;x
+853;2;energy (final);Final Energy|Transportation|LDV|Hydrogen;EJ/yr;FE|Transport|LDV|Hydrogen;EJ/yr;;;;;x
+854;2;energy (final);Final Energy|Transportation|LDV|Liquids;EJ/yr;FE|Transport|LDV|Liquids;EJ/yr;;;;;x
 855;2;energy (final);Final Energy|Transportation|Rail|Electricity;EJ/yr;;;;;;;
 856;2;energy (final);Final Energy|Transportation|Rail|Gases;EJ/yr;;;;;;;
 857;2;energy (final);Final Energy|Transportation|Rail|Hydrogen;EJ/yr;;;;;;;


### PR DESCRIPTION
The following variables are excluded from the remind2 NAVIGATE test, as they are produced by EDGE-T reporting, not standard remind2 reporting.

```
Emi|CO2|Transport|Pass|Road|LDV|Demand (Mt CO2/yr)
FE|Transport|LDV|Electricity (EJ/yr)
FE|Transport|LDV|Gases (EJ/yr)
FE|Transport|LDV|Hydrogen (EJ/yr)
```