### PR TITLE
add CO2 extraction variable to NGFS mapping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3650008'
+ValidationKey: '3672250'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.0
+    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.18.4
-date-released: '2024-04-24'
+version: 0.18.5
+date-released: '2024-05-07'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.18.4
-Date: 2024-04-24
+Version: 0.18.5
+Date: 2024-05-07
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -9,7 +9,7 @@
 areUnitsIdentical <- function(vec1, vec2) {
   # only add units that actually have the same meaning, just different spelling
   identicalUnits <- list(
-    c("\u00B0C", "K"),
+    c("\u00B0C", "\u00C2\u00B0C", "K"),
     c("billion m2/yr", "bn m2/yr"),
     c("billion pkm/yr", "bn pkm/yr"),
     c("billion tkm/yr", "bn tkm/yr"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.18.4**
+R package **piamInterfaces**, version **0.18.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.18.4, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.18.5, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.18.4},
+  note = {R package version 0.18.5},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AR6_NGFS.csv
+++ b/inst/mappings/mapping_AR6_NGFS.csv
@@ -21,3 +21,4 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 ;GDP|MER|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
 ;GDP|MER|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
 ;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;Rx
+;Emissions|CO2|Energy|Supply|Extraction;Mt CO2/yr;Emi|CO2|Energy|Supply|Extraction;Mt CO2/yr;1;;;;energy-related CO2 emissions from extraction processes;R


### PR DESCRIPTION
## Purpose of this PR

Adds the variable ``Emi|CO2|Energy|Supply|Extraction`` to the NGFS mapping.

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
