### PR TITLE
fix AR6 Hydrogen summation group: Biomass is part of Renewable already

### DIFF
--- a/inst/summations/summation_groups_AR6.csv
+++ b/inst/summations/summation_groups_AR6.csv
@@ -521,7 +521,6 @@ Investment|Energy Supply|Electricity;Investment|Energy Supply|Electricity|Other;
 Investment|Energy Supply|Electricity;Investment|Energy Supply|Electricity|Solar;1
 Investment|Energy Supply|Electricity;Investment|Energy Supply|Electricity|Transmission and Distribution;1
 Investment|Energy Supply|Electricity;Investment|Energy Supply|Electricity|Wind;1
-Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Biomass;1
 Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Electricity;1
 Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Fossil;1
 Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Other;1


### PR DESCRIPTION
The values from `Investment|Energy Supply|Hydrogen|Biomass` ([sum over `peBio`](
https://github.com/pik-piam/remind2/blob/a173ba563b4ed648374ed4eb85d9e4e3409d1bcd/R/reportEnergyInvestment.R#L149-L150)) is already contained in `Investment|Energy Supply|Hydrogen|Renewable` (sum over `peRe`) as defined in [`core/sets.gms`](https://github.com/remindmodel/remind/blob/733070da3f70e42a99878acdb83e6e9b563c430e/core/sets.gms#L1676-L1691), leading to double-counting, so I take biomass out of the summation group.