### PR TITLE
allow to auto-remove intensive units in checkSummationsRegional

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2810748'
+ValidationKey: '2969100'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.14.2
+version: 0.15.0
 date-released: '2024-03-12'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.14.2
+Version: 0.15.0
 Date: 2024-03-12
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkSummationsRegional.R
+++ b/R/checkSummationsRegional.R
@@ -6,6 +6,8 @@
 #' @param parentRegion region to sum up to. Defaults to World or GLO
 #' @param childRegions regions that should sum up to `parentRegion`. Default to all except parentRegion
 #' @param variables list of variables to check. Defaults to all in mifFile
+#' @param skipUnits units to be skipped, because they are not expected to sum up. Set to TRUE to get
+#'        list of units pointing towards their variable being intensive. You can also use c(TRUE, "additionalunit")
 #' @importFrom dplyr group_by summarise ungroup left_join mutate %>% filter select
 #' @importFrom rlang sym syms .data
 #' @importFrom quitte as.quitte
@@ -19,10 +21,31 @@
 #')
 #'}
 #' @export
-checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions = NULL, variables = NULL) {
+checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions = NULL,
+                                    variables = NULL, skipUnits = NULL) {
+  if (TRUE %in% skipUnits) {
+    tmp <- c("", "%", "% of Total GDP", "% pa", "%/yr", "$/GJ", "1", "arbitrary unit/yr",
+             "billionDpktU", "billionDpTWyr", "cm/capita", "DM per live animal", "GE per GE",
+             "GJ/cap/yr", "GJ/t", "hectares per capita",
+             "index", "Index", "Index 2005=100", "Index 2010=100",
+             "kcal/cap/day", "kcal/capita/day", "kcal/kcal", "kUS$2005/per capita", "m3/ha", "MJ/US$2005",
+             "Mt CO2-equiv/EJ", "Mt CO2-equiv/US$2005", "Mt CO2/EJ", "Nr per Nr", "percent",
+             "Percent", "ratio", "share", "share of total land", "t DM/ha", "t DM/ha/yr", "t/million US$2005",
+             "tC/ha", "tC/tC", "tDM/capita/yr", "tr US$2005/input unit", "trUS$2005/Input", "unitless",
+             "US$05 PPP/cap/yr", "US$05/GJ", "US$05/ha", "US$05/tDM", "US$05/worker", "US$2005/GJ", "US$2005/kW",
+             "US$2005/kW/yr", "US$2005/t CH4", "US$2005/t CO2", "US$2005/t N2O", "US$2005/tCH4", "US$2005/tCO2",
+             "US$2005/tCO2 yr", "US$2005/tN2O", "US$2005/US$2005", "US$2005/yr", "US$2010/kW", "US$2010/kW/yr",
+             "USD/capita", "USD05/cap/yr", "USD05/USD05", "years")
+    skipUnits <- c(setdiff(skipUnits, TRUE), tmp)
+  }
 
   data <- droplevels(quitte::as.quitte(mifFile, na.rm = TRUE))
-  if (! is.null(variables))  data <- filter(data, .data$variable %in% variables)
+  if (! is.null(variables))  data <- droplevels(filter(data, .data$variable %in% variables))
+  skippedUnits <- intersect(skipUnits, levels(data$unit))
+  if (length(skippedUnits) > 0) {
+    data <- droplevels(filter(data, ! .data$unit %in% skippedUnits))
+    message(length(skippedUnits), " skipped.")
+  }
   if (is.null(parentRegion)) parentRegion <- intersect(c("World", "GLO"), levels(data$region))[[1]]
   if (is.null(childRegions)) childRegions <- setdiff(levels(data$region), parentRegion)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.14.2**
+R package **piamInterfaces**, version **0.15.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -104,7 +104,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.14.2, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.15.0, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -113,7 +113,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.14.2},
+  note = {R package version 0.15.0},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/checkSummationsRegional.Rd
+++ b/man/checkSummationsRegional.Rd
@@ -8,7 +8,8 @@ checkSummationsRegional(
   mifFile,
   parentRegion = NULL,
   childRegions = NULL,
-  variables = NULL
+  variables = NULL,
+  skipUnits = NULL
 )
 }
 \arguments{
@@ -19,6 +20,9 @@ checkSummationsRegional(
 \item{childRegions}{regions that should sum up to \code{parentRegion}. Default to all except parentRegion}
 
 \item{variables}{list of variables to check. Defaults to all in mifFile}
+
+\item{skipUnits}{units to be skipped, because they are not expected to sum up. Set to TRUE to get
+list of units pointing towards their variable being intensive. You can also use c(TRUE, "additionalunit")}
 }
 \description{
 Checks for a run if the regions for selected variables sum up as expected


### PR DESCRIPTION
## Purpose of this PR

- several variables are not expected to sum up regionally, as they are "intensive", not "extensive" variables, such as interest rates, costs in $/GW, agriculture production in t/ha etc. As a human, you can quite easily see that in their unit, but it seems difficult to do it automatically. So I added an option to `checkSummationsRegional` that allows to skip a number of selected units that I know are intensive and that are used either in MAgPIE, REMIND, AR6 or NAVIGATE reporting. Not sure I caught all of them, but it is a start.
- I also left "unitless" and "" – no proper summation without a meaningful unit
- I first had "income" (currently only used by `SDG|SDG02|Food expenditure share`) as well, but I think that isn't "intensive" in general, so I decided to remove it.