### PR TITLE
in NAVIGATE, make non-energy use FE variables from remind2 non-mandatory

### DIFF
--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -549,7 +549,7 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 508;2;energy (capacity);Capacity Additions|Electricity|Transmissions Grid;GWkm/yr;;;;;;Capacity additions of electricity storage (yearly average additions between previos and current model time step);
 509;2;energy (capacity);Capacity|Electricity|Storage Capacity;GWh;;;;;;Total installed capacity of operating electricity storage;
 510;2;energy (capacity);Capacity|Electricity|Transmissions Grid;GWkm;;;;;;Total installed capacity of operating transmission grid;
-511;1;energy (final);Final Energy|Non-Energy Use;EJ/yr;FE|Non-energy Use|Industry;EJ/yr;;;;final energy consumption by the non-combustion processes;
+511;1;energy (final);Final Energy|Non-Energy Use;EJ/yr;FE|Non-energy Use|Industry;EJ/yr;;;;final energy consumption by the non-combustion processes;x
 512;1;energy (final);Final Energy|Non-Energy Use|Solids;EJ/yr;FE|Non-energy Use|Industry|+|Solids;EJ/yr;;;;final energy consumption of solids by the non-combustion processes;x
 513;1;energy (final);Final Energy|Non-Energy Use|Liquids;EJ/yr;FE|Non-energy Use|Industry|+|Liquids;EJ/yr;;;;final energy consumption of liquids (conventional & unconventional oil, biofuels, coal-to-liquids, gas-to-liquids) by the non-combustion processes;x
 514;1;energy (final);Final Energy|Non-Energy Use|Gases;EJ/yr;FE|Non-energy Use|Industry|+|Gases;EJ/yr;;;;final energy consumption of gases (natural gas, biogas, coal-gas) by the non-combustion processes;x
@@ -678,17 +678,17 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 637;3;energy (final);Final Energy|Agriculture|Heat;EJ/yr;;;;;;final energy consumption by the agriculture sector of heat;
 638;3;energy (final);Final Energy|Agriculture|Liquids;EJ/yr;;;;;;final energy consumption by the agriculture sector of refined liquids (conventional & unconventional oil, biofuels, coal-to-liquids, gas-to-liquids, efuels);
 639;3;energy (final);Final Energy|Agriculture|Gases;EJ/yr;;;;;;final energy consumption by the agriculture sector of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses;
-640;1;energy (final);Final Energy|Industry;EJ/yr;FE|w/o Non-energy Use|Industry;EJ/yr;;;;final energy consumed by the industrial sector, excluding non-energy use (e.g.feedstocks);
+640;1;energy (final);Final Energy|Industry;EJ/yr;FE|w/o Non-energy Use|Industry;EJ/yr;;;;final energy consumed by the industrial sector, excluding non-energy use (e.g.feedstocks);x
 641;1;energy (final);Final Energy|Industry|Electricity;EJ/yr;FE|Industry|+|Electricity;EJ/yr;;;;final energy consumption by the industrial sector of electricity (including on-site solar PV), excluding transmission/distribution losses;
-642;1;energy (final);Final Energy|Industry|Gases;EJ/yr;FE|w/o Non-energy Use|Industry|Gases;EJ/yr;;;;final energy consumption by the industrial sector of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses, excluding fuel use for autoproduction;
+642;1;energy (final);Final Energy|Industry|Gases;EJ/yr;FE|w/o Non-energy Use|Industry|Gases;EJ/yr;;;;final energy consumption by the industrial sector of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses, excluding fuel use for autoproduction;x
 643;1;energy (final);Final Energy|Industry|Heat;EJ/yr;FE|Industry|+|Heat;EJ/yr;;;;final energy consumption by the industrial sector of heat (e.g., district heat, process heat, solar heating and warm water), excluding transmission/distribution losses;
 644;2;energy (final);Final Energy|Industry|Solar;EJ/yr;;;;;;final energy consumption by the industrial sector of solar thermal heat;
 645;2;energy (final);Final Energy|Industry|Geothermal;EJ/yr;;;;;;final energy consumption by the industrial sector of geothermal heat;
 646;1;energy (final);Final Energy|Industry|Hydrogen;EJ/yr;FE|Industry|+|Hydrogen;EJ/yr;;;;final energy consumption by the industrial sector of hydrogen, excluding fuel use for autoproduction;
-647;1;energy (final);Final Energy|Industry|Liquids;EJ/yr;FE|w/o Non-energy Use|Industry|Liquids;EJ/yr;;;;final energy consumption by the industrial sector of refined liquids (conventional & unconventional oil, biofuels, coal-to-liquids, gas-to-liquids), excluding fuel use for autoproduction;
+647;1;energy (final);Final Energy|Industry|Liquids;EJ/yr;FE|w/o Non-energy Use|Industry|Liquids;EJ/yr;;;;final energy consumption by the industrial sector of refined liquids (conventional & unconventional oil, biofuels, coal-to-liquids, gas-to-liquids), excluding fuel use for autoproduction;x
 648;1;energy (final);Final Energy|Industry|Waste;EJ/yr;;;;;;final energy consumption of non-renewable waste by the industrial sector;
 649;1;energy (final);Final Energy|Industry|Other;EJ/yr;;;;;;final energy consumption by the industrial sector of other sources that do not fit to any other category (please provide a definition of the sources in this category in the 'comments' tab);
-650;1;energy (final);Final Energy|Industry|Solids;EJ/yr;FE|w/o Non-energy Use|Industry|Solids;EJ/yr;;;;final energy solid fuel consumption by the industrial sector (including coal and solid biomass), excluding fuel use for autoproduction;
+650;1;energy (final);Final Energy|Industry|Solids;EJ/yr;FE|w/o Non-energy Use|Industry|Solids;EJ/yr;;;;final energy solid fuel consumption by the industrial sector (including coal and solid biomass), excluding fuel use for autoproduction;x
 651;1;energy (final);Final Energy|Industry|Solids|Biomass;EJ/yr;FE|Industry|Solids|+|Biomass;EJ/yr;;;;final energy consumption by the industrial sector of solid biomass (modern and traditional), excluding final energy consumption of bioliquids which are reported in the liquids category;
 652;1;energy (final);Final Energy|Industry|Solids|Fossil;EJ/yr;FE|Industry|Solids|+|Fossil;EJ/yr;;;;final energy consumption of fossil solids by the industrial sector;
 653;1;energy (final);Final Energy|Industry|Gases|Biomass;EJ/yr;FE|w/o Non-energy Use|Industry|Gases|+|Biomass;EJ/yr;;;;final energy consumption by the industrial sector of biogas, excluding transmission/distribution losses;x
@@ -866,7 +866,7 @@ idx;Tier;Category;Variable;Unit;piam_variable;piam_unit;piam_factor;internal_com
 823;2;energy (final);Final Energy|Residential and Commercial|Liquids|Electricity;EJ/yr;;;;;;final energy consumption by the residential & commercial sector of liquid efuels ("power-to-liquid");
 824;2;energy (final);Final Energy|Residential and Commercial|Liquids|Fossil;EJ/yr;;;;;;final energy consumption by the residential & commercial sector of liquids from fossil origin (conventional & unconventional petroleum, coal-to-liquids, gas-to-liquids);
 825;1;energy (final);Final Energy|Transportation;EJ/yr;FE|Transport|w/o Bunkers;EJ/yr;;;;final energy consumed in the transportation sector, excluding bunker fuels, excluding pipelines;
-826;1;energy (final);Final Energy|Transportation (w/ bunkers);EJ/yr;FE|Transport edge;EJ/yr;;;;final energy consumed in the transportation sector, including bunker fuels, excluding pipelines;
+826;1;energy (final);Final Energy|Transportation (w/ bunkers);EJ/yr;FE|Transport edge;EJ/yr;;;;final energy consumed in the transportation sector, including bunker fuels, excluding pipelines;x
 827;1;energy (final);Final Energy|Transportation|Electricity;EJ/yr;FE|Transport|w/o Bunkers|+|Electricity;EJ/yr;;;;final energy consumption by the transportation sector of electricity (including on-site solar PV), excluding transmission/distribution losses;
 828;1;energy (final);Final Energy|Transportation|Gases;EJ/yr;FE|Transport|w/o Bunkers|+|Gases;EJ/yr;;;;final energy consumption by the transportation sector of gases (natural gas, biogas, coal-gas), excluding transmission/distribution losses;
 829;1;energy (final);Final Energy|Transportation|Hydrogen;EJ/yr;FE|Transport|w/o Bunkers|+|Hydrogen;EJ/yr;;;;final energy consumption by the transportation sector of hydrogen;


### PR DESCRIPTION
## Purpose of this PR

- close https://github.com/pik-piam/remind2/issues/517

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
