### PR TITLE
cleanup Emissions|N2O and CH4

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2670570'
+ValidationKey: '2690352'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.5
+version: 0.13.6
 date-released: '2024-02-29'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.5
+Version: 0.13.6
 Date: 2024-02-29
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -164,9 +164,6 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
   }
 
   # perform summation checks ----
-
-  message("# Apply summation checks")
-
   prefix <- gsub("\\.[A-Za-z]+$", "", if (is.null(outputFilename)) "output" else basename(outputFilename))
 
   if (isTRUE(checkSummation)) checkSummation <- intersect(mapping, names(summationsNames()))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.5**
+R package **piamInterfaces**, version **0.13.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.5, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.6, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.5},
+  note = {R package version 0.13.6},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -262,16 +262,18 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 224;Emissions|CFC|Industrial Processes;Mt CO2-equiv/yr;;;;;;;CFC emissions from industrial processes;x
 225;Emissions|CFC|Waste;Mt CO2-equiv/yr;;;;;;;;x
 226;Emissions|CH4;Mt CH4/yr;Emi|CH4;Mt CH4/yr;;;;;total CH4 emissions;
-227;Emissions|CH4|AFOLU;Mt CH4/yr;Emissions|CH4|Land;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);x
-228;Emissions|CH4|AFOLU|Agriculture;Mt CH4/yr;Emissions|CH4|Land|+|Agriculture;Mt CH4/yr;;;;;CH4|AFOLU|Agric emissions from agriculture;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emissions|CH4|Land|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emissions|CH4|Land|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation;Mt CH4/yr;Emissions|CH4|Land|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;Mt CH4/yr;Emissions|CH4|Land|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Rice;Mt CH4/yr;Emissions|CH4|Land|Agriculture|+|Rice;Mt CH4/yr;;;;;;x
+227;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);x
+;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);x
+228;Emissions|CH4|AFOLU|Agriculture;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4|AFOLU|Agric emissions from agriculture;x
+;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
+;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
+;Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
+;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
+;Emissions|CH4|AFOLU|Agriculture|Rice;Mt CH4/yr;Emi|CH4|Agriculture|+|Rice;Mt CH4/yr;;;;;;x
 229;Emissions|CH4|AFOLU|Land;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;;CH4|AFOL emissions from forestry and other land use;
-;Emissions|CH4|AFOLU|Wetlands|Peatlands;Mt CH4/yr;Emissions|CH4|Land|+|Peatland;Mt CH4/yr;;;;;;x
-230;Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|Energy Supply and Demand;Mt CH4/yr;;;;;CH4 emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
+;Emissions|CH4|AFOLU|Wetlands|Peatlands;Mt CH4/yr;Emi|CH4|Land-Use Change|+|Peatland;Mt CH4/yr;;;;;;x
+230;Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Energy Supply;Mt CH4/yr;;;;;CH4 emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
+;Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Extraction;Mt CH4/yr;;;;;CH4 emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
 231;Emissions|CH4|Energy|Demand|Residential and Commercial;Mt CH4/yr;;;;;;;CH4 emissions from fuel combustion in residential,commercial,institutional sectors (IPCC category 1A4a,1A4b);x
 232;Emissions|CH4|Energy|Demand|Residential and Commercial|Commercial;Mt CH4/yr;;;;;;;CH4 emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);x
 233;Emissions|CH4|Energy|Demand|Residential and Commercial|Residential;Mt CH4/yr;;;;;;;CH4 emissions from fuel combustion in residential sector (IPCC category 1A4a,1A4b);x
@@ -291,7 +293,7 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 248;Emissions|CH4|Industrial Processes|Plastics;Mt CH4/yr;;;;;;;CH4 emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the plastics sector  (IPCC categories 2A,B,C,E);x
 249;Emissions|CH4|Industrial Processes|Pulp and Paper;Mt CH4/yr;;;;;;;CH4 emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the pulp and paper sector  (IPCC categories 2A,B,C,E);x
 250;Emissions|CH4|Industrial Processes|Steel;Mt CH4/yr;;;;;;;CH4 emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the steel sector  (IPCC categories 2A,B,C,E);x
-251;Emissions|CH4|Other;Mt CH4/yr;Emi|CH4|Other;Mt CH4/yr;;;;;CH4 emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
+251;Emissions|CH4|Other;Mt CH4/yr;;Mt CH4/yr;;;;;CH4 emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
 252;Emissions|CH4|Waste;Mt CH4/yr;Emi|CH4|+|Waste;Mt CH4/yr;;;;;;
 253;Emissions|CO;Mt CO/yr;Emi|CO;Mt CO/yr;;;;;total CO emissions;
 254;Emissions|CO2;Mt CO2/yr;Emi|CO2;Mt CO2/yr;;;;;total net-CO2 emissions from all sources;
@@ -415,13 +417,19 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 372;Emissions|HFC|Waste;Mt CO2-equiv/yr;;;;;;;;x
 373;Emissions|Kyoto Gases;Mt CO2-equiv/yr;Emi|GHG;Mt CO2eq/yr;;;;100-year GWPs from AR5 were used;total Kyoto GHG emissions,including CO2,CH4,N2O and F-gases (preferably use 100-year GWPs from AR4 for aggregation of different gases;
 374;Emissions|N2O;kt N2O/yr;Emi|N2O;kt N2O/yr;;;;;total N2O emissions;
-375;Emissions|N2O|AFOLU;kt N2O/yr;Emissions|N2O|Land;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
-376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emissions|N2O|Land|+|Agriculture;Mt N2O/yr;1000;;;;N2O|AFOLU|Agric emissions from agriculture;x
-;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emissions|N2O|Land|Agriculture|+|Animal Waste Management;Mt N2O/yr;1000;;;;;x
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emissions|N2O|Land|Agriculture|+|Agricultural Soils;Mt N2O/yr;1000;;;;;x
+375;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
+;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Land-Use Change;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
+376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O|AFOLU|Agric emissions from agriculture;x
+;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emi|N2O|Agriculture|+|Animal Waste Management;Mt N2O/yr;1000;;;;;x
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Decay of Crop Residues;Mt N2O/yr;1000;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Inorganic Fertilizers;Mt N2O/yr;1000;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Manure applied to Croplands;Mt N2O/yr;1000;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Pasture;Mt N2O/yr;1000;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Soil Organic Matter Loss;Mt N2O/yr;1000;;;;;x
 377;Emissions|N2O|AFOLU|Land;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;;N2O|AFOL emissions from forestry and other land use;
-;Emissions|N2O|AFOLU|Wetlands|Peatlands;kt N2O/yr;Emissions|N2O|Land|+|Peatland;Mt N2O/yr;1000;;;;;x
-378;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|Energy Supply and Demand;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
+;Emissions|N2O|AFOLU|Wetlands|Peatlands;kt N2O/yr;Emi|N2O|Land-Use Change|+|Peatland;Mt N2O/yr;1000;;;;;x
+378;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Energy Supply;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
+;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
 379;Emissions|N2O|Energy|Demand|Residential and Commercial|Commercial;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);x
 380;Emissions|N2O|Energy|Demand|Residential and Commercial|Residential;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in residential sector (IPCC category 1A4a,1A4b);x
 382;Emissions|N2O|Energy|Demand|Transportation;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from fuel combustion in the transportation sector (part of IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);
@@ -433,7 +441,7 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 388;Emissions|N2O|Industrial Processes|Other;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the other sector (All other production,please specify in comments tab) (IPCC categories 2A,B,C,E);x
 389;Emissions|N2O|Industrial Processes|Plastics;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the plastics sector  (IPCC categories 2A,B,C,E);x
 390;Emissions|N2O|Industrial Processes|Steel;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the steel sector  (IPCC categories 2A,B,C,E);x
-391;Emissions|N2O|Other;kt N2O/yr;Emi|N2O|Other;kt N2O/yr;;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
+391;Emissions|N2O|Other;kt N2O/yr;;kt N2O/yr;;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
 392;Emissions|N2O|Waste;kt N2O/yr;Emi|N2O|+|Waste;kt N2O/yr;;;;;;
 393;Emissions|NH3;Mt NH3/yr;Emi|NH3;Mt NH3/yr;;;;;total ammonium (NH3) emissions;
 394;Emissions|NH3|AFOLU;Mt NH3/yr;Emi|NH3|Land Use;Mt NH3/yr;;;;;land use based ammonia Emissions;

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -262,13 +262,15 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 224;Emissions|CFC|Industrial Processes;Mt CO2-equiv/yr;;;;;;;CFC emissions from industrial processes;x
 225;Emissions|CFC|Waste;Mt CO2-equiv/yr;;;;;;;;x
 226;Emissions|CH4;Mt CH4/yr;Emi|CH4;Mt CH4/yr;;;;;total CH4 emissions;
-227;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);x
-;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);x
-228;Emissions|CH4|AFOLU|Agriculture;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4|AFOLU|Agric emissions from agriculture;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;x
-;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;x
+227;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);
+;Emissions|CH4|AFOLU;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;;CH4 emissions from agriculture,forestry and other land use (IPCC category 3);
+228;Emissions|CH4|AFOLU|Agriculture;Mt CH4/yr;Emi|CH4|+|Agriculture;Mt CH4/yr;;;;;CH4|AFOLU|Agric emissions from agriculture;
+;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;
+;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;
+;Emissions|CH4|AFOLU|Agriculture|Livestock;Mt CH4/yr;Emi|CH4|Agriculture|+|Waste Burning;Mt CH4/yr;;;;;;
+;Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation;Mt CH4/yr;Emi|CH4|Agriculture|+|Enteric fermentation;Mt CH4/yr;;;;;;
+;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;Mt CH4/yr;Emi|CH4|Agriculture|+|Animal waste management;Mt CH4/yr;;;;;;
+;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;Mt CH4/yr;Emi|CH4|Agriculture|+|Waste Burning;Mt CH4/yr;;;;;added because own category is missing;
 ;Emissions|CH4|AFOLU|Agriculture|Rice;Mt CH4/yr;Emi|CH4|Agriculture|+|Rice;Mt CH4/yr;;;;;;x
 229;Emissions|CH4|AFOLU|Land;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;;CH4|AFOL emissions from forestry and other land use;
 ;Emissions|CH4|AFOLU|Wetlands|Peatlands;Mt CH4/yr;Emi|CH4|Land-Use Change|+|Peatland;Mt CH4/yr;;;;;;x
@@ -417,19 +419,20 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 372;Emissions|HFC|Waste;Mt CO2-equiv/yr;;;;;;;;x
 373;Emissions|Kyoto Gases;Mt CO2-equiv/yr;Emi|GHG;Mt CO2eq/yr;;;;100-year GWPs from AR5 were used;total Kyoto GHG emissions,including CO2,CH4,N2O and F-gases (preferably use 100-year GWPs from AR4 for aggregation of different gases;
 374;Emissions|N2O;kt N2O/yr;Emi|N2O;kt N2O/yr;;;;;total N2O emissions;
-375;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
-;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Land-Use Change;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
-376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O|AFOLU|Agric emissions from agriculture;x
-;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emi|N2O|Agriculture|+|Animal Waste Management;Mt N2O/yr;1000;;;;;x
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Decay of Crop Residues;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Inorganic Fertilizers;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Manure applied to Croplands;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Pasture;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Soil Organic Matter Loss;Mt N2O/yr;1000;;;;;x
+375;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Agriculture;kt N2O/yr;;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);
+;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);
+376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emi|N2O|+|Agriculture;kt N2O/yr;;;;;N2O|AFOLU|Agric emissions from agriculture;
+;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emi|N2O|Agriculture|+|Animal Waste Management;kt N2O/yr;;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emi|N2O|Agriculture|+|Waste Burning;kt N2O/yr;;;;;added because own category is missing;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Decay of Crop Residues;kt N2O/yr;;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Inorganic Fertilizers;kt N2O/yr;;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Manure applied to Croplands;kt N2O/yr;;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Pasture;kt N2O/yr;;;;;;
+;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Soil Organic Matter Loss;kt N2O/yr;;;;;;
 377;Emissions|N2O|AFOLU|Land;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;;N2O|AFOL emissions from forestry and other land use;
-;Emissions|N2O|AFOLU|Wetlands|Peatlands;kt N2O/yr;Emi|N2O|Land-Use Change|+|Peatland;Mt N2O/yr;1000;;;;;x
-378;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Energy Supply;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
-;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
+;Emissions|N2O|AFOLU|Wetlands|Peatlands;kt N2O/yr;Emi|N2O|Land-Use Change|+|Peatland;kt N2O/yr;;;;;;
+378;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Energy Supply;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);
+;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);
 379;Emissions|N2O|Energy|Demand|Residential and Commercial|Commercial;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);x
 380;Emissions|N2O|Energy|Demand|Residential and Commercial|Residential;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in residential sector (IPCC category 1A4a,1A4b);x
 382;Emissions|N2O|Energy|Demand|Transportation;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from fuel combustion in the transportation sector (part of IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);

--- a/inst/templates/mapping_template_CAMPAIGNers.csv
+++ b/inst/templates/mapping_template_CAMPAIGNers.csv
@@ -333,6 +333,7 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 297;2;emissions (non-CO2);Emissions|CH4|AFOLU|Land;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;CH4 emissions from forestry and other land use;
 298;2;emissions (non-CO2);Emissions|CH4|AFOLU|Land|Wetlands;Mt CH4/yr;Emi|CH4|Land-Use Change|+|Peatland;Mt CH4/yr;;;;CH4 emissions from managed peatlands (drained and rewetted);
 299;2;emissions (non-CO2);Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Energy Supply;Mt CH4/yr;;;;CH4 emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
+299;2;emissions (non-CO2);Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Extraction;Mt CH4/yr;;;;CH4 emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
 300;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Industry;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in industry (IPCC category 1A2);
 301;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Residential and Commercial;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in residential, commercial, institutional sectors (IPCC category 1A4a,  1A4b);
 302;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Transportation;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in transportation sector (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei);

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -333,6 +333,7 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 297;2;emissions (non-CO2);Emissions|CH4|AFOLU|Land;Mt CH4/yr;Emi|CH4|+|Land-Use Change;Mt CH4/yr;;;;CH4 emissions from forestry and other land use;
 298;2;emissions (non-CO2);Emissions|CH4|AFOLU|Land|Wetlands;Mt CH4/yr;Emi|CH4|Land-Use Change|+|Peatland;Mt CH4/yr;;;;CH4 emissions from managed peatlands (drained and rewetted);
 299;2;emissions (non-CO2);Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Energy Supply;Mt CH4/yr;;;;CH4 emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
+299;2;emissions (non-CO2);Emissions|CH4|Energy;Mt CH4/yr;Emi|CH4|+|Extraction;Mt CH4/yr;;;;CH4 emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
 300;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Industry;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in industry (IPCC category 1A2);
 301;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Residential and Commercial;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in residential, commercial, institutional sectors (IPCC category 1A4a,  1A4b);
 302;2;emissions (non-CO2);Emissions|CH4|Energy|Demand|Transportation;Mt CH4/yr;;;;;;CH4 emissions from fuel combustion in transportation sector (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei);
@@ -368,9 +369,11 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 327;2;emissions (non-CO2);Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Pasture;kt N2O/yr;;;;N2O  emissions from soil management practices in the agriculture sector;
 328;2;emissions (non-CO2);Emissions|N2O|AFOLU|Land;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;N2O emissions from forestry and other land use;
 329;2;emissions (non-CO2);Emissions|N2O|AFOLU|Land|Wetlands;kt N2O/yr;Emi|N2O|Land-Use Change|+|Peatland;kt N2O/yr;;;;N2O emissions from managed peatlands (drained and rewetted);
-330;2;emissions (non-CO2);Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|Energy Supply and Demand;kt N2O/yr;;;;N2O emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);x
+330;2;emissions (non-CO2);Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Energy Supply;kt N2O/yr;;;;N2O emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
+330;2;emissions (non-CO2);Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Industry;kt N2O/yr;;;;N2O emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
+330;2;emissions (non-CO2);Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;N2O emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);
 331;2;emissions (non-CO2);Emissions|N2O|Waste;kt N2O/yr;Emi|N2O|+|Waste;kt N2O/yr;;;;N2O emissions from waste (IPCC category 6);
-332;2;emissions (non-CO2);Emissions|N2O|Other;kt N2O/yr;Emi|N2O|Other;kt N2O/yr;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
+332;2;emissions (non-CO2);Emissions|N2O|Other;kt N2O/yr;;kt N2O/yr;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);
 333;2;emissions (non-CO2);Emissions|NH3;Mt NH3/yr;Emi|NH3;Mt NH3/yr;;;;total ammonium emissions;
 334;2;emissions (non-CO2);Emissions|NH3|AFOLU;Mt NH3/yr;Emi|NH3|Land Use;Mt NH3/yr;;;;Land Use based Ammonia Emissions;
 335;2;emissions (non-CO2);Emissions|NH3|Energy;Mt NH3/yr;Emi|NH3|Energy Supply and Demand;Mt NH3/yr;;;;Ammonia emissions from energy use on supply and demand side, including fugitive emissions from fuels (IPCC category 1A, 1B);


### PR DESCRIPTION
## Purpose of this PR

- close #248 and implement the suggestions described therein
- remove non-existent REMIND variables, replace MAgPIE variables by those reported by REMIND to avoid that standalone runs don't have them. They differ slightly because of the rescaling that exists within REMIND, but like that internal consistency is kept. If you don't like that, switch off the rescaling within REMIND using the `c_scaleEmiHistorical` switch
- The following overview was obtained with `piamInterfaces::variableInfo`


### N2O. Results from template: AR6
```
old:
  . Emissions|N2O|AFOLU                   . Emissions|N2O|Land
  . Emissions|N2O|Energy                  . Emi|N2O|Energy Supply and Demand
  . Emissions|N2O|Industrial Processes    . Emi|N2O|+|Industry
  . Emissions|N2O|Other                   . Emi|N2O|Other
  . Emissions|N2O|Waste                   . Emi|N2O|+|Waste

new:
  . Emissions|N2O|AFOLU                   . Emi|N2O|+|Agriculture + Emi|N2O|+|Land-Use Change
  . Emissions|N2O|Energy                  . Emi|N2O|+|Energy Supply + Emi|N2O|+|Transport
  . Emissions|N2O|Industrial Processes    . Emi|N2O|+|Industry
  . Emissions|N2O|Other                   . NA
  . Emissions|N2O|Waste                   . Emi|N2O|+|Waste
```

### N2O. Results from template: NAVIGATE, CAMPAIGners
```
old:
  . Emissions|N2O|AFOLU                   . Emi|N2O|+|Agriculture + Emi|N2O|+|Land-Use Change
  . Emissions|N2O|Energy                  . Emi|N2O|Energy Supply and Demand
  . Emissions|N2O|Waste                   . Emi|N2O|+|Waste
  . Emissions|N2O|Other                   . NA

new:
  . Emissions|N2O|AFOLU                   . Emi|N2O|+|Agriculture + Emi|N2O|+|Land-Use Change
  . Emissions|N2O|Energy                  . Emi|N2O|+|Energy Supply + Emi|N2O|+|Industry + Emi|N2O|+|Transport
  . Emissions|N2O|Waste                   . Emi|N2O|+|Waste
  . Emissions|N2O|Other                   . NA
```

### CH4. Results from template: AR6

```
old:
  . Emissions|CH4|AFOLU                   . Emissions|CH4|Land
  . Emissions|CH4|Energy                  . Emi|CH4|Energy Supply and Demand
  . Emissions|CH4|Industrial Processes    . NA
  . Emissions|CH4|Other                   . Emi|CH4|Other
  . Emissions|CH4|Waste                   . Emi|CH4|+|Waste

new:
  . Emissions|CH4|AFOLU                   . Emi|CH4|+|Agriculture + Emi|CH4|+|Land-Use Change
  . Emissions|CH4|Energy                  . Emi|CH4|+|Energy Supply + Emi|CH4|+|Extraction
  . Emissions|CH4|Industrial Processes    . NA
  . Emissions|CH4|Other                   . NA
  . Emissions|CH4|Waste                   . Emi|CH4|+|Waste
```

### CH4: Results from template: NAVIGATE, CAMPAIGners

```
old:
  . Emissions|CH4|AFOLU                   . Emi|CH4|+|Agriculture + Emi|CH4|+|Land-Use Change
  . Emissions|CH4|Energy                  . Emi|CH4|+|Energy Supply
  . Emissions|CH4|Waste                   . Emi|CH4|+|Waste
  . Emissions|CH4|Industrial Processes    . NA
  . Emissions|CH4|Other                   . NA

new:
  . Emissions|CH4|AFOLU                   . Emi|CH4|+|Agriculture + Emi|CH4|+|Land-Use Change
  . Emissions|CH4|Energy                  . Emi|CH4|+|Energy Supply + Emi|CH4|+|Extraction
  . Emissions|CH4|Waste                   . Emi|CH4|+|Waste
  . Emissions|CH4|Industrial Processes    . NA
  . Emissions|CH4|Other                   . NA
```

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)