### PR TITLE
add Emi|PFC + HFC subcats to MAGICC7 template, add test

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3426092'
+ValidationKey: '3446418'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.17.3
-date-released: '2024-03-22'
+version: 0.17.4
+date-released: '2024-03-25'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.17.3
-Date: 2024-03-22
+Version: 0.17.4
+Date: 2024-03-25
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummationsRegional.R
+++ b/R/checkSummationsRegional.R
@@ -25,18 +25,19 @@
 checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions = NULL,
                                     variables = NULL, skipUnits = NULL, skipBunkers = NULL) {
   if (TRUE %in% skipUnits) {
-    years <- c(2005, 2010, 2015, 2020)
+    years <- paste0(c("05", 2005, 2010, 2015, 2020))
     index <- c(paste0("Index ", years, "=100"), paste0("Index (", years, " = 1)"))
     tmp <- c("", "%", "% of Total GDP", "% pa", "%/yr", "$/GJ", "1", "arbitrary unit", "arbitrary unit/yr",
              "billionDpktU", "billionDpTWyr", "cm/capita", "DM per live animal", "GE per GE",
              "GJ/cap/yr", "GJ/t", "hectares per capita", "index", "Index",
              "kcal/cap/day", "kcal/capita/day", "kcal/kcal", "m3/ha", "MJ/t",
              "Mt CO2-equiv/EJ", "Mt CO2/EJ", "Nr per Nr", "percent",
-             "Percent", "ratio", "share", "share of total land", "t DM/ha", "t DM/ha/yr",
+             "Percent", "protein/capita/day", "ratio", "share", "share of total land", "t DM/ha", "t DM/ha/yr",
              "tC/ha", "tC/tC", "tDM/capita/yr", "tDM/cap/yr", "unitless", "years")
-    curr <- c("USD", "USD05", "US$05", paste0("US$", years), paste0("USD_", years), paste0("EUR_", years))
+    curr <- c("USD", paste0("USDMER", years), paste0("USD", years), paste0("US$", years), paste0("USD_", years),
+              paste0("EUR_", years))
     usecurr <- c("EJ/billion __", "MJ/__", "Mt CO2-equiv/__", "t/million __", "tr __/input unit", "tr__/Input",
-                 "__ PPP/cap/yr", "k__/per capita", "__/capita", "__/GJ", "__/ha", "__/tDM",
+                 "__ PPP/cap/yr", "k__/per capita", "__/capita", "__/GJ", "__/h", "__/ha", "__/tDM",
                  "__/worker", "__/GJ", "__/kW", "__/kW/yr", "__/t CH4", "__/t CO2", "__/t N2O",
                  "__/tCH4", "__/tCO2", "__/tCO2 yr", "__/tN2O", "__/__", "__/yr", "__/cap/yr")
     tmp <- unique(c(index, tmp, unlist(lapply(curr, function(x) gsub("__", x, usecurr)))))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.17.3**
+R package **piamInterfaces**, version **0.17.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.3, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.4, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.17.3},
+  note = {R package version 0.17.4},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/iiasaTemplates/climate_assessment_variables.yaml
+++ b/inst/iiasaTemplates/climate_assessment_variables.yaml
@@ -102,6 +102,22 @@
     unit: Mt CO2-equiv/yr
 - Emissions|HFC:
     unit: kt HFC134a-equiv/yr
+- Emissions|HFC|HFC125:
+    unit: kt HFC125/yr
+- Emissions|HFC|HFC134a:
+    unit: kt HFC134a/yr
+- Emissions|HFC|HFC143a:
+    unit: kt HFC143a/yr
+- Emissions|HFC|HFC227ea:
+    unit: kt HFC227ea/yr
+- Emissions|HFC|HFC23:
+    unit: kt HFC23/yr
+- Emissions|HFC|HFC245fa:
+    unit: kt HFC245fa/yr
+- Emissions|HFC|HFC32:
+    unit: kt HFC32/yr
+- Emissions|HFC|HFC43-10:
+    unit: kt HFC43-10/yr
 - Emissions|Kyoto Gases:
     unit: Mt CO2-equiv/yr
 - Emissions|N2O:
@@ -114,5 +130,7 @@
     unit: kt N2O/yr
 - Emissions|N2O|Waste:
     unit: kt N2O/yr
+- Emissions|PFC:
+    unit: kt CF4-equiv/yr
 - Emissions|SF6:
     unit: kt SF6/yr

--- a/tests/testthat/test-loadIIASATemplate.R
+++ b/tests/testthat/test-loadIIASATemplate.R
@@ -21,3 +21,22 @@ test_that("loadIIASATemplate works", {
   writeLines(yamlstring, iiasayaml)
   expect_identical(templatedata, loadIIASATemplate(iiasayaml))
 })
+
+test_that("All variables in MAGICC7 template are mapped to something from REMIND via AR6 mapping", {
+
+  # check whether all variables in MAGICC template have proper piam_variable
+  t <- getMapping("AR6")
+  magiccfile <- file.path(system.file("iiasaTemplates", package = "piamInterfaces"),
+                          "climate_assessment_variables.yaml")
+  magicc <- loadIIASATemplate(magiccfile)
+  expect_true("variable" %in% colnames(magicc))
+  expect_true("unit" %in% colnames(magicc))
+  magiccvars <- paste0(magicc$variable, " (", magicc$unit, ")")
+  tvars <- paste0(t$variable, " (", t$unit, ")")[! is.na(t$piam_variable)]
+  missingvars <- setdiff(magiccvars, tvars)
+  if (length(missingvars) > 0) {
+    warning("MAGICC7 variables with no piam_variable in AR6 template: ",
+            paste0(missingvars, collapse = ", "))
+  }
+  expect_true(length(missingvars) == 0)
+})


### PR DESCRIPTION
## Purpose of this PR

- PFC + HFC categories are now available from REMIND (#280, https://github.com/pik-piam/remind2/pull/571) and should be included into MAGICC
- add a test that makes sure every variable specifed in the MAGICC template shows up in the AR6 mapping with a piam_variable specified
- minor stuff: [add 'USDMER' as currency unit and USD/h for wages as intensive variable](https://github.com/pik-piam/piamInterfaces/pull/286/commits/8f8e192ab7630fa1a9a1e98236dfe057ee8b9d72)