### PR TITLE
split Waste emi in AR6

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3406288'
+ValidationKey: '3426092'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.17.2
+version: 0.17.3
 date-released: '2024-03-22'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.17.2
+Version: 0.17.3
 Date: 2024-03-22
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -45,7 +45,7 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                          )
   template$piam_factor[is.na(template$piam_factor)] <- 1
   success <- areUnitsIdentical(template$piam_unit, template$unit) & template$piam_factor %in% c(1, -1)
-  success <- success | is.na(template$piam_variable) | template$piam_variable %in% "TODO"
+  success <- success | is.na(template$piam_variable) | template$piam_variable %in% c("TODO", "Emi|CO2|Energy|+|Waste")
 
   firsterror <- TRUE
   for (sc in scaleConversion) {

--- a/R/getMapping.R
+++ b/R/getMapping.R
@@ -29,7 +29,8 @@ getMapping <- function(project = NULL) {
   }
   filename <- if (project %in% names(mappings)) mappings[project] else project
   if (file.exists(filename)) {
-    data <- read.csv2(filename, header = TRUE, sep = ";", na.strings = list(""), strip.white = TRUE, quote = "")
+    data <- read.csv2(filename, header = TRUE, sep = ";", na.strings = list(""),
+                      strip.white = TRUE, quote = "", comment.char = "#")
 
     requiredCols <- c("variable", "unit", "piam_variable", "piam_unit", "piam_factor")
 

--- a/R/plotIntercomparison.R
+++ b/R/plotIntercomparison.R
@@ -157,7 +157,7 @@ makepdf <- function(pdfFilename, plotdata, plotvariables, areaplotVariables, mai
   pdf(pdfFilename,
       width = 1.1 * max(12, length(quitte::getRegs(plotdata)),
                   length(quitte::getModels(plotdata)) * length(quitte::getScenarios(plotdata)) * 2),
-      height = 1.1 * 7)
+      height = 1.1 * 9)
   plotvariables <- sort(intersect(plotvariables, unique(plotdata$variable)))
   for (p in plotvariables) {
     message(which(p == plotvariables), "/", length(plotvariables), ": Add plot for ", p)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.17.2**
+R package **piamInterfaces**, version **0.17.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -20,7 +20,7 @@ Project specific interfaces to REMIND / MAgPIE.
 Mappings found in
 [the `inst/mappings` folder](https://github.com/pik-piam/piamInterfaces/tree/master/inst/mappings)
 serve to map variables from the PIAM framework to variables needed for the submission to databases.
-The mappings are `;`-separated files with the following mandatory columns:
+The mappings are `;`-separated files, using `#` as comment character, with the following mandatory columns:
 
 - `variable`: name of the variable in the project template
 - `unit`: unit corresponding to `variable`
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.2, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.3, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.17.2},
+  note = {R package version 0.17.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AR6.csv
+++ b/inst/mappings/mapping_AR6.csv
@@ -1,4 +1,10 @@
 idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+# temporary fix until waste emissions are separated
+;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
+#
 0;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Fertilizer;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure From Stubble Grazing;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M

--- a/tutorial.md
+++ b/tutorial.md
@@ -11,7 +11,7 @@
 Mappings found in
 [the `inst/mappings` folder](https://github.com/pik-piam/piamInterfaces/tree/master/inst/mappings)
 serve to map variables from the PIAM framework to variables needed for the submission to databases.
-The mappings are `;`-separated files with the following mandatory columns:
+The mappings are `;`-separated files, using `#` as comment character, with the following mandatory columns:
 
 - `variable`: name of the variable in the project template
 - `unit`: unit corresponding to `variable`


### PR DESCRIPTION
## Purpose of this PR

- temporary fix, see #241
- first, only for AR6, as NGFS will submit soon
- I think I only need to adjust these subcategories
- the automated checks complained about the piam_factor, so I added that as an exception.
- (also adjust a bit the plotting height to let the legend fit better, and allow comments in mapping files)