### PR TITLE
bugfix in plotIntercomparison after Variable->variable rename in mappings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3590135'
+ValidationKey: '3610152'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.18.1
-date-released: '2024-04-22'
+version: 0.18.2
+date-released: '2024-04-23'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.18.1
-Date: 2024-04-22
+Version: 0.18.2
+Date: 2024-04-23
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/plotIntercomparison.R
+++ b/R/plotIntercomparison.R
@@ -7,12 +7,12 @@
 #' @param summationsFile in inst/summations folder that describes the required summation groups
 #' @param renameModels vector with oldname = newname
 #' @param lineplotVariables vector with variable names for additional lineplots or filenames
-#'        of files containing a 'Variable' column (or both)
+#'        of files containing a 'variable' column (or both)
 #' @param interactive boolean whether you want to select variables, regions and models to be plotted
 #' @param mainReg region name of main region to be passed to mip
 #' @param plotby whether you would like to have everything plotted by scenario, model and/or onefile
 #' @param diffto if specified, the difference to this scenario is calculated and plotted
-#' @importFrom dplyr group_by summarise ungroup left_join mutate arrange %>% filter select desc
+#' @importFrom dplyr group_by summarise ungroup left_join mutate arrange %>% filter select desc pull
 #' @importFrom rlang sym syms .data
 #' @importFrom quitte as.quitte getModels getRegs getScenarios
 #' @importFrom grDevices pdf dev.off
@@ -45,7 +45,7 @@ plotIntercomparison <- function(mifFile, outputDirectory = "output", summationsF
   mappingfiles <- lineplotVariables[lineplotVariables %in% names(mappingNames()) || file.exists(lineplotVariables)]
   tmpLpv <- setdiff(lineplotVariables, mappingfiles)
   for (mapping in mappingfiles) {
-    tmpLpv <- c(tmpLpv, getMapping(mapping)$Variable)
+    tmpLpv <- c(tmpLpv, getMapping(mapping) %>% pull("variable"))
   }
   lineplotVariables <- unique(tmpLpv)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.18.1**
+R package **piamInterfaces**, version **0.18.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.18.1, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.18.2, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.18.1},
+  note = {R package version 0.18.2},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/plotIntercomparison.Rd
+++ b/man/plotIntercomparison.Rd
@@ -27,7 +27,7 @@ plotIntercomparison(
 \item{renameModels}{vector with oldname = newname}
 
 \item{lineplotVariables}{vector with variable names for additional lineplots or filenames
-of files containing a 'Variable' column (or both)}
+of files containing a 'variable' column (or both)}
 
 \item{interactive}{boolean whether you want to select variables, regions and models to be plotted}
 


### PR DESCRIPTION
## Purpose of this PR

lineplotVariables = "AR6" did not work anymore

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
