### PR TITLE
add piam_factor check for EUR_2020, simplify code

### DIFF
--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -24,7 +24,9 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                           c("1000", "T", "P"),
                           c("1000", "G", "T"),
                           c("1000", "M", "G"),
-                          c("1000", "k", "M")
+                          c("1000", "k", "M"),
+                          c("1.10774", "US$2010", "US$2005"),
+                          c("1.17", "EUR_2020", "US$2005")
                          )
   firsterror <- TRUE
   for (sc in scaleConversion) {
@@ -35,7 +37,7 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                     filter(! .data$piam_factor %in% c(sc[[1]], paste0("-", sc[[1]])))
     if (nrow(wrongScale) > 0) {
       if (isTRUE(firsterror)) {
-        errortext <- c(errortext, "The following variables have the wrong factor as scale correction:")
+        errortext <- c(errortext, "According to checkUnitFactor(), the following variables use the wrong piam_factor:")
         firsterror <- FALSE
       }
       errortext <- c(errortext,
@@ -43,18 +45,6 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                "\n  Expected: ", sc[[1]], " ", sc[[2]], " = 1 ", sc[[3]])
       )
     }
-  }
-
-  # check whether US$2005 values are correctly transformed in US$2010
-  wrongInflation <- template %>%
-    filter(grepl("US$2010", .data$unit, fixed = TRUE)) %>%
-    filter(! grepl("/US$2010", .data$unit, fixed = TRUE)) %>%
-    filter(.data$piam_unit %in% gsub("US$2010", "US$2005", .data$unit, fixed = TRUE)) %>%
-    filter(! (.data$piam_factor %in% "1.10774" | (.data$piam_factor %in% "-1.10774" & grepl("Loss|Policy Cost", .data$variable))))
-  if (nrow(wrongInflation) > 0) {
-    errortext <- c(errortext,
-                   paste0("\nThose variables should use 1.10774 as inflation correction US$2005 -> US$2010:\n- ",
-                          paste0(wrongInflation$variable, ": ", wrongInflation$piam_factor, collapse = "\n- ")))
   }
 
   if (! is.null(logFile)) {

--- a/tests/testthat/test-checkUnitFactor.R
+++ b/tests/testthat/test-checkUnitFactor.R
@@ -1,29 +1,41 @@
 test_that("checkUnitFactor works", {
+
+  # these should fail
+
   mapping <- data.frame(Variable = character(), Unit = character(),
-                         piam_unit = character(), piam_factor = character())
+                        piam_unit = character(), piam_factor = character())
   mapping[nrow(mapping) + 1, ] <- c("Population", "million", "billion", "100")
   expect_error(checkUnitFactor(mapping, logFile = NULL))
 
   mapping <- data.frame(Variable = character(), Unit = character(),
-                         piam_unit = character(), piam_factor = character())
+                        piam_unit = character(), piam_factor = character())
   mapping[nrow(mapping) + 1, ] <- c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "100")
   expect_error(checkUnitFactor(mapping, logFile = NULL))
 
   mapping <- data.frame(Variable = character(), Unit = character(),
-                         piam_unit = character(), piam_factor = character())
+                        piam_unit = character(), piam_factor = character())
   mapping[nrow(mapping) + 1, ] <- c("GDP", "US$2010", "US$2005", "110.774")
   expect_error(checkUnitFactor(mapping, logFile = NULL))
 
   mapping <- data.frame(Variable = character(), Unit = character(),
-                         piam_unit = character(), piam_factor = character())
+                        piam_unit = character(), piam_factor = character())
   mapping[nrow(mapping) + 1, ] <- c("Trade", "US$2010", "US$2005", NA)
   expect_error(checkUnitFactor(mapping, logFile = NULL))
 
   mapping <- data.frame(Variable = character(), Unit = character(),
-                         piam_unit = character(), piam_factor = character())
+                        piam_unit = character(), piam_factor = character())
+  mapping[nrow(mapping) + 1, ] <- c("Trade", "EUR_2020", "US$2005", NA)
+  expect_error(checkUnitFactor(mapping, logFile = NULL))
+
+  # these are correct
+
+  mapping <- data.frame(Variable = character(), Unit = character(),
+                        piam_unit = character(), piam_factor = character())
   mapping[nrow(mapping) + 1, ] <- c("Population", "million", "billion", "1000")
   mapping[nrow(mapping) + 1, ] <- c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "1000")
+  mapping[nrow(mapping) + 1, ] <- c("FE", "MJ", "GJ", "1000")
   mapping[nrow(mapping) + 1, ] <- c("GDP", "US$2010", "US$2005", "1.10774")
+  mapping[nrow(mapping) + 1, ] <- c("Trade", "EUR_2017", "US$2005", "1.17")
   expect_no_error(checkUnitFactor(mapping, logFile = NULL))
 })
 

--- a/tests/testthat/test-checkUnitFactor.R
+++ b/tests/testthat/test-checkUnitFactor.R
@@ -2,41 +2,32 @@ test_that("checkUnitFactor works", {
 
   # these should fail
 
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("Population", "million", "billion", "100")
-  expect_error(checkUnitFactor(mapping, logFile = NULL))
-
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "100")
-  expect_error(checkUnitFactor(mapping, logFile = NULL))
-
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("GDP", "US$2010", "US$2005", "110.774")
-  expect_error(checkUnitFactor(mapping, logFile = NULL))
-
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("Trade", "US$2010", "US$2005", NA)
-  expect_error(checkUnitFactor(mapping, logFile = NULL))
-
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("Trade", "EUR_2020", "US$2005", NA)
-  expect_error(checkUnitFactor(mapping, logFile = NULL))
-
-  # these are correct
-
-  mapping <- data.frame(Variable = character(), Unit = character(),
-                        piam_unit = character(), piam_factor = character())
-  mapping[nrow(mapping) + 1, ] <- c("Population", "million", "billion", "1000")
-  mapping[nrow(mapping) + 1, ] <- c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "1000")
-  mapping[nrow(mapping) + 1, ] <- c("FE", "MJ", "GJ", "1000")
-  mapping[nrow(mapping) + 1, ] <- c("GDP", "US$2010", "US$2005", "1.10774")
-  mapping[nrow(mapping) + 1, ] <- c("Trade", "EUR_2017", "US$2005", "1.17")
-  expect_no_error(checkUnitFactor(mapping, logFile = NULL))
+  wrong <- list(
+    c("Population", "million", "billion", "100"),
+    c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "100"),
+    c("GDP", "US$2010", "US$2005", "110.774"),
+    c("Trade", "US$2010", "US$2005", NA),
+    c("Trade", "EUR_2020", "US$2005", NA)
+  )
+  correct <- list(
+    c("Population", "million", "billion", "1000"),
+    c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "1000"),
+    c("FE", "MJ", "GJ", "1000"),
+    c("GDP", "US$2010", "US$2005", "1.10774"),
+    c("Trade", "EUR_2017", "US$2005", "1.17")
+  )
+  for (w in wrong) {
+    mapping <- data.frame(Variable = character(), Unit = character(),
+                          piam_unit = character(), piam_factor = character())
+    mapping[nrow(mapping) + 1, ] <- w
+    expect_error(checkUnitFactor(mapping, logFile = NULL))
+  }
+  for (c in correct) {
+    mapping <- data.frame(Variable = character(), Unit = character(),
+                          piam_unit = character(), piam_factor = character())
+    mapping[nrow(mapping) + 1, ] <- c
+    expect_no_error(checkUnitFactor(mapping, logFile = NULL))
+  }
 })
 
 for (t in names(templateNames())) {


### PR DESCRIPTION
## Purpose of this PR

- realized that much of my code was actually redundant, so just use one of them
- added a check for EUR_2020 used in ECEMF template

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
