### PR TITLE
don't fail early on unit mismatches, buildLibrary

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25955296'
+ValidationKey: '25981644'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md
@@ -6,4 +6,4 @@ AcceptedWarnings:
 - .*was deprecated in.*
 - .*cannot open file.*Permission denied.*
 AcceptedNotes: checking installed package size
-enforceVersionUpdate: no
+enforceVersionUpdate: yes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.13.12
-date-released: '2024-03-01'
+version: 0.13.13
+date-released: '2024-03-06'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.13.12
-Date: 2024-03-01
+Version: 0.13.13
+Date: 2024-03-06
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -71,7 +71,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 
   data <- data %>%
     filter(!!sym("variable") %in% unique(c(parentVariables, unlist(checkVariables, use.names = FALSE))))
-  message("# The filtered data contains ", length(unique(data$variable)), " variables.")
+  message("# Run summation check on a total of ", length(unique(data$variable)), " variables.")
 
   if (nrow(data) == 0) {
     return(NULL)

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -132,7 +132,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
            " before 1.111.0 on 2023-05-26, please use piamInterfaces version 0.9.0 or earlier, see PR #128.")
   }
 
-  mifdata <- checkFixUnits(mifdata, mapData, logFile = logFile, failOnUnitMismatch = TRUE)
+  mifdata <- checkFixUnits(mifdata, mapData, logFile = logFile, failOnUnitMismatch = FALSE)
   mifdata <- .setModelAndScenario(mifdata, model, removeFromScen, addToScen)
 
   # apply mapping to data ----

--- a/R/plotIntercomparison.R
+++ b/R/plotIntercomparison.R
@@ -69,14 +69,16 @@ plotIntercomparison <- function(mifFile, outputDirectory = "output", summationsF
     dref <- data %>%
       filter(.data$scenario == diffto) %>%
       select(-"scenario") %>%
-      rename("ref" = "value")
+      rename("ref" = "value") %>%
+      droplevels()
     data <- data %>%
       left_join(dref, by = c("model", "region", "variable", "unit", "period")) %>%
       mutate("value" = !!sym("value") - !!sym("ref")) %>%
-      filter(.data$scenario != diffto)
+      filter(.data$scenario != diffto) %>%
+      droplevels()
   }
 
-  message("The filtered data contains ", length(unique(data$variable)), " variables.")
+  message("The plots will show a total of ", length(unique(data$variable)), " variables.")
   newModelNames <- levels(data$model)
   for (n in names(renameModels)) {
     newModelNames <- gsub(n, renameModels[n], newModelNames, fixed = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.13.12**
+R package **piamInterfaces**, version **0.13.13**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -74,7 +74,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.12, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.13.13, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -83,7 +83,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.13.12},
+  note = {R package version 0.13.13},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

- update version number, enforce that for future PRs
- don't fail on unit mismatches
- adjust some "The filtered data contains 123 variables" logs that were quite incomprehensible


## Checklist:
- [x] I added an `x` in column `exclude_remind2_validation` for all `piam_variable` not produced by `remind2::convGDX2MIF` (for example EDGE-T, MAgPIE)
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
