### PR TITLE
Add extra log line to display variables missing from the data in failed summations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '588870'
+ValidationKey: '608716'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '628448'
+ValidationKey: '648087'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.3.2
+version: 0.3.3
 date-released: '2023-10-09'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.3.0
-date-released: '2023-09-29'
+version: 0.3.1
+date-released: '2023-10-06'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.3.0
-Date: 2023-09-29
+Version: 0.3.1
+Date: 2023-10-06
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.3.2
+Version: 0.3.3
 Date: 2023-10-09
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -169,7 +169,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
         if (! is.null(template)) paste0("corresponding REMIND/MAgPIE variables extracted from ", basename(templateName))
          ))
       for (p in problematic) {
-        signofdiff <- paste0("<"[max(fileLarge$diff[fileLarge$variable == p]) > 0],
+                signofdiff <- paste0("<"[max(fileLarge$diff[fileLarge$variable == p]) > 0],
                              ">"[min(fileLarge$diff[fileLarge$variable == p]) < 0])
 
         childs <- checkVariables[[p]]
@@ -202,6 +202,10 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
                           absDiffMax, " ",
                           paste0(unique(fileLarge$unit[fileLarge$variable == p]), collapse = ", "), ".")
         )
+        childMissing <- childs[!childs %in% data$variable]
+        if (length(childMissing) > 0) {
+          text <- c(text, paste0("Variables not found in the data: ", toString(childMissing)))
+        }
         if (generatePlots) {
           message("Add plot for ", p)
           mip::showAreaAndBarPlots(plotdata, intersect(childs, unique(plotdata$variable)), tot = p,

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -169,7 +169,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
         if (! is.null(template)) paste0("corresponding REMIND/MAgPIE variables extracted from ", basename(templateName))
          ))
       for (p in problematic) {
-                signofdiff <- paste0("<"[max(fileLarge$diff[fileLarge$variable == p]) > 0],
+        signofdiff <- paste0("<"[max(fileLarge$diff[fileLarge$variable == p]) > 0],
                              ">"[min(fileLarge$diff[fileLarge$variable == p]) < 0])
 
         childs <- checkVariables[[p]]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.3.2**
+R package **piamInterfaces**, version **0.3.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.3.2, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.3.3, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -73,7 +73,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3.2},
+  note = {R package version 0.3.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.3.0**
+R package **piamInterfaces**, version **0.3.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.3.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.3.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -73,7 +73,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3.0},
+  note = {R package version 0.3.1},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```


### PR DESCRIPTION
Add extra log line to the `checkSummations` function to display variables missing from the data in failed summations.