### PR TITLE
make csv separator in checkSummations an optional input parameter

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1041026'
+ValidationKey: '1060722'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.5.3
-date-released: '2023-10-12'
+version: 0.5.4
+date-released: '2023-10-13'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.5.3
-Date: 2023-10-12
+Version: 0.5.4
+Date: 2023-10-13
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -20,6 +20,7 @@
 #'                to be listed in human-readable summary
 #' @param roundDiff should the absolute and relative differences in human-readable summary
 #'                  be rounded?
+#' @param csvSeparator separator for dataDumpFile, defaults to semicolon
 #' @importFrom dplyr group_by summarise ungroup left_join mutate arrange %>%
 #'             filter select desc
 #' @importFrom grDevices pdf dev.off
@@ -35,7 +36,7 @@
 checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, summationsFile = NULL,
                             logFile = NULL, logAppend = FALSE, generatePlots = FALSE, mainReg = "World",
                             dataDumpFile = "checkSummations.csv", remindVar = "piam_variable",
-                            plotprefix = NULL, absDiff = 0.001, relDiff = 1, roundDiff = TRUE) {
+                            plotprefix = NULL, absDiff = 0.001, relDiff = 1, roundDiff = TRUE, csvSeparator = ";") {
   if (!is.null(outputDirectory) && !dir.exists(outputDirectory) && ! is.null(c(logFile, dataDumpFile))) {
     dir.create(outputDirectory, recursive = TRUE)
   }
@@ -118,8 +119,12 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
   if (!is.null(outputDirectory) && length(dataDumpFile) > 0) {
     dataDumpFile <- file.path(outputDirectory, dataDumpFile)
     write.table(
-      arrange(tmp, desc(abs(!!sym("reldiff")))), sep = ";",
-      file = dataDumpFile, quote = FALSE, row.names = FALSE)
+      arrange(tmp, desc(abs(!!sym("reldiff")))),
+      file = dataDumpFile,
+      sep = csvSeparator,
+      quote = FALSE,
+      row.names = FALSE
+    )
   }
 
   # generate human-readable summary of larger differences

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.5.3**
+R package **piamInterfaces**, version **0.5.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.5.3, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.5.4, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -73,7 +73,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2023},
-  note = {R package version 0.5.3},
+  note = {R package version 0.5.4},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/checkSummations.Rd
+++ b/man/checkSummations.Rd
@@ -18,7 +18,8 @@ checkSummations(
   plotprefix = NULL,
   absDiff = 0.001,
   relDiff = 1,
-  roundDiff = TRUE
+  roundDiff = TRUE,
+  csvSeparator = ";"
 )
 }
 \arguments{
@@ -53,6 +54,8 @@ to be listed in human-readable summary}
 
 \item{roundDiff}{should the absolute and relative differences in human-readable summary
 be rounded?}
+
+\item{csvSeparator}{separator for dataDumpFile, defaults to semicolon}
 }
 \description{
 Checks for a run if the variables sum up as expected and logs spotted gaps


### PR DESCRIPTION
Renato requested:
 > Could we add the separator of the checksummations csv file as an option of the function?
It is more common for other model partners to use comma instead of semicolon as the csv separator file.
This option would make easier to share results in the project.  