### PR TITLE
add TRUE_or_fixed option to fixOnRef

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2710134'
+ValidationKey: '2730054'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.7
-date-released: '2024-02-29'
+version: 0.13.8
+date-released: '2024-03-01'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.7
-Date: 2024-02-29
+Version: 0.13.8
+Date: 2024-03-01
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.7**
+R package **piamInterfaces**, version **0.13.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.7, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.8, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.7},
+  note = {R package version 0.13.8},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/fixOnRef.Rd
+++ b/man/fixOnRef.Rd
@@ -22,7 +22,8 @@ fixOnRef(
 
 \item{ret}{"boolean": just return TRUE/FALSE if check was successful
 "fails": data frame with mismatches between scenario and reference data
-"fixed": quitte object with data correctly fixed on reference data}
+"fixed": quitte object with data correctly fixed on reference data
+"TRUE_or_fixed": TRUE if check was successful, fixed object otherwise}
 
 \item{failfile}{csv file to which mismatches are written to}
 

--- a/tests/testthat/test-fixOnRef.R
+++ b/tests/testthat/test-fixOnRef.R
@@ -7,6 +7,7 @@ test_that("fixOnRef works", {
   expect_true(fixOnRef(d, d, startyear = 2020, ret = "boolean"))
   # somehow, only MESSAGEix results are correct in the dataset above
   expect_true(fixOnRef(filter(qe, model == "MESSAGEix"), "Current Policies", startyear = 2020, ret = "boolean"))
+  expect_true(fixOnRef(filter(qe, model == "MESSAGEix"), "Current Policies", startyear = 2020, ret = "TRUE_or_fixed"))
   qefixed <- fixOnRef(qe, "Current Policies", startyear = 2020, ret = "fixed")
   expect_true(fixOnRef(qefixed, "Current Policies", startyear = 2020, ret = "boolean"))
   expect_identical(fixOnRef(d, d, startyear = 2020, ret = "fixed"), d)
@@ -15,6 +16,7 @@ test_that("fixOnRef works", {
   dwrong <- mutate(d, value = ifelse(period == 2020, 2 * value, value))
   expect_true(fixOnRef(dwrong, d, startyear = 2020, ret = "boolean"))
   expect_false(fixOnRef(dwrong, d, startyear = 2025, ret = "boolean"))
+  expect_false(isTRUE(fixOnRef(dwrong, d, startyear = 2025, ret = "TRUE_or_fixed")))
   # adjust only one variable
   dwrong <- mutate(d, value = ifelse(period == 2020 & variable == "Population", 0, value))
   expect_true(is.null(fixOnRef(dwrong, d, startyear = 2020, ret = "fails")))


### PR DESCRIPTION
## Purpose of this PR

- returns `TRUE` if everything is fine, and the fixed object else. Will allow for [remindmodel/scripts/output/single/fixOnRef.R](https://github.com/remindmodel/remind/blob/develop/scripts/output/single/fixOnRef.R) not to ask to fix data if everything is fine.
- don't drop `NA` from data, they should be kept.