### PR TITLE
try to repair units automatically, fix some wrong AR6 units

### DIFF
--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -132,6 +132,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
            " before 1.111.0 on 2023-05-26, please use piamInterfaces version 0.9.0 or earlier, see PR #128.")
   }
 
+  mifdata <- checkFixUnits(mifdata, mapData, logFile = logFile, failOnUnitMismatch = TRUE)
   mifdata <- .setModelAndScenario(mifdata, model, removeFromScen, addToScen)
 
   # apply mapping to data ----

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -1744,8 +1744,8 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 1603;Transport|Stock|Road|Freight;million vehicles;TODO;;;;;;The stock of road transport freight vehicles at the reported year;x
 1604;Transport|Stock|Road|Passenger;million vehicles;TODO;;;;;;The stock of road transport passenger vehicles at the reported year;x
 1605;Transport|Stock|Road|Passenger|2W&3W;million vehicles;TODO;;;;;;The stock of road transport passenger 2W &3W vehicles at the reported year;x
-1606;Transport|Stock|Road|Passenger|Bus;million vehicles;Stock|Transport|Bus;million vehicles;;;;;The stock of road transport passenger buses at the reported year;x
-1607;Transport|Stock|Road|Passenger|LDV;million vehicles;Stock|Transport|LDV;million vehicles;;;;;The stock of road transport passenger LDVs at the reported year;x
+1606;Transport|Stock|Road|Passenger|Bus;million vehicles;Stock|Transport|Bus;Million vehicles;;;;;The stock of road transport passenger buses at the reported year;x
+1607;Transport|Stock|Road|Passenger|LDV;million vehicles;Stock|Transport|LDV;Million vehicles;;;;;The stock of road transport passenger LDVs at the reported year;x
 1608;Final Energy|Residential and Commercial|Commercial|Water|Desalination;EJ/yr;;;;;;;Energy consumption for desalination water;
 1609;Final Energy|Residential and Commercial|Commercial|Water|Groundwater Extraction;EJ/yr;;;;;;;Energy consumption for groundwater extraction;
 1610;Final Energy|Residential and Commercial|Commercial|Water|Surface Water Extraction;EJ/yr;;;;;;;Energy consumption for surface water extraction;


### PR DESCRIPTION
## Purpose of this PR

- with your new checks, I noticed that for example `Interest Rate` had the wrong unit, and also some Transport variables
- I still prefer to have `unitless` in the template because that is more clear
- we already have the function to automatically repair units in case they are nearly correct to avoid that we have to keep track of all detail changes in iiasatemplate, and it can be easily adapted to also do that from data to the `piam_variable` in our mapping. I think that might be handy in the future if we harmonize variable names etc.
