### PR TITLE
bugfix checkUnitFactor, don't match full column

### DIFF
--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -20,7 +20,7 @@ areUnitsIdentical <- function(vec1, vec2) {
     c("kt CF4/yr", "kt CF4-equiv/yr"),
     c("ktU/yr", "kt U/yr"),
     c("km\u00b3", "km3"),
-    c("Million", "million"),
+    c("Million", "million", "million people"),
     c("million t DM/yr", "Mt DM/yr"),
     c("million vehicles", "Million vehicles"),
     c("Mt/yr", "Mt/year"),

--- a/R/checkSummationsRegional.R
+++ b/R/checkSummationsRegional.R
@@ -46,7 +46,7 @@ checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions =
   skippedUnits <- intersect(skipUnits, levels(data$unit))
   if (length(skippedUnits) > 0) {
     data <- droplevels(filter(data, ! .data$unit %in% skippedUnits))
-    message(length(skippedUnits), " skipped.")
+    message(length(skippedUnits), " units skipped, as they point to intensive variables that would not sum up anyway.")
   }
   if (is.null(parentRegion)) parentRegion <- intersect(c("World", "GLO"), levels(data$region))[[1]]
   if (is.null(childRegions)) childRegions <- setdiff(levels(data$region), parentRegion)

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -19,7 +19,6 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
   # check whether scales are correctly transformed. c(piam_factor, unit, piam_unit)
   # the first line checks that mapping "billion whatever" to "million whatever" uses a factor 1000 etc.
   scaleConversion <- list(
-                          c("1", "million", "million people"),
                           c("1", "million", "Million vehicles"),
                           c("6", "GWh/yr", "GW/yr"), # for 'New Cap|Electricity|Storage|Battery'
                           c("6", "GWh", "GW"),       # for 'Cap|Electricity|Storage|Battery'
@@ -51,7 +50,7 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
   firsterror <- TRUE
   for (sc in scaleConversion) {
     fails <- template %>%
-               mutate(matches = .data$piam_unit %in% gsub(sc[[2]], sc[[3]], .data$unit, fixed = TRUE)) %>%
+               mutate(matches = .data$piam_unit == gsub(sc[[2]], sc[[3]], .data$unit, fixed = TRUE)) %>%
                mutate(matches = .data$matches & grepl(sc[[2]], .data$unit, fixed = TRUE)) %>%
                mutate(matches = .data$matches & ! grepl(paste0("/", sc[[2]]), .data$unit, fixed = TRUE)) %>%
                mutate(failed  = ! .data$piam_factor %in% c(sc[[1]], paste0("-", sc[[1]])))


### PR DESCRIPTION
## Purpose of this PR

- if you match with `%in%` here, it finds elements along the full dimension, which is nonsense.
