### PR TITLE
only return summation checks that fail

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3486384'
+ValidationKey: '3526180'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.17.6
-date-released: '2024-03-27'
+version: 0.17.8
+date-released: '2024-03-28'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.17.6
-Date: 2024-03-27
+Version: 0.17.8
+Date: 2024-03-28
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -19,8 +19,8 @@
 #'                to be listed in human-readable summary
 #' @param relDiff threshold (in percent) for relative difference between parent variable and summation
 #'                to be listed in human-readable summary
-#' @param roundDiff should the absolute and relative differences in human-readable summary
-#'                  be rounded?
+#' @param roundDiff should the absolute and relative differences in human-readable summary and dataDumpFile
+#'                  be rounded? The returned object always contains unrounded values.
 #' @param csvSeparator separator for dataDumpFile, defaults to semicolon
 #' @importFrom dplyr group_by summarise ungroup left_join mutate arrange %>%
 #'             filter select desc reframe last_col
@@ -142,20 +142,19 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
     comparison <- rbind(comparison, comp)
   }
 
+  comparison <- comparison %>%
+    filter(abs(.data$reldiff) >= relDiff, abs(.data$diff) >= absDiff) %>%
+    arrange(desc(abs(.data$reldiff)))
+
   # write data to dataDumpFile
   if (!is.null(outputDirectory) && length(dataDumpFile) > 0) {
     dataDumpFile <- file.path(outputDirectory, dataDumpFile)
-
-    fileLarge <- comparison %>%
-      filter(abs(!!sym("reldiff")) >= relDiff, abs(!!sym("diff")) >= absDiff) %>%
-      arrange(desc(abs(!!sym("reldiff"))))
-
+    filedata <- comparison
     if (isTRUE(roundDiff)) {
-      fileLarge <- fileLarge %>% mutate(reldiff = niceround(!!sym("reldiff"), digits = 2))
+      filedata <- comparison %>% mutate(reldiff = niceround(.data$reldiff, digits = 2))
     }
-
     write.table(
-      fileLarge,
+      filedata,
       file = dataDumpFile,
       sep = csvSeparator,
       quote = FALSE,
@@ -167,7 +166,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
   .checkSummationsSummary(
     mifFile, data, comparison, mapping, summationsFile, summationGroups, checkVariables,
     generatePlots, mainReg, outputDirectory, logFile, logAppend, dataDumpFile, remindVar,
-    plotprefix, absDiff, relDiff, roundDiff
+    plotprefix, roundDiff
   )
 
   return(invisible(comparison))
@@ -176,8 +175,7 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 .checkSummationsSummary <- function(mifFile, data, comparison, mapping, summationsFile, # nolint: cyclocomp_linter.
                                     summationGroups, checkVariables, generatePlots,
                                     mainReg, outputDirectory, logFile, logAppend,
-                                    dataDumpFile, remindVar, plotprefix, absDiff,
-                                    relDiff, roundDiff) {
+                                    dataDumpFile, remindVar, plotprefix, roundDiff) {
 
   text <- paste0("\n### Analyzing ", if (is.null(ncol(mifFile))) mifFile else "provided data",
                  ".\n# Use ", summationsFile, " to check if summation groups add up.")
@@ -195,10 +193,11 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 
   for (thismodel in quitte::getModels(data)) {
     text <- c(text, paste0("# Analyzing results of model ", thismodel))
-    fileLarge <- filter(comparison, abs(!!sym("reldiff")) >= relDiff,
-                        abs(!!sym("diff")) >= absDiff, !!sym("model") == thismodel)
+    fileLarge <- filter(comparison, .data$model == thismodel, abs(.data$diff) > 0)
     problematic <- sort(unique(c(fileLarge$variable)))
-    if (length(problematic) > 0) {
+    if (length(problematic) == 0) {
+      summarytext <- c(summarytext, paste0("\n# All summation checks were fine for model ", thismodel, "."))
+    } else {
       if (generatePlots) {
         pdfFilename <- file.path(outputDirectory,
                                  paste0(plotprefix, "checkSummations_", gsub(" ", "_", thismodel), ".pdf"))
@@ -283,8 +282,6 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
         dev.off()
         summarytext <- c(summarytext, paste0("\n# Find plot comparison of all errors in ", pdfFilename))
       }
-    } else {
-      summarytext <- c(summarytext, paste0("\n# All summation checks were fine for model ", thismodel, "."))
     }
   }
   summarytext <- c(summarytext, "\n# As generatePlots=FALSE, no plot comparison was produced."[! generatePlots])

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -74,9 +74,9 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 
   data <- data %>%
     filter(!!sym("variable") %in% unique(c(parentVariables, unlist(checkVariables, use.names = FALSE))))
-  message("# Run summation check on a total of ", length(unique(data$variable)), " variables.")
 
   if (nrow(data) == 0) {
+    warning("No variable found that matches summationsFile=", paste(summationsFile, collapse = ", "))
     return(NULL)
   }
 
@@ -193,10 +193,13 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
 
   for (thismodel in quitte::getModels(data)) {
     text <- c(text, paste0("# Analyzing results of model ", thismodel))
-    fileLarge <- filter(comparison, .data$model == thismodel, abs(.data$diff) > 0)
+    fileLarge <- droplevels(filter(comparison, .data$model == thismodel, abs(.data$diff) > 0))
+    text <- c(text, paste("# Run summation check on a total of", length(levels(data$variable)), "variables."))
     problematic <- sort(unique(c(fileLarge$variable)))
     if (length(problematic) == 0) {
-      summarytext <- c(summarytext, paste0("\n# All summation checks were fine for model ", thismodel, "."))
+      if (length(levels(data$variable)) > 0) {
+        summarytext <- c(summarytext, paste0("\n# All summation checks were fine for model ", thismodel, "."))
+      }
     } else {
       if (generatePlots) {
         pdfFilename <- file.path(outputDirectory,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.17.6**
+R package **piamInterfaces**, version **0.17.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.6, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.17.8, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.17.6},
+  note = {R package version 0.17.8},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/checkSummations.Rd
+++ b/man/checkSummations.Rd
@@ -53,8 +53,8 @@ to be listed in human-readable summary}
 \item{relDiff}{threshold (in percent) for relative difference between parent variable and summation
 to be listed in human-readable summary}
 
-\item{roundDiff}{should the absolute and relative differences in human-readable summary
-be rounded?}
+\item{roundDiff}{should the absolute and relative differences in human-readable summary and dataDumpFile
+be rounded? The returned object always contains unrounded values.}
 
 \item{csvSeparator}{separator for dataDumpFile, defaults to semicolon}
 }

--- a/tests/testthat/test-checkSummations.R
+++ b/tests/testthat/test-checkSummations.R
@@ -1,121 +1,127 @@
-varnames <- paste(c("Final Energy|Industry", "Final Energy|Industry|Electricity", "Final Energy|Industry|Liquids"),
-                  "(EJ/yr)")
+test_that("checkSummations works", {
+  varnames <- paste(c("Final Energy|Industry", "Final Energy|Industry|Electricity", "Final Energy|Industry|Liquids"),
+                    "(EJ/yr)")
 
-data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 2, 1, 2),
-                             names = varnames)
-magclass::getSets(data)[3] <- "variable"
-data <- magclass::add_dimension(data, dim = 3.1, add = "model", nm = "REMIND")
-data <- magclass::add_dimension(data, dim = 3.1, add = "scenario", nm = "default")
-magclass::write.report(data, file = file.path(tempdir(), "test.mif"), ndigit = 0)
+  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 2, 1, 2),
+                               names = varnames)
+  magclass::getSets(data)[3] <- "variable"
+  data <- magclass::add_dimension(data, dim = 3.1, add = "model", nm = "REMIND")
+  data <- magclass::add_dimension(data, dim = 3.1, add = "scenario", nm = "default")
+  magclass::write.report(data, file = file.path(tempdir(), "test.mif"), ndigit = 0)
 
-dataerror <- magclass::new.magpie(cells_and_regions = c("CAZ", "World"), years = c(2030, 2050),
-                                  fill = c(3, 5, 1, 2, 1, 2, 3, 5, 1, 2, 1, 2),
-                                  names = varnames)
-magclass::getSets(dataerror)[3] <- "variable"
-dataerror <- magclass::add_dimension(dataerror, dim = 3.1, add = "model", nm = "REMIND")
-dataerror <- magclass::add_dimension(dataerror, dim = 3.1, add = "scenario", nm = "default")
-magclass::write.report(dataerror, file = file.path(tempdir(), "testerror.mif"), ndigit = 0)
+  dataerror <- magclass::new.magpie(cells_and_regions = c("CAZ", "World"), years = c(2030, 2050),
+                                    fill = c(3, 5, 1, 2, 1, 2, 3, 5, 1, 2, 1, 2),
+                                    names = varnames)
+  magclass::getSets(dataerror)[3] <- "variable"
+  dataerror <- magclass::add_dimension(dataerror, dim = 3.1, add = "model", nm = "REMIND")
+  dataerror <- magclass::add_dimension(dataerror, dim = 3.1, add = "scenario", nm = "default")
+  magclass::write.report(dataerror, file = file.path(tempdir(), "testerror.mif"), ndigit = 0)
 
 
-for (summationFile in names(summationsNames())) {
-  test_that(paste("test summationFile without errors using", summationFile), {
-    if (summationFile == "AR6") {
-      expect_message(tmp <- checkSummations(data, logFile = NULL,
-                                            template = summationFile, summationsFile = summationFile,
-                                            outputDirectory = tempdir(),
-                                            dataDumpFile = "checkSummations1.csv"),
-                     "All summation checks were fine")
-      expect_true(file.exists(file.path(tempdir(), "checkSummations1.csv")))
-    } else {
-      expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "test.mif"), logFile = NULL,
-                                            template = summationFile, summationsFile = summationFile,
-                                            outputDirectory = tempdir(),
-                                            dataDumpFile = "checkSummations2.csv"),
-                     "All summation checks were fine")
-      expect_true(file.exists(file.path(tempdir(), "checkSummations2.csv")))
-    }
-    tmp <- droplevels(filter(tmp, !is.na(tmp$value)))
-    expect_true(all(tmp$diff == 0))
-    expect_true(length(tmp$diff) > 0)
-    expect_true(any(grepl("^Final Energy\\|Industry( [0-9]+)?$", unique(tmp$variable))))
-  })
-  test_that(paste("test summationFile with errors using", summationFile), {
-    if (summationFile == "AR6") {
-      expect_message(tmp <- checkSummations(mifFile = dataerror, logFile = NULL,
-                                            template = summationFile, summationsFile = summationFile,
-                                            outputDirectory = tempdir(),
-                                            dataDumpFile = "checkSummations3.csv"),
-                     "Final Energy|Industry", fixed = TRUE)
-      expect_true(file.exists(file.path(tempdir(), "checkSummations3.csv")))
-      capture.output(expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "testerror.mif"),
-                                                           logFile = "log4.txt", template = summationFile,
-                                                           summationsFile = summationFile,
-                                                           outputDirectory = tempdir(),
-                                                           dataDumpFile = "checkSummations4.csv", generatePlots = TRUE,
-                                                           plotprefix = "TESTTHAT_"),
-                                    "1 equations are not satisfied"))
-      expect_true(file.exists(file.path(tempdir(), "TESTTHAT_checkSummations_REMIND.pdf")))
-      expect_true(file.info(file.path(tempdir(), "TESTTHAT_checkSummations_REMIND.pdf"))$size > 0)
-      expect_true(file.exists(file.path(tempdir(), "log4.txt")))
-      expect_true(file.exists(file.path(tempdir(), "checkSummations4.csv")))
-    } else {
-      expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "testerror.mif"), logFile = NULL,
-                                            template = summationFile,
-                                            summationsFile = summationFile, outputDirectory = tempdir(),
-                                            dataDumpFile = "checkSummations3.csv"),
-                     "Final Energy|Industry", fixed = TRUE)
-      expect_true(file.exists(file.path(tempdir(), "checkSummations3.csv")))
-    }
-    expect_false(all(tmp$diff == 0))
-  })
-}
+  for (summationFile in names(summationsNames())) {
+    test_that(paste("test summationFile without errors using", summationFile), {
+      if (summationFile == "AR6") {
+        expect_message(tmp <- checkSummations(data, logFile = NULL,
+                                              template = summationFile, summationsFile = summationFile,
+                                              outputDirectory = tempdir(),
+                                              dataDumpFile = "checkSummations1.csv", absDiff = 0, relDiff = 0),
+                       "All summation checks were fine")
+        tmp <- droplevels(filter(tmp, !is.na(tmp$value)))
+        expect_true(file.exists(file.path(tempdir(), "checkSummations1.csv")))
+        expect_true(all(tmp$diff == 0))
+        expect_true(nrow(tmp) > 0)
+        expect_true(any(grepl("^Final Energy\\|Industry( [0-9]+)?$", unique(tmp$variable))))
+      } else {
+        expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "test.mif"), logFile = NULL,
+                                              template = summationFile, summationsFile = summationFile,
+                                              outputDirectory = tempdir(),
+                                              dataDumpFile = "checkSummations2.csv"),
+                       "All summation checks were fine")
+        expect_true(file.exists(file.path(tempdir(), "checkSummations2.csv")))
+        tmp <- droplevels(filter(tmp, !is.na(tmp$value)))
+        expect_true(nrow(tmp) == 0)
+      }
+    })
+    test_that(paste("test summationFile with errors using", summationFile), {
+      if (summationFile == "AR6") {
+        expect_message(tmp <- checkSummations(mifFile = dataerror, logFile = NULL,
+                                              template = summationFile, summationsFile = summationFile,
+                                              outputDirectory = tempdir(),
+                                              dataDumpFile = "checkSummations3.csv"),
+                       "Final Energy|Industry", fixed = TRUE)
+        expect_true(file.exists(file.path(tempdir(), "checkSummations3.csv")))
+        capture.output(expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "testerror.mif"),
+                                                             logFile = "log4.txt", template = summationFile,
+                                                             summationsFile = summationFile,
+                                                             outputDirectory = tempdir(),
+                                                             dataDumpFile = "checkSummations4.csv",
+                                                             generatePlots = TRUE,
+                                                             plotprefix = "TESTTHAT_"),
+                                      "1 equations are not satisfied"))
+        expect_true(file.exists(file.path(tempdir(), "TESTTHAT_checkSummations_REMIND.pdf")))
+        expect_true(file.info(file.path(tempdir(), "TESTTHAT_checkSummations_REMIND.pdf"))$size > 0)
+        expect_true(file.exists(file.path(tempdir(), "log4.txt")))
+        expect_true(file.exists(file.path(tempdir(), "checkSummations4.csv")))
+      } else {
+        expect_message(tmp <- checkSummations(mifFile = file.path(tempdir(), "testerror.mif"), logFile = NULL,
+                                              template = summationFile,
+                                              summationsFile = summationFile, outputDirectory = tempdir(),
+                                              dataDumpFile = "checkSummations3.csv"),
+                       "Final Energy|Industry", fixed = TRUE)
+        expect_true(file.exists(file.path(tempdir(), "checkSummations3.csv")))
+      }
+      expect_false(all(tmp$diff == 0))
+    })
+  }
 
-unlink(file.path(tempdir(), c("test.mif", "testerror.mif", "log.txt", "checkSummations.csv")))
+  unlink(file.path(tempdir(), c("test.mif", "testerror.mif", "log.txt", "checkSummations.csv")))
 
-# test usage of same variables multiple times as a child in summation groups ----
-# Capacity|Electricity|Oil = Capacity|Electricity|Oil|w/o CCS + Capacity|Electricity|Oil|w/ CCS
-# Capacity|Electricity" = ... + Capacity|Electricity|Nuclear, Capacity|Electricity|Oil|w/o CCS
-varnames <- paste(c("Capacity|Electricity|Oil", "Capacity|Electricity|Oil|w/o CCS", "Capacity|Electricity|Oil|w/ CCS",
-                    "Capacity|Electricity", "Capacity|Electricity|Nuclear"),
-                  "(EJ/yr)")
+  # test usage of same variables multiple times as a child in summation groups ----
+  # Capacity|Electricity|Oil = Capacity|Electricity|Oil|w/o CCS + Capacity|Electricity|Oil|w/ CCS
+  # Capacity|Electricity" = ... + Capacity|Electricity|Nuclear, Capacity|Electricity|Oil|w/o CCS
+  varnames <- paste(c("Capacity|Electricity|Oil", "Capacity|Electricity|Oil|w/o CCS", "Capacity|Electricity|Oil|w/ CCS",
+                      "Capacity|Electricity", "Capacity|Electricity|Nuclear"),
+                    "(EJ/yr)")
 
-data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 5, 7, 2),
-                             names = varnames)
+  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 5, 7, 2),
+                               names = varnames)
 
-magclass::getSets(data)[3] <- "variable"
-sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
-  filter(diff != 0)
-expect_true(nrow(sumChecks) == 0)
+  magclass::getSets(data)[3] <- "variable"
+  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
+    filter(diff != 0)
+  expect_true(nrow(sumChecks) == 0)
 
-# test usage of different summations for same variable ----
-# Final Energy = .. + Final Energy|Electricity + Final Energy|Gases
-# Final Energy 2 = .. + Final Energy|Industry + Final Energy|Transportation
+  # test usage of different summations for same variable ----
+  # Final Energy = .. + Final Energy|Electricity + Final Energy|Gases
+  # Final Energy 2 = .. + Final Energy|Industry + Final Energy|Transportation
 
-varnames <- paste(c("Final Energy", "Final Energy|Industry", "Final Energy|Transportation",
-                    "Final Energy|Electricity", "Final Energy|Gases"),
-                  "(EJ/yr)")
+  varnames <- paste(c("Final Energy", "Final Energy|Industry", "Final Energy|Transportation",
+                      "Final Energy|Electricity", "Final Energy|Gases"),
+                    "(EJ/yr)")
 
-data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 6, 7, 3),
-                             names = varnames)
-magclass::getSets(data)[3] <- "variable"
-sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
-  filter(diff != 0)
-expect_true(nrow(sumChecks) == 1)
-expect_true(unique(sumChecks$variable) == "Final Energy 2")
+  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 6, 7, 3),
+                               names = varnames)
+  magclass::getSets(data)[3] <- "variable"
+  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
+    filter(diff != 0)
+  expect_true(nrow(sumChecks) == 1)
+  expect_true(unique(sumChecks$variable) == "Final Energy 2")
 
-# test extractVariableGroups option ----
-varnames <- paste(c("FE|Industry|Steel", "FE|Industry|Steel|+|Primary", "FE|Industry|Steel|+|Secondary"),
-                  "(EJ/yr)")
-data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 2, 1, 2),
-                             names = varnames)
-magclass::getSets(data)[3] <- "variable"
-sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "extractVariableGroups") %>%
-  filter(diff != 0)
-expect_true(nrow(sumChecks) == 0)
+  # test extractVariableGroups option, testing a magclass object  ----
+  varnames <- paste(c("FE|Industry|Steel", "FE|Industry|Steel|+|Primary", "FE|Industry|Steel|+|Secondary"),
+                    "(EJ/yr)")
+  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 2, 1, 2),
+                               names = varnames)
+  magclass::getSets(data)[3] <- "variable"
+  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "extractVariableGroups") %>%
+    filter(diff != 0)
+  expect_true(nrow(sumChecks) == 0)
 
-dataerror <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 1, 1, 1),
-                                  names = varnames)
-magclass::getSets(dataerror)[3] <- "variable"
-sumChecks <- checkSummations(mifFile = dataerror, outputDirectory = NULL, summationsFile = "extractVariableGroups") %>%
-  filter(diff != 0)
-expect_true(nrow(sumChecks) == 1)
+  dataerror <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030, 2050), fill = c(2, 4, 1, 1, 1, 1),
+                                    names = varnames)
+  magclass::getSets(dataerror)[3] <- "variable"
+  sumChecks <- dataerror %>%
+    checkSummations(outputDirectory = NULL, summationsFile = "extractVariableGroups") %>%
+    filter(.data$diff != 0)
+  expect_true(nrow(sumChecks) == 1)
+})

--- a/tests/testthat/test-checkSummations.R
+++ b/tests/testthat/test-checkSummations.R
@@ -124,4 +124,7 @@ test_that("checkSummations works", {
     checkSummations(outputDirectory = NULL, summationsFile = "extractVariableGroups") %>%
     filter(.data$diff != 0)
   expect_true(nrow(sumChecks) == 1)
+
+  expect_warning(checkSummations(filter(qeAR6, 0 > 1), outputDirectory = NULL, summationsFile = "AR6"),
+                 "No variable found that matches summationsFile")
 })

--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -45,7 +45,7 @@ test_that("Correct Prices are selected and plusses ignored", {
   }
   f <- file.path(tempdir(), "Pricecheck_AR6_1.mif")
   expect_no_warning(generateIIASASubmission(droplevels(filter(qe, grepl("Electricity", variable))),
-                                            mapping = "AR6", outputDirectory = dirname(f),
+                                            mapping = "AR6", outputDirectory = dirname(f), checkSummation = FALSE,
                                             outputFilename = basename(f), logFile = file.path(tempdir(), "price.log")))
   expect_true(file.exists(f))
   qemif <- quitte::as.quitte(f)
@@ -56,9 +56,9 @@ test_that("Correct Prices are selected and plusses ignored", {
   # check whether results are identical if we remove the plus and don't write to file
   qenoplus <- qe
   levels(qenoplus$variable) <- removePlus(levels(qenoplus$variable))
-  qenoplusmif <- expect_no_warning(droplevels(as.quitte(dplyr::as_tibble(
+  expect_no_warning(qenoplusmif <- droplevels(as.quitte(dplyr::as_tibble(
     generateIIASASubmission(droplevels(filter(qe, grepl("Electricity", variable))),
-      mapping = "AR6", outputDirectory = NULL, outputFilename = NULL, logFile = NULL
+      mapping = "AR6", outputDirectory = NULL, outputFilename = NULL, logFile = NULL, checkSummation = FALSE
     )
   ))))
   sortquitte <- function(d) {
@@ -69,7 +69,7 @@ test_that("Correct Prices are selected and plusses ignored", {
   f2 <- file.path(tempdir(), "Pricecheck_AR6_2.mif")
   # if Rawdata is not present, warn
   expect_warning(generateIIASASubmission(droplevels(filter(qe, grepl("Gases", variable))),
-                                         mapping = "AR6", outputDirectory = dirname(f2),
+                                         mapping = "AR6", outputDirectory = dirname(f2), checkSummation = FALSE,
                                          outputFilename = basename(f2), logFile = file.path(tempdir(), "price.log")),
                  "Your data contains no Price|*|Rawdata variables.")
   expect_true(file.exists(f2))


### PR DESCRIPTION
## Purpose of this PR

- it makes no sense to always have everything returned. If you want everything, set `absDiff = 0` and `relDiff = 0` and you are good to go.
- I had to rewrite the tests a bit, but that is ok, I guess
- best look at it with in no-whitespace mode, because the lintr was complaining: https://github.com/pik-piam/piamInterfaces/pull/291/files?diff=unified&w=1