### PR TITLE
make sure niceround works well on vectors

### DIFF
--- a/R/niceround.R
+++ b/R/niceround.R
@@ -6,5 +6,6 @@
 niceround <- function(x, digits = 3) {
   x <- as.numeric(x)
   digits <- pmax(digits, ceiling(log10(abs(x))))
-  return(format(signif(x, digits), scientific = FALSE))
+  # this construction is needed to make sure every value is rounded individually
+  return(vapply(seq_along(x), function(i) format(signif(x[i], digits[i]), scientific = FALSE), character(1)))
 }

--- a/tests/testthat/test-niceround.R
+++ b/tests/testthat/test-niceround.R
@@ -29,4 +29,9 @@ test_that("niceround works", {
   expect_identical(niceround(.000, digits = 1), "0")
   expect_identical(niceround("4.4", digits = 1), "4")
   expect_identical(niceround("1e-3", digits = 1), "0.001")
+  test <- c(1234, 0.000312340897, "-112.1234")
+  for (d in seq_along(10)) {
+    expect_identical(niceround(test, digits = d),
+                     sapply(test, niceround, digits = d, USE.NAMES = FALSE))
+  }
 })


### PR DESCRIPTION
old:
```
niceround(c(1234, 0.000333))
> "1234.000000" "   0.000333"
```
new:
```
niceround(c(1234, 0.000333))
> "1234"     "0.000333"
```