### PR TITLE
let extractVariableGroups work with multiple summations (+, ++, …)

### DIFF
--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -42,6 +42,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 
   if (isTRUE(summationsFile == "extractVariableGroups")) {
     checkVariables <- extractVariableGroups(levels(data$variable), keepOrigNames = TRUE)
+    names(checkVariables) <- make.unique(names(checkVariables), sep = " ")
   } else {
     summationGroups <- getSummations(summationsFile)
     if (summationsFile %in% names(summationsNames())) {


### PR DESCRIPTION
- fixes #158
- if the summation group parents are identical, the script is confused. So if they are not unique, make them unique by adding some number