### PR TITLE
fix transport and BC inconsistencies

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2611092'
+ValidationKey: '2630873'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.2
+version: 0.13.3
 date-released: '2024-02-28'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.2
+Version: 0.13.3
 Date: 2024-02-28
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.2**
+R package **piamInterfaces**, version **0.13.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.2, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.3, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.2},
+  note = {R package version 0.13.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -223,8 +223,10 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 189;Value Added|Industry|Share of energy costs;%;;;;;;;share of energy costs to the total economic valuye added by Industry;x
 190;Emissions|BC;Mt BC/yr;Emi|BC;Mt BC/yr;;;;;total black carbon emissions;
 191;Emissions|BC|AFOLU;Mt BC/yr;Emi|BC|Land Use;Mt BC/yr;;;;;black carbon emissions from agriculture,forestry and other land use (IPCC category 3);
-192;Emissions|BC|AFOLU|Agriculture;Mt BC/yr;Emi|BC|Land Use|Agriculture;Mt BC/yr;;;;;BC|AFOLU|Agric emissions from agriculture;
-193;Emissions|BC|AFOLU|Land;Mt BC/yr;;;;;;;BC|AFOL emissions from forestry and other land use;x
+192;Emissions|BC|AFOLU|Agriculture;Mt BC/yr;Emi|BC|Land Use|Agriculture;Mt BC/yr;;;;;Black Carbon emissions from agriculture;
+192;Emissions|BC|AFOLU|Agriculture;Mt BC/yr;Emi|BC|Land Use|Agricultural Waste Burning;Mt BC/yr;;;;;Black Carbon AFOLU emissions from agriculture;
+193;Emissions|BC|AFOLU|Land;Mt BC/yr;Emi|BC|Land Use|Forest Burning;Mt BC/yr;;;;;Black Carbon AFOLU emissions from forestry and other land use;
+193;Emissions|BC|AFOLU|Land;Mt BC/yr;Emi|BC|Land Use|Savannah Burning;Mt BC/yr;;;;;Black Carbon AFOLU emissions from forestry and other land use;
 194;Emissions|BC|Energy;Mt BC/yr;Emi|BC|Energy Supply and Demand;Mt BC/yr;;;;;black carbon emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);
 195;Emissions|BC|Energy|Demand|Residential and Commercial;Mt BC/yr;Emi|BC|Energy Demand|Buildings;Mt BC/yr;;;;;black carbon emissions from fuel combustion in residential,commercial,institutional sectors and agriculture (IPCC category 1A4a,1A4b);
 196;Emissions|BC|Energy|Demand|Residential and Commercial|Commercial;Mt BC/yr;;;;;;;BC emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);x
@@ -349,7 +351,8 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 309;Emissions|CO2|Energy|Demand|Transportation|Rail;Mt CO2/yr;Emi|CO2|Transport|Rail|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from transport by rail mode;x
 310;Emissions|CO2|Energy|Demand|Transportation|Rail|Freight;Mt CO2/yr;Emi|CO2|Transport|Freight|Rail|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from transport by freight rail mode;x
 311;Emissions|CO2|Energy|Demand|Transportation|Rail|Passenger;Mt CO2/yr;Emi|CO2|Transport|Pass|Rail|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from transport by passenger rail mode;x
-312;Emissions|CO2|Energy|Demand|Transportation|Road;Mt CO2/yr;Emi|CO2|Transport|Road|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport vehicles;x
+312;Emissions|CO2|Energy|Demand|Transportation|Road;Mt CO2/yr;Emi|CO2|Transport|Freight|Road|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport vehicles;x
+312;Emissions|CO2|Energy|Demand|Transportation|Road;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport vehicles;x
 313;Emissions|CO2|Energy|Demand|Transportation|Road|Freight;Mt CO2/yr;Emi|CO2|Transport|Freight|Road|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road freight transport vehicles;x
 314;Emissions|CO2|Energy|Demand|Transportation|Road|Passenger;Mt CO2/yr;Emi|CO2|Transport|Pass|Road|Demand;Mt CO2/yr;;;;;carbon dioxide emissions from road transport passenger vehicles;x
 315;Emissions|CO2|Energy|Demand|Transportation|Road|Passenger|2W&3W;Mt CO2/yr;;;;;;;;x


### PR DESCRIPTION
## Purpose of this PR

- For `Emi|CO2|Transport|Road|Demand`: probably because of [this line](https://github.com/pik-piam/edgeTransport/blob/436043da71b76d4956515f0b26b0e39c0dc22572/R/reportEDGET.R#L566) and [this line](https://github.com/pik-piam/edgeTransport/blob/436043da71b76d4956515f0b26b0e39c0dc22572/R/reportEDGET.R#L536), this variable is calculated twice and then summed, leading to a summation mismatch of exactly 50%.
- For BC, add further variables that were missing as of now.

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)