### PR TITLE
add test for inconsistent units

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25915730'
+ValidationKey: '25935513'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.10
+version: 0.13.11
 date-released: '2024-03-01'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.10
+Version: 0.13.11
 Date: 2024-03-01
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.10**
+R package **piamInterfaces**, version **0.13.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.10, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.11, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.10},
+  note = {R package version 0.13.11},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/tests/testthat/test-getTemplate.R
+++ b/tests/testthat/test-getTemplate.R
@@ -5,11 +5,23 @@ for (template in names(templateNames())) {
     expect_true(all(c("variable", "unit", "piam_variable", "piam_unit", "piam_factor") %in% names(templateData)))
     expect_true(class(templateData) == "data.frame")
     expect_true(length(templateData$variable) > max(0, unlist(minimalLength[template])))
+    # look for empty cells in variable column
     expect_true(sum(is.na(templateData$variable)) == 0)
+    # look for merge conflicts
     conflictsigns <- grep("===|<<<|>>>", templateData[, 1], value = TRUE)
     if (length(conflictsigns) > 0) {
       warning("Lines that look like merge conflicts:\n", paste(conflictsigns, collapse = "\n"))
     }
-    expect_true(length(conflictsigns) == 0)
+    expect_true(length(conflictsigns) == 0, label = paste0(template, " has no merge conflicts"))
+    # check for inconsistent variable + unit combinations
+    nonempty <- dplyr::filter(templateData, ! is.na(.data$piam_variable), ! .data$piam_variable == "TODO")
+    allVarUnit <- paste0(nonempty$piam_variable, " (", nonempty$piam_unit, ")")
+    unclearVar <- nonempty$piam_variable[duplicated(nonempty$piam_variable) & ! duplicated(allVarUnit)]
+    unclearVarUnit <- sort(unique(allVarUnit[nonempty$piam_variable %in% unclearVar]))
+    if (length(unclearVarUnit)) {
+      warning("These variables have inconsistent units:\n",
+              paste(unclearVarUnit, collapse = "\n"))
+    }
+    expect_true(length(unclearVarUnit) == 0, label = paste("variables and units are consistent for", template))
   })
 }


### PR DESCRIPTION
## Purpose of this PR

I think #254 merits its own short test. Looks like that:

```
Warning (test-getTemplate.R:22:7): basic checks on template AR6
These variables have inconsistent units:
Productivity|Yield|Crops|+|Cereals (t DM/h)
Productivity|Yield|Crops|+|Cereals (t DM/ha)

Failure (test-getTemplate.R:25:5): basic checks on template AR6
variables and units are consistent for AR6 is not TRUE
```