### PR TITLE
add SE|Solids|Coal to NAVIGATE template

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '196110'
+ValidationKey: '215732'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.1.0
-date-released: '2023-09-11'
+version: 0.1.1
+date-released: '2023-09-12'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.1.0
-Date: 2023-09-11
+Version: 0.1.1
+Date: 2023-09-12
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.1.0**
+R package **piamInterfaces**, version **0.1.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.1.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.1.1, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -73,7 +73,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2023},
-  note = {R package version 0.1.0},
+  note = {R package version 0.1.1},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -1303,7 +1303,7 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 1239;2;energy (secondary);Secondary Energy|Solids;EJ/yr;SE|Solids;EJ/yr;;;;solid secondary energy carriers (e.g., briquettes, coke, wood chips, wood pellets);
 1240;2;energy (secondary);Secondary Energy|Solids|Biomass;EJ/yr;SE|Solids|+|Biomass;EJ/yr;;;;solid secondary energy carriers produced from biomass (e.g., commercial charcoal, wood chips, wood pellets). Tradional bioenergy use is excluded.;
 1240;2;energy (secondary);Secondary Energy|Solids|Biomass;EJ/yr;SE|Solids|+|Traditional Biomass;EJ/yr;;;;solid secondary energy carriers produced from biomass (e.g., commercial charcoal, wood chips, wood pellets). Tradional bioenergy use is excluded.;
-1241;2;energy (secondary);Secondary Energy|Solids|Fossil;EJ/yr;;;;;;solid secondary energy carriers produced from fossils (e.g., briquettes, coke);
+1241;2;energy (secondary);Secondary Energy|Solids|Fossil;EJ/yr;SE|Solids|+|Coal;EJ/yr;;;;solid secondary energy carriers produced from fossils (e.g., briquettes, coke);
 1242;2;energy (secondary);Conversion Input|Liquids|Electricity;EJ/yr;;;;;;secondary energy consumption of efuels for the production of electricity;
 1243;2;energy (secondary);Conversion Input|Hydrogen|Electricity;EJ/yr;;;;;;secondary energy consumption of hydrogen for the production of electricity;
 1244;2;energy (secondary);Conversion Input|Hydrogen|Liquids;EJ/yr;;;;;;secondary energy consumption of hydrogen for the production of liquids (synfuels);

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -1253,8 +1253,8 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 1189;2;energy (secondary);Secondary Energy|Gases|Biomass;EJ/yr;SE|Gases|+|Biomass;EJ/yr;;;;total production of biogas;
 1190;2;energy (secondary);Secondary Energy|Gases|Coal;EJ/yr;SE|Gases|Fossil|+|Coal;EJ/yr;;;;total production of coal gas from coal gasification;
 1191;2;energy (secondary);Secondary Energy|Gases|Fossil;EJ/yr;;;;;;total production of gas from fossils;
-1192;2;energy (secondary);Secondary Energy|Gases|Electricity;EJ/yr;;;;;;total production of gas from electricity (power to gas);
-1193;2;energy (secondary);Secondary Energy|Gases|Other;EJ/yr;SE|Gases|+|Hydrogen;EJ/yr;;;;total production of gases from sources that do not fit any other category;
+1192;2;energy (secondary);Secondary Energy|Gases|Electricity;EJ/yr;SE|Gases|+|Hydrogen;EJ/yr;;;;total production of gas from electricity (power to gas);
+1193;2;energy (secondary);Secondary Energy|Gases|Other;EJ/yr;;;;;;total production of gases from sources that do not fit any other category;
 1194;2;energy (secondary);Secondary Energy|Heat|Biomass;EJ/yr;SE|Heat|+|Biomass;EJ/yr;;;;centralized heat generation from biomass;
 1195;2;energy (secondary);Secondary Energy|Heat|Coal;EJ/yr;SE|Heat|+|Coal;EJ/yr;;;;centralized heat generation from coal;
 1196;2;energy (secondary);Secondary Energy|Heat|Gas;EJ/yr;SE|Heat|+|Gas;EJ/yr;;;;centralized heat generation from gases;


### PR DESCRIPTION
- any reason `SE|Solids|Coal` was not mapped to `Secondary Energy|Solids|Fossil`?
- Another question: We map remind2 variable `Price|Secondary Energy|Gases|Hydrogen` to `Price|Secondary Energy|Gases|Electricity`, but we do not map anything to `Secondary Energy|Gases|Electricity`, but rather map `SE|Gases|+|Hydrogen` to `Secondary Energy|Gases|Other` which seems plausible. But to me, it is strange to have a price for a variable that we don't report. What to do?