### PR TITLE
fix merge conflict in template and make sure they never happen again

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2730054'
+ValidationKey: '2749837'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.8
+version: 0.13.9
 date-released: '2024-03-01'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.8
+Version: 0.13.9
 Date: 2024-03-01
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.8**
+R package **piamInterfaces**, version **0.13.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.8, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.9, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.8},
+  note = {R package version 0.13.9},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -419,7 +419,6 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 372;Emissions|HFC|Waste;Mt CO2-equiv/yr;;;;;;;;
 373;Emissions|Kyoto Gases;Mt CO2-equiv/yr;Emi|GHG;Mt CO2eq/yr;;;;100-year GWPs from AR5 were used;total Kyoto GHG emissions,including CO2,CH4,N2O and F-gases (preferably use 100-year GWPs from AR4 for aggregation of different gases;
 374;Emissions|N2O;kt N2O/yr;Emi|N2O;kt N2O/yr;;;;;total N2O emissions;
-<<<<<<< HEAD;;;;;;;;;;
 375;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Agriculture;kt N2O/yr;;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);
 ;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);
 376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emi|N2O|+|Agriculture;kt N2O/yr;;;;;N2O|AFOLU|Agric emissions from agriculture;
@@ -436,42 +435,16 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 ;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);
 379;Emissions|N2O|Energy|Demand|Residential and Commercial|Commercial;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);x
 380;Emissions|N2O|Energy|Demand|Residential and Commercial|Residential;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in residential sector (IPCC category 1A4a,1A4b);x
-=======;;;;;;;;;;
-375;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
-;Emissions|N2O|AFOLU;kt N2O/yr;Emi|N2O|+|Land-Use Change;Mt N2O/yr;1000;;;;N2O emissions from agriculture,forestry and other land use (IPCC category 3);x
-376;Emissions|N2O|AFOLU|Agriculture;kt N2O/yr;Emi|N2O|+|Agriculture;Mt N2O/yr;1000;;;;N2O|AFOLU|Agric emissions from agriculture;x
-;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;kt N2O/yr;Emi|N2O|Agriculture|+|Animal Waste Management;Mt N2O/yr;1000;;;;;x
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Decay of Crop Residues;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Inorganic Fertilizers;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Manure applied to Croplands;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Pasture;Mt N2O/yr;1000;;;;;
-;Emissions|N2O|AFOLU|Agriculture|Managed Soils;kt N2O/yr;Emi|N2O|Agriculture|+|Soil Organic Matter Loss;Mt N2O/yr;1000;;;;;x
-377;Emissions|N2O|AFOLU|Land;kt N2O/yr;Emi|N2O|+|Land-Use Change;kt N2O/yr;;;;;N2O|AFOL emissions from forestry and other land use;
-;Emissions|N2O|AFOLU|Wetlands|Peatlands;kt N2O/yr;Emi|N2O|Land-Use Change|+|Peatland;Mt N2O/yr;1000;;;;;x
-378;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Energy Supply;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
-;Emissions|N2O|Energy;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from energy use on supply and demand side,including fugitive emissions from fuels (IPCC category 1A,1B);x
-379;Emissions|N2O|Energy|Demand|Residential and Commercial|Commercial;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in commercial sector (IPCC category 1A4a,1A4b);
-380;Emissions|N2O|Energy|Demand|Residential and Commercial|Residential;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in residential sector (IPCC category 1A4a,1A4b);
->>>>>>> cleanupx;;;;;;;;;;
 382;Emissions|N2O|Energy|Demand|Transportation;kt N2O/yr;Emi|N2O|+|Transport;kt N2O/yr;;;;;N2O emissions from fuel combustion in the transportation sector (part of IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);
 383;Emissions|N2O|Energy|Demand|Transportation|Freight;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in Freight transportation sector (part of IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);
 384;Emissions|N2O|Energy|Demand|Transportation|Passenger;kt N2O/yr;;;;;;;N2O emissions from fuel combustion in Passenger transportation sector (part of IPCC category 1A3),excluding pipeline emissions (IPCC category 1A3ei);
 385;Emissions|N2O|Industrial Processes;kt N2O/yr;Emi|N2O|+|Industry;kt N2O/yr;;;;;N2O emissions from industrial processes;
-<<<<<<< HEAD;;;;;;;;;;
-386;Emissions|N2O|Industrial Processes|Chemicals;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the chemicals sector  (IPCC categories 2A,B,C,E);x
-387;Emissions|N2O|Industrial Processes|Non-ferrous metals;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the non-ferrous metals sector  (IPCC categories 2A,B,C,E);x
-388;Emissions|N2O|Industrial Processes|Other;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the other sector (All other production,please specify in comments tab) (IPCC categories 2A,B,C,E);x
-389;Emissions|N2O|Industrial Processes|Plastics;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the plastics sector  (IPCC categories 2A,B,C,E);x
-390;Emissions|N2O|Industrial Processes|Steel;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the steel sector  (IPCC categories 2A,B,C,E);x
-391;Emissions|N2O|Other;kt N2O/yr;;kt N2O/yr;;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);x
-=======;;;;;;;;;;
 386;Emissions|N2O|Industrial Processes|Chemicals;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the chemicals sector  (IPCC categories 2A,B,C,E);
 387;Emissions|N2O|Industrial Processes|Non-ferrous metals;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the non-ferrous metals sector  (IPCC categories 2A,B,C,E);
 388;Emissions|N2O|Industrial Processes|Other;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the other sector (All other production,please specify in comments tab) (IPCC categories 2A,B,C,E);
 389;Emissions|N2O|Industrial Processes|Plastics;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the plastics sector  (IPCC categories 2A,B,C,E);
 390;Emissions|N2O|Industrial Processes|Steel;kt N2O/yr;;;;;;;N2O emissions from industrial processes (excl. fuel combustion IPCC 1A2) in the steel sector  (IPCC categories 2A,B,C,E);
 391;Emissions|N2O|Other;kt N2O/yr;;kt N2O/yr;;;;;N2O emissions from other sources (please provide a definition of other sources in this category in the 'comments' tab);
->>>>>>> cleanupx;;;;;;;;;;
 392;Emissions|N2O|Waste;kt N2O/yr;Emi|N2O|+|Waste;kt N2O/yr;;;;;;
 393;Emissions|NH3;Mt NH3/yr;Emi|NH3;Mt NH3/yr;;;;;total ammonium (NH3) emissions;
 394;Emissions|NH3|AFOLU;Mt NH3/yr;Emi|NH3|Land Use;Mt NH3/yr;;;;;land use based ammonia Emissions;

--- a/tests/testthat/test-getTemplate.R
+++ b/tests/testthat/test-getTemplate.R
@@ -1,9 +1,15 @@
-test_that("basic checks on main templates", {
-  minimalLength <- list("AR6" = 1900, "NAVIGATE" = 1900)
-  for (template in names(templateNames())) {
+minimalLength <- list("AR6" = 1900, "NAVIGATE" = 1900)
+for (template in names(templateNames())) {
+  test_that(paste("basic checks on template", template), {
     expect_silent(templateData <- getTemplate(template))
     expect_true(all(c("variable", "unit", "piam_variable", "piam_unit", "piam_factor") %in% names(templateData)))
     expect_true(class(templateData) == "data.frame")
     expect_true(length(templateData$variable) > max(0, unlist(minimalLength[template])))
-  }
-})
+    expect_true(sum(is.na(templateData$variable)) == 0)
+    conflictsigns <- grep("===|<<<|>>>", templateData[, 1], value = TRUE)
+    if (length(conflictsigns) > 0) {
+      warning("Lines that look like merge conflicts:\n", paste(conflictsigns, collapse = "\n"))
+    }
+    expect_true(length(conflictsigns) == 0)
+  })
+}


### PR DESCRIPTION
## Purpose of this PR

- sorry if that caused any inconvenience except for myself.
- if something like `===`, `<<<` or `>>>` is found in a template, fail tests

## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
