### PR TITLE
update tutorial, pr template, documentation, checkSummation bug

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,8 +1,8 @@
-ValidationKey: '23928149'
+ValidationKey: '23950332'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md
 AcceptedWarnings:
 - .*was deprecated in.*
 - .*cannot open file.*Permission denied.*
-- .*checking installed package size.*
+AcceptedNotes: checking installed package size

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.12.11
-date-released: '2024-02-06'
+version: 0.12.12
+date-released: '2024-02-08'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.12.11
-Date: 2024-02-06
+Version: 0.12.12
+Date: 2024-02-08
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.12.11**
+R package **piamInterfaces**, version **0.12.12**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.11, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.12, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.12.11},
+  note = {R package version 0.12.12},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/checkSummations.Rd
+++ b/man/checkSummations.Rd
@@ -32,15 +32,16 @@ checkSummations(
 \item{summationsFile}{in inst/summations folder that describes the required summation groups
 if set to 'extractVariableGroups', tries to extract summations from variables with + notation}
 
-\item{logFile}{file where human-readable summary is saved. If NULL, write to stdout}
+\item{logFile}{file where human-readable summary is saved. If NULL, write to stdout. If FALSE, don't log.}
 
 \item{logAppend}{boolean whether to append or overwrite logFile}
 
-\item{generatePlots}{boolean whether pdfs to compare data are generated}
+\item{generatePlots}{boolean whether pdfs to compare data are generated. Requires outputDirectory.}
 
 \item{mainReg}{main region for the plot generation}
 
-\item{dataDumpFile}{file where data.frame with the data analysis is saved. If NULL, result is returned}
+\item{dataDumpFile}{file where data.frame with the data analysis is saved. Requires outputDirectory.
+If NULL, result is returned.}
 
 \item{remindVar}{REMIND/MAgPIE variable column name in template}
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,3 +5,5 @@
 ## Checklist:
 - [ ] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
 - [ ] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
+
+It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.


### PR DESCRIPTION
## Purpose of this PR

- "package size" is a note, no warning
- checkSummations with mapping = NULL asked which template to use and then fails. Now, it doesn't fail anymore
- add option not to log to checkSummations

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
