### PR TITLE
report reldiff as 0 if both value are 0, minor log fixes

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,10 +1,9 @@
-ValidationKey: '2630873'
+ValidationKey: '2650654'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md
 AcceptedWarnings:
 - .*was deprecated in.*
 - .*cannot open file.*Permission denied.*
-- No shared levels found between.*
 AcceptedNotes: checking installed package size
 enforceVersionUpdate: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.3
+version: 0.13.4
 date-released: '2024-02-28'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.3
+Version: 0.13.4
 Date: 2024-02-28
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -129,9 +129,9 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
           collapse = " + "),
         .groups = "drop") %>%
       ungroup() %>%
+      mutate(diff = !!sym("checkSum") - !!sym("value")) %>%
       mutate(
-        diff = !!sym("checkSum") - !!sym("value"),
-        reldiff = 100 * (!!sym("checkSum") - !!sym("value")) / !!sym("value"),
+        reldiff = ifelse(abs(!!sym("checkSum")) + abs(!!sym("value")) == 0, 0, 100 * !!sym("diff") / !!sym("value")),
         details = gsub("\\+ \\-", "-", !!sym("details"))
       ) %>%
       relocate(!!sym("details"), .after = last_col())
@@ -271,7 +271,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
         paste0("# All deviations can be found in the returned object",
                paste0(" and in ", dataDumpFile)[! is.null(dataDumpFile)], "."),
         paste0("# To get more detailed information on '", problematic[1], "', run piamInterfaces::variableInfo('",
-               problematic[1], "').")
+               gsub(" [1-9]$", "", problematic[1]), "').")
         )
       if (generatePlots) {
         dev.off()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.3**
+R package **piamInterfaces**, version **0.13.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.3, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.4, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.3},
+  note = {R package version 0.13.4},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/generateIIASASubmission.Rd
+++ b/man/generateIIASASubmission.Rd
@@ -52,7 +52,7 @@ used to delete superfluous variables and adapt units}
 
 \item{timesteps}{timesteps that are accepted in final submission}
 
-\item{checkSummation}{either TRUE to identify summation files from mapping, or filename}
+\item{checkSummation}{either TRUE to identify summation files from mapping, or filename, or FALSE}
 
 \item{mappingFile}{has no effect and is only kept for backwards-compatibility}
 }


### PR DESCRIPTION
## Purpose of this PR
- in checkSummations, report reldiff as 0 if both value are 0
- don't say you run summation checks if you don't
- remove the ` 2` from `FE 2` when telling how to access more information about variable
- close https://github.com/pik-piam/piamInterfaces/issues/244

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
