### PR TITLE
Variable set for use with IIASA's `climate_assessment`

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2403644'
+ValidationKey: '2428881'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,3 @@
-# Run CI for R using https://eddelbuettel.github.io/r-ci/
-
 name: check
 
 on:
@@ -8,11 +6,6 @@ on:
   pull_request:
     branches: [main, master]
 
-env:
-  USE_BSPM: "true"
-  _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -20,79 +13,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Bootstrap
-        run: |
-          sudo chown runner -R .
-          sudo locale-gen en_US.UTF-8
-          sudo add-apt-repository -y ppa:ubuntugis/ppa
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
-          ./run.sh bootstrap
-          rm -f bspm_*.tar.gz
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Enable r-universe repo, modify bspm integration
-        run: |
-          # install packages from https://pik-piam.r-universe.dev and CRAN
-          echo '
-          options(repos = c(universe = "https://pik-piam.r-universe.dev",
-                            CRAN = "https://cloud.r-project.org"))
-          ' >> .Rprofile
-          cat .Rprofile
-          # modify bspm integration to never install binary builds of PIK CRAN packages
-          sudo sed -i '/bspm::enable()/d' /etc/R/Rprofile.site
-          # need double % because of printf, %s is replaced with "$NO_BINARY_INSTALL_R_PACKAGES" (see "env:" above)
-          printf '
-          local({
-            expr <- quote({
-              if (!is.null(repos)) {
-                noBinaryInstallRPackages <- %s
-                pkgs <- c(bspm::install_sys(pkgs[!pkgs %%in%% noBinaryInstallRPackages]),
-                          pkgs[pkgs %%in%% noBinaryInstallRPackages])
-              }
-              type <- "source"
-            })
-            trace(utils::install.packages, expr, print = FALSE)
-          })
-          ' "$NO_BINARY_INSTALL_R_PACKAGES" | sudo tee --append /etc/R/Rprofile.site >/dev/null
-          cat /etc/R/Rprofile.site
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
 
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            gamstransfer=?ignore
+            any::lucode2
+            any::covr
+            any::madrat
+            any::magclass
+            any::citation
+            any::gms
+            any::goxygen
+            any::GDPuc
+          # piam packages also available on CRAN (madrat, magclass, citation,
+          # gms, goxygen, GDPuc) will usually have an outdated binary version
+          # available; by using extra-packages we get the newest version
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-
-      - name: Cache R libraries
-        if: ${{ !env.ACT }} # skip when running locally via nektos/act
-        uses: pat-s/always-upload-cache@v3
-        with:
-          path: /usr/local/lib/R/
-          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
-          restore-keys: |
-            3-${{ runner.os }}-usr-local-lib-R-
-
-      - name: Restore R library permissions
-        run: |
-          sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
-
-      - name: Install dependencies
-        run: |
-          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
-          ./run.sh install_all
-          ./run.sh install_r_binary covr rstudioapi
-          ./run.sh install_r lucode2
 
       - name: Install python dependencies if applicable
         run: |
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
-
-      - name: Remove bspm integration # to get rid of error when running install.packages
-        run: |
-          sudo sed -i '/  trace(utils::install.packages, expr, print = FALSE)/d' /etc/R/Rprofile.site
-          cat /etc/R/Rprofile.site
 
       - name: Verify validation key
         shell: Rscript {0}
@@ -106,6 +57,8 @@ jobs:
 
       - name: Test coverage
         shell: Rscript {0}
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
+          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9013
+    rev: v0.3.2.9025
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.12.2
-date-released: '2023-12-11'
+version: 0.12.3
+date-released: '2024-01-25'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.12.2
-Date: 2023-12-11
+Version: 0.12.3
+Date: 2024-01-25
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.12.2**
+R package **piamInterfaces**, version **0.12.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -64,7 +64,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2023). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.2, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.3, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -72,8 +72,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  year = {2023},
-  note = {R package version 0.12.2},
+  year = {2024},
+  note = {R package version 0.12.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/iiasaTemplates/climate_assessment_variables.yaml
+++ b/inst/iiasaTemplates/climate_assessment_variables.yaml
@@ -1,0 +1,118 @@
+- Carbon Sequestration|CCS:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Demand|Industry:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Supply:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Supply|Electricity:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Supply|Gases:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Supply|Hydrogen:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Biomass|Energy|Supply|Liquids:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Demand|Industry:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Supply:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Supply|Electricity:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Supply|Gases:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Supply|Hydrogen:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Energy|Supply|Liquids:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Fossil|Industrial Processes:
+    unit: Mt CO2/yr
+- Carbon Sequestration|CCS|Industrial Processes:
+    unit: Mt CO2/yr
+- Carbon Sequestration|Direct Air Capture:
+    unit: Mt CO2/yr
+- Carbon Sequestration|Enhanced Weathering:
+    unit: Mt CO2/yr
+- Carbon Utilization|CCS|Industry:
+    unit: Mt CO2/yr
+- Emissions|C2F6:
+    unit: kt C2F6/yr
+- Emissions|C6F14:
+    unit: kt C6F14/yr
+- Emissions|CF4:
+    unit: kt CF4-equiv/yr
+- Emissions|CH4:
+    unit: Mt CH4/yr
+- Emissions|CH4|AFOLU|Land:
+    unit: Mt CH4/yr
+- Emissions|CH4|Energy|Supply:
+    unit: Mt CH4/yr
+- Emissions|CH4|Waste:
+    unit: Mt CH4/yr
+- Emissions|CO2:
+    unit: Mt CO2/yr
+- Emissions|CO2|AFOLU:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy and Industrial Processes:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Industry:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Industry|Cement:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Industry|Chemicals:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Industry|Other:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Industry|Steel:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Residential and Commercial:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Demand|Transportation:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Electricity:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Gases:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Heat:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Liquids:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Other Sector:
+    unit: Mt CO2/yr
+- Emissions|CO2|Energy|Supply|Solids:
+    unit: Mt CO2/yr
+- Emissions|CO2|Industrial Processes:
+    unit: Mt CO2/yr
+- Emissions|CO2|Industrial Processes|Cement:
+    unit: Mt CO2/yr
+- Emissions|CO2|Other:
+    unit: Mt CO2/yr
+- Emissions|F-Gases:
+    unit: Mt CO2-equiv/yr
+- Emissions|HFC:
+    unit: kt HFC134a-equiv/yr
+- Emissions|Kyoto Gases:
+    unit: Mt CO2-equiv/yr
+- Emissions|N2O:
+    unit: kt N2O/yr
+- Emissions|N2O|AFOLU|Land:
+    unit: kt N2O/yr
+- Emissions|N2O|Energy|Demand|Transportation:
+    unit: kt N2O/yr
+- Emissions|N2O|Industrial Processes:
+    unit: kt N2O/yr
+- Emissions|N2O|Waste:
+    unit: kt N2O/yr
+- Emissions|SF6:
+    unit: kt SF6/yr


### PR DESCRIPTION
## Purpose of this PR

Facilitates emission data extraction from REMIND MIFs before generating input suitable for use with IIASA's [`climate_assessment` package](https://github.com/iiasa/climate-assessment/tree/main) as suggested in [this comment](https://github.com/remindmodel/remind/pull/1475#discussion_r1404060669) to a more extensive REMIND PR.

## Checklist:
- [ ] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)

