### PR TITLE
Correct ar6 emissions mapping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2548266'
+ValidationKey: '23903550'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.12.9
-date-released: '2024-02-01'
+version: 0.12.10
+date-released: '2024-02-02'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.12.9
-Date: 2024-02-01
+Version: 0.12.10
+Date: 2024-02-02
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.12.9**
+R package **piamInterfaces**, version **0.12.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.9, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.10, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.12.9},
+  note = {R package version 0.12.10},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -298,8 +298,6 @@ idx;Variable;Unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 257;Emissions|CO2|AFOLU|Land;Mt CO2/yr;;;;;;;CO2|AFOL emissions from forestry and other land use;x
 ;Emissions|CO2|AFOLU|Wetlands|Peatlands;Mt CO2/yr;;;;;;;;x
 258;Emissions|CO2|Energy;Mt CO2/yr;Emi|CO2|+|Energy;Mt CO2/yr;;;;;CO2 emissions from energy use on supply and demand side (IPCC category 1A,1B);
-;Emissions|CO2|Energy;Mt CO2/yr;Carbon Management|Carbon Capture;Mt CO2/yr;;;;;;
-;Emissions|CO2|Energy;Mt CO2/yr;Carbon Management|Storage;Mt CO2/yr;-1;;;;;
 259;Emissions|CO2|Energy and Industrial Processes;Mt CO2/yr;Emi|CO2|Energy and Industrial Processes;Mt CO2/yr;;;;;CO2 emissions from energy use on supply and demand side (IPCC category 1A,1B) and from industrial processes (IPCC categories 2A,B,C,E);
 260;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Demand;Mt CO2/yr;;;;;CO2 emissions from fuel combustion in industry (IPCC category 1A2),residential,commercial,institutional sectors and agriculture,forestry,fishing (AFOFI) (IPCC category 1A4a,1A4b,1A4c),and transportation sector (IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);
 261;Emissions|CO2|Energy|Demand|AFOFI;Mt CO2/yr;;;;;;;CO2 emissions from fuel combustion in agriculture,forestry,fishing (AFOFI) (IPCC category 1A4c);x
@@ -357,15 +355,11 @@ idx;Variable;Unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 315;Emissions|CO2|Energy|Demand|Transportation|Road|Passenger|2W&3W;Mt CO2/yr;;;;;;;;x
 316;Emissions|CO2|Energy|Demand|Transportation|Road|Passenger|Bus;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|Bus|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport passenger Buses;x
 317;Emissions|CO2|Energy|Demand|Transportation|Road|Passenger|LDV;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|LDV|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport passenger LDVs;x
-318;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Supply;Mt CO2/yr;;;;!!! warning - the sum only works with Emi|CO2|Fossil Fuels and Industry|Energy Supply, Indirect is not identical to Supply;CO2 emissions from fuel combustion and fugitive emissions from fuels: electricity and heat production and distribution (IPCC category 1A1a),other energy conversion (e.g. refineries,synfuel production,solid fuel processing,IPCC category 1Ab,1Ac),incl. pipeline transportation (IPCC category 1A3ei),fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide transport and storage (IPCC category 1C);
-;Emissions|CO2|Energy|Supply;Mt CO2/yr;Carbon Management|Carbon Capture;Mt CO2/yr;;;;;;
-;Emissions|CO2|Energy|Supply;Mt CO2/yr;Carbon Management|Storage;Mt CO2/yr;-1;;;;;
+318;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Supply;Mt CO2/yr;;;;;CO2 emissions from fuel combustion and fugitive emissions from fuels: electricity and heat production and distribution (IPCC category 1A1a),other energy conversion (e.g. refineries,synfuel production,solid fuel processing,IPCC category 1Ab,1Ac),incl. pipeline transportation (IPCC category 1A3ei),fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide transport and storage (IPCC category 1C);
 319;Emissions|CO2|Energy|Supply|Electricity;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Electricity w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from electricity and CHP production and distribution (IPCC category 1A1ai and 1A1aii);
 320;Emissions|CO2|Energy|Supply|Gases;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Gases w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from fuel combustion and fugitive emissions from fuels: gaseous fuel extraction and processing (e.g. natural gas extraction production,IPCC category 1B2b,parts of 1A1cii);
 321;Emissions|CO2|Energy|Supply|Heat;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Heat w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from heat production and distribution (IPCC category 1A1aiii);
 322;Emissions|CO2|Energy|Supply|Liquids;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Liquids w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from fuel combustion and fugitive emissions from fuels: liquid fuel extraction and processing (e.g. oil production,refineries,synfuel production,IPCC category 1A1b,parts of 1A1cii,1B2a);
-;Emissions|CO2|Energy|Supply|Liquids;Mt CO2/yr;Carbon Management|Carbon Capture;Mt CO2/yr;;;;;;
-;Emissions|CO2|Energy|Supply|Liquids;Mt CO2/yr;Carbon Management|Storage;Mt CO2/yr;-1;;;;;
 323;Emissions|CO2|Energy|Supply|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Hydrogen w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from fuel combustion in other energy supply sectors (please provide a definition of other sources in this category in the 'comments' tab);
 324;Emissions|CO2|Energy|Supply|Solids;Mt CO2/yr;Emi|CO2|Energy|Supply|+|Solids w/ couple prod;Mt CO2/yr;;;;;CO2 emissions from fuel combustion and fugitive emissions from fuels: solid fuel extraction and processing (IPCC category 1A1ci,parts of 1A1cii,1B1);
 325;Emissions|CO2|Industrial Processes;Mt CO2/yr;Emi|CO2|+|Industrial Processes;Mt CO2/yr;;;;;CO2 emissions from industrial processes (IPCC categories 2A,B,C,E);


### PR DESCRIPTION
## Purpose of this PR

Fixes emissions mapping in the AR6 template, as discussed in https://github.com/pik-piam/piamInterfaces/issues/214.
Also removes an obsolete (almost 4 year old) warning (added [here](https://github.com/pik-piam/project_interfaces/commit/0bee56acaa4b58e79a4d3e6f468be3aa7ed1b6fd#diff-893707106e03eddd3318b01162fcff5b4f255f8f653eae748f1ac5c647620523R320)).

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
