### PR TITLE
avoiding double accounting introduced by deprecated SE|Gases|+|Waste variables

### DIFF
--- a/inst/templates/mapping_template_ARIADNE.csv
+++ b/inst/templates/mapping_template_ARIADNE.csv
@@ -1236,7 +1236,7 @@ Tier;Category;Variable;Unit;Definition;piam_variable;piam_unit;piam_factor;Comme
 1;energy (supply);Secondary Energy|Gases|Coal;PJ/yr;total production of coal gas from coal gasification;SE|Gases|Fossil|+|Coal;EJ/yr;1000;;0;;
 1;energy (supply);Secondary Energy|Gases|Natural Gas;PJ/yr;Secondary energy gases derived from natural gas (excluding pure hydrogen) for the usage in the buildings, transport and industry sector. This does not include the usage of natural gas for energy conversion into secondary energy other than gases.;SE|Gases|Fossil|+|Natural Gas;EJ/yr;1000;;0;;
 1;energy (supply);Secondary Energy|Gases|Hydrogen;PJ/yr;Total production of gases from hydrogen and CO2;SE|Gases|+|Hydrogen;EJ/yr;1000;;0;;
-1;energy (supply);Secondary Energy|Gases|Other;PJ/yr;total production of gases from sources that do not fit any other category;SE|Gases|+|Waste;EJ/yr;1000;;0;;
+1;energy (supply);Secondary Energy|Gases;PJ/yr;total production of gases from sources that do not fit any other category;SE|Gases|+|Waste;EJ/yr;-1000;;0;;
 1;energy (supply);Secondary Energy|Heat;PJ/yr;total district heat generation;SE|Heat;EJ/yr;1000;;0;;
 1;energy (supply);Secondary Energy|Heat|Biomass;PJ/yr;district heat generation from biomass;SE|Heat|+|Biomass;EJ/yr;1000;;0;;
 2;energy (supply);Secondary Energy|Heat|Biomass|w/ CCS;PJ/yr;district heat generation from biomass with CCS;;;;;0;;

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -1240,7 +1240,7 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 1177;1;energy (secondary);Secondary Energy|Electricity|Wind|Onshore;EJ/yr;;;;;;net electricity production from onshore wind energy;
 1178;1;energy (secondary);Secondary Energy|Electricity|Hydrogen;EJ/yr;;;;;;net electricity production from hydrogen;
 1179;1;energy (secondary);Secondary Energy|Gases;EJ/yr;SE|Gases;EJ/yr;;;;total production of gaseous fuels, including natural gas;
-1179;1;energy (secondary);Secondary Energy|Gases;EJ/yr;SE|Gases|+|Waste;EJ/yr;;;;total production of gaseous fuels, including natural gas;
+1179;1;energy (secondary);Secondary Energy|Gases;EJ/yr;SE|Gases|+|Waste;EJ/yr;-1;;;total production of gaseous fuels, including natural gas;
 1180;1;energy (secondary);Secondary Energy|Heat;EJ/yr;SE|Heat;EJ/yr;;;;total centralized heat generation;
 1181;1;energy (secondary);Secondary Energy|Hydrogen;EJ/yr;SE|Hydrogen;EJ/yr;;;;total hydrogen production;
 1182;1;energy (secondary);Secondary Energy|Liquids;EJ/yr;SE|Liquids;EJ/yr;;;;total production of refined liquid fuels from all energy sources (incl. oil products, synthetic fossil fuels from gas and coal, biofuels);


### PR DESCRIPTION
- subtracting deprecated `SE|Gases|+|Waste` from total `SE|Gases` variable mappings to avoid double accounting as its contents are already included at `SE|Gases|+|Biomass` in the model.

Warning: 
- the remind2 bugfix related with this change will cause a warning message to pop-up while buildings the remind2 library.
- In order to apply this fix to current runs, we will keep this variable in the mappings for a couple of months.
- Any reporting created after the pull request https://github.com/pik-piam/remind2/pull/456 will not need this ex-post fix.
- After this transition period, all references for the `SE|Gases|+|Waste` will be removed from piamInterfaces.