### PR TITLE
fix Agricultural Demand|Crops subcategories in AR6

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3207114'
+ValidationKey: '3227726'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3227726'
+ValidationKey: '3247692'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.16.2
-date-released: '2024-03-15'
+version: 0.16.3
+date-released: '2024-03-20'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.16.3
-date-released: '2024-03-20'
+version: 0.16.4
+date-released: '2024-03-21'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.16.3
-Date: 2024-03-20
+Version: 0.16.4
+Date: 2024-03-21
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.16.2
-Date: 2024-03-15
+Version: 0.16.3
+Date: 2024-03-20
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummationsRegional.R
+++ b/R/checkSummationsRegional.R
@@ -33,7 +33,7 @@ checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions =
              "kcal/cap/day", "kcal/capita/day", "kcal/kcal", "m3/ha", "MJ/t",
              "Mt CO2-equiv/EJ", "Mt CO2/EJ", "Nr per Nr", "percent",
              "Percent", "ratio", "share", "share of total land", "t DM/ha", "t DM/ha/yr",
-             "tC/ha", "tC/tC", "tDM/capita/yr", "unitless", "years")
+             "tC/ha", "tC/tC", "tDM/capita/yr", "tDM/cap/yr", "unitless", "years")
     curr <- c("USD", "USD05", "US$05", paste0("US$", years), paste0("USD_", years), paste0("EUR_", years))
     usecurr <- c("EJ/billion __", "MJ/__", "Mt CO2-equiv/__", "t/million __", "tr __/input unit", "tr__/Input",
                  "__ PPP/cap/yr", "k__/per capita", "__/capita", "__/GJ", "__/ha", "__/tDM",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.16.2**
+R package **piamInterfaces**, version **0.16.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -104,7 +104,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.16.2, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.16.3, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -113,7 +113,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.16.2},
+  note = {R package version 0.16.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.16.3**
+R package **piamInterfaces**, version **0.16.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -104,7 +104,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.16.3, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.16.4, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -113,7 +113,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.16.3},
+  note = {R package version 0.16.4},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/summations/summation_groups_NAVIGATE.csv
+++ b/inst/summations/summation_groups_NAVIGATE.csv
@@ -103,3 +103,16 @@ Carbon Capture|Industry;Carbon Capture|Industrial Processes;1
 Carbon Capture|Industry;Carbon Capture|Industry|Electricity;1
 Carbon Capture|Usage;Carbon Capture|Usage|Liquids;1
 Carbon Capture|Usage;Carbon Capture|Usage|Gases;1
+Agricultural Demand;Agricultural Demand|Energy;1
+Agricultural Demand;Agricultural Demand|Non-Energy;1
+Agricultural Production;Agricultural Production|Energy;1
+Agricultural Production;Agricultural Production|Non-Energy;1
+Agricultural Demand|Energy;Agricultural Demand|Energy|Crops|1st generation;1
+Agricultural Demand|Energy;Agricultural Demand|Energy|Crops|2nd generation;1
+Agricultural Demand|Energy;Agricultural Demand|Energy|Residues;1
+Agricultural Production|Energy;Agricultural Production|Energy|Crops|1st generation;1
+Agricultural Production|Energy;Agricultural Production|Energy|Crops|2nd generation;1
+Agricultural Production|Energy;Agricultural Production|Energy|Residues;1
+Agricultural Demand|Non-Energy|Crops;Agricultural Demand|Non-Energy|Crops|Feed;1
+Agricultural Demand|Non-Energy|Crops;Agricultural Demand|Non-Energy|Crops|Food;1
+Agricultural Demand|Non-Energy|Crops;Agricultural Demand|Non-Energy|Crops|Other;1

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -1485,11 +1485,9 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 1373;Investment|Infrastructure|Water|Other;billion US$2010/yr;;;;;;;investment into water-related infrastructure (other than for thermal cooling and irrigation);
 1374;Investment|RnD|Energy Supply;billion US$2010/yr;;;;;;;Investments into research and development,energy supply sector;
 1375;Agricultural Demand;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
-1375;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1375;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1375;Agricultural Demand;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1376;Agricultural Demand|Crops;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
-1376;Agricultural Demand|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
 1376;Agricultural Demand|Crops;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
 1377;Agricultural Demand|Crops|Energy;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;demand for modern primary energy crops (1st and 2nd generation);M
 1377;Agricultural Demand|Crops|Energy;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;demand for modern primary energy crops (1st and 2nd generation);M
@@ -1502,6 +1500,7 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 1382;Agricultural Demand|Crops|Other;million t DM/yr;Demand|Material|+|Crops;Mt DM/yr;;;;;total demand for other crops;M
 1382;Agricultural Demand|Crops|Other;million t DM/yr;Demand|Processing|+|Crops;Mt DM/yr;;;;;total demand for other crops;M
 1382;Agricultural Demand|Crops|Other;million t DM/yr;Demand|Seed|+|Crops;Mt DM/yr;;;;;total demand for other crops;M
+1382;Agricultural Demand|Crops|Other;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;;substract from Demand|Crops to avoid double-counting;;total demand for other crops;M
 1383;Agricultural Demand|Livestock;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;;total demand for livestock;M
 1384;Agricultural Demand|Livestock|Food;million t DM/yr;Demand|Food|+|Livestock products;Mt DM/yr;;;;;total demand for food livestock;M
 1385;Agricultural Demand|Livestock|Other;million t DM/yr;Demand|Agricultural Supply Chain Loss|+|Livestock products;Mt DM/yr;;;;;total demand for other livestock;M

--- a/inst/templates/mapping_template_AR6.csv
+++ b/inst/templates/mapping_template_AR6.csv
@@ -1485,9 +1485,11 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 1373;Investment|Infrastructure|Water|Other;billion US$2010/yr;;;;;;;investment into water-related infrastructure (other than for thermal cooling and irrigation);
 1374;Investment|RnD|Energy Supply;billion US$2010/yr;;;;;;;Investments into research and development,energy supply sector;
 1375;Agricultural Demand;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
+1375;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1375;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1375;Agricultural Demand;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;;total demand for food,non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 1376;Agricultural Demand|Crops;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
+1376;Agricultural Demand|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
 1376;Agricultural Demand|Crops;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;total demand for food,non-food and feed crops and bioenergy crops (1st & 2nd generation);M
 1377;Agricultural Demand|Crops|Energy;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;;demand for modern primary energy crops (1st and 2nd generation);M
 1377;Agricultural Demand|Crops|Energy;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;;demand for modern primary energy crops (1st and 2nd generation);M

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -4,13 +4,16 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 3;1;agriculture;Agricultural Demand|Energy;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;agricultural demand level for all bioenergy (consumption, not production);M
 3;1;agriculture;Agricultural Demand|Energy;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;agricultural demand level for all bioenergy (consumption, not production);M
+3;1;agriculture;Agricultural Demand|Energy;million t DM/yr;Demand|Bioenergy|+|Crop residues;Mt DM/yr;;;;agricultural demand level for all bioenergy (consumption, not production);M
 4;1;agriculture;Agricultural Demand|Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;demand for modern primary energy crops (1st and 2nd generation);M
 4;1;agriculture;Agricultural Demand|Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;demand for modern primary energy crops (1st and 2nd generation);M
 5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock);M
 5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops and livestock);M
+5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|Bioenergy|+|Crop residues ;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops and livestock);M
 5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock);M
 6;1;agriculture;Agricultural Demand|Non-Energy|Crops;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops);M
 6;1;agriculture;Agricultural Demand|Non-Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops);M
+6;1;agriculture;Agricultural Demand|Non-Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Crop residues ;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Crops;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Livestock products;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Bioenergy crops;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
@@ -40,6 +43,7 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Processing|+|Crops;Mt DM/yr;;;;total demand for non-food and non-feed (crops);M
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Seed|+|Crops;Mt DM/yr;;;;total demand for non-food and non-feed (crops);M
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for non-food and non-feed (crops);M
+25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Bioenergy|+|Crop residues ;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for non-food and non-feed (crops);M
 26;2;agriculture;Agricultural Demand|Non-Energy|Livestock;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for livestock products;M
 27;2;agriculture;Agricultural Demand|Non-Energy|Livestock|Food;million t DM/yr;Demand|Food|+|Livestock products;Mt DM/yr;;;;total demand for food livestock products;M
 28;2;agriculture;Agricultural Demand|Non-Energy|Livestock|Other;million t DM/yr;Demand|Agricultural Supply Chain Loss|+|Livestock products;Mt DM/yr;;;;total demand for non-food livestock products;M

--- a/inst/templates/mapping_template_NAVIGATE.csv
+++ b/inst/templates/mapping_template_NAVIGATE.csv
@@ -7,8 +7,10 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 4;1;agriculture;Agricultural Demand|Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;;;;demand for modern primary energy crops (1st and 2nd generation);M
 4;1;agriculture;Agricultural Demand|Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;demand for modern primary energy crops (1st and 2nd generation);M
 5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock);M
+5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops and livestock);M
 5;1;agriculture;Agricultural Demand|Non-Energy;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock);M
 6;1;agriculture;Agricultural Demand|Non-Energy|Crops;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops);M
+6;1;agriculture;Agricultural Demand|Non-Energy|Crops;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for food, non-food and feed products (crops);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Crops;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Livestock products;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 7;1;agriculture;Agricultural Production;million t DM/yr;Production|+|Bioenergy crops;Mt DM/yr;;;;total production of food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
@@ -37,6 +39,7 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Material|+|Crops;Mt DM/yr;;;;total demand for non-food and non-feed (crops);M
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Processing|+|Crops;Mt DM/yr;;;;total demand for non-food and non-feed (crops);M
 25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Seed|+|Crops;Mt DM/yr;;;;total demand for non-food and non-feed (crops);M
+25;2;agriculture;Agricultural Demand|Non-Energy|Crops|Other;million t DM/yr;Demand|Bioenergy|+|Secondary products;Mt DM/yr;-1;remove from Demand|Crops to avoid double-counting;;total demand for non-food and non-feed (crops);M
 26;2;agriculture;Agricultural Demand|Non-Energy|Livestock;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for livestock products;M
 27;2;agriculture;Agricultural Demand|Non-Energy|Livestock|Food;million t DM/yr;Demand|Food|+|Livestock products;Mt DM/yr;;;;total demand for food livestock products;M
 28;2;agriculture;Agricultural Demand|Non-Energy|Livestock|Other;million t DM/yr;Demand|Agricultural Supply Chain Loss|+|Livestock products;Mt DM/yr;;;;total demand for non-food livestock products;M


### PR DESCRIPTION
## Purpose of this PR

old situation in AR6 template:
```
Agricultural Demand|Crops <                  Demand|Crops + Demand|Bioenergy|Bioenergy crops <
   + Agricultural Demand|Crops|Energy           + Demand|Bioenergy|Secondary products + Demand|Bioenergy|Bioenergy crops
   + Agricultural Demand|Crops|Feed             + Demand|Feed|Crops
   + Agricultural Demand|Crops|Food             + Demand|Food|Crops
   + Agricultural Demand|Crops|Other            + Demand|Agricultural Supply Chain Loss|Crops + Demand|Domestic Balanceflow|Crops
                                                  + Demand|Material|Crops + Demand|Processing|Crops + Demand|Seed|Crops
Relative difference between -17.5% and -1%, absolute difference up to 162 million t DM/yr.
```

Add missing `Demand|Bioenergy|+|Secondary products` to the main category as is the case in `NAVIGATE` to make sure summations sum up. Additionally, I had to add it to `Agricultural Demand` as well.

It might be that the last part need to be done in NAVIGATE as well, @flohump? https://github.com/pik-piam/piamInterfaces/blob/master/inst/templates/mapping_template_NAVIGATE.csv#L3