### PR TITLE
remove some specific NGFS + ELEVATE variables from remind2 validation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '23994710'
+ValidationKey: '24014475'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.12.14
+version: 0.12.15
 date-released: '2024-02-12'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.12.14
+Version: 0.12.15
 Date: 2024-02-12
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.12.14**
+R package **piamInterfaces**, version **0.12.15**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.14, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.12.15, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.12.14},
+  note = {R package version 0.12.15},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_AR6_NGFS.csv
+++ b/inst/templates/mapping_template_AR6_NGFS.csv
@@ -15,9 +15,9 @@ idx;Variable;Unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 ;Revenue|Government|Tax|Carbon|Demand|Industry;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Industry;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on industry sector emissions (carbon price by region multiplied by GHG emissions);
 ;Revenue|Government|Tax|Carbon|Demand|Transportation;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Transport;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on transport sector emissions (carbon price by region multiplied by GHG emissions);
 ;Revenue|Government|Tax|Carbon|Supply;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Supply;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on the supply sector emissions (carbon price by region multiplied by GHG emissions);
-;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;
-;GDP|PPP|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;
-;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;
-;GDP|MER|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;
-;GDP|MER|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;
-;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;
+;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;x
+;GDP|PPP|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;x
+;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;x
+;GDP|MER|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;x
+;GDP|MER|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;x
+;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;x

--- a/inst/templates/mapping_template_ELEVATE.csv
+++ b/inst/templates/mapping_template_ELEVATE.csv
@@ -1,5 +1,5 @@
 idx;Variable;Unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;exclude_remind2_validation
-;Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2005/t CO2;1.12;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);
+;Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2005/t CO2;1.12;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);x
 ;Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2005/yr;1.12;;;;government revenue from import taxes;
 ;Extracted|Primary Energy|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;
 ;Extracted|Primary Energy|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;


### PR DESCRIPTION
## Purpose of this PR

- remove some specific NGFS + ELEVATE variables from remind2 validation

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
