### PR TITLE
fix typo, buildLibrary

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2488626'
+ValidationKey: '2508758'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.12.6
-date-released: '2024-01-29'
+version: 0.12.7
+date-released: '2024-02-01'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.12.6
-Date: 2024-01-29
+Version: 0.12.7
+Date: 2024-02-01
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.12.6**
+R package **piamInterfaces**, version **0.12.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -8,7 +8,7 @@ R package **piamInterfaces**, version **0.12.6**
 
 Project specific interfaces to REMIND / MAgPIE.
 
-## Tutorials
+## Tutorial
 
 - To understand how to submit to the IIASA database, read this [REMIND tutorial](https://github.com/remindmodel/remind/blob/develop/tutorials/13_Submit_to_IIASA_database.md).
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.6, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.7, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.12.6},
+  note = {R package version 0.12.7},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/tests/testthat/test-checkUnitFactor.R
+++ b/tests/testthat/test-checkUnitFactor.R
@@ -7,25 +7,26 @@ test_that("checkUnitFactor works", {
     c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "100"),
     c("GDP", "US$2010", "US$2005", "110.774"),
     c("Trade", "US$2010", "US$2005", NA),
-    c("Trade", "EUR_2020", "US$2005", NA)
+    c("Trade", "EUR_2020", "US$2005", NA),
+    c("Trade", "EUR_2020", "US$2005", "1.10")
   )
   correct <- list(
     c("Population", "million", "billion", "1000"),
     c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "1000"),
     c("FE", "MJ", "GJ", "1000"),
     c("GDP", "US$2010", "US$2005", "1.10774"),
-    c("Trade", "EUR_2017", "US$2005", "1.17")
+    c("Trade", "EUR_2020", "US$2005", "1.17")
   )
   for (w in wrong) {
     mapping <- data.frame(Variable = character(), Unit = character(),
                           piam_unit = character(), piam_factor = character())
-    mapping[nrow(mapping) + 1, ] <- w
+    mapping[1, ] <- w
     expect_error(checkUnitFactor(mapping, logFile = NULL))
   }
   for (c in correct) {
     mapping <- data.frame(Variable = character(), Unit = character(),
                           piam_unit = character(), piam_factor = character())
-    mapping[nrow(mapping) + 1, ] <- c
+    mapping[1, ] <- c
     expect_no_error(checkUnitFactor(mapping, logFile = NULL))
   }
 })

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,5 +1,5 @@
 
-## Tutorials
+## Tutorial
 
 - To understand how to submit to the IIASA database, read this [REMIND tutorial](https://github.com/remindmodel/remind/blob/develop/tutorials/13_Submit_to_IIASA_database.md).
 
@@ -9,6 +9,16 @@
   ...
   write.csv2(templatedata, "test.csv", na = "", row.names = FALSE, quote = FALSE)
   ```
+
+- Opening the csv files in Excel can be problematic, as it sometimes changes values and quotation marks.
+  You can edit the files in LibreOffice Calc using these settings in the Text Import dialog:
+  - Text Import with:
+    - Character set: Unicode (UTF-8)
+    - Separated by: Semicolon.
+  - Save with:
+    - Character set: Unicode (UTF-8)
+    - Field Delimiter: ;
+    - String Delimiter: (none)
 
 - The github diff on a large semicolon-separated file is often unreadable.
 For a human-readable output, save the old version of the mapping and run:


### PR DESCRIPTION
## Purpose of this PR

- fix typo in tests
- buildLibrary

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
