### PR TITLE
remove cement from navigate summation group

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4015962'
+ValidationKey: '4038076'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.20.2
-date-released: '2024-06-07'
+version: 0.20.3
+date-released: '2024-06-18'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke
@@ -12,6 +12,5 @@ authors:
 - family-names: Richters
   given-names: Oliver
 license: LGPL-3.0
-keywords: ~
 repository-code: https://github.com/pik-piam/piamInterfaces
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.20.2
-Date: 2024-06-07
+Version: 0.20.3
+Date: 2024-06-18
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.20.2**
+R package **piamInterfaces**, version **0.20.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.2, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.3, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.20.2},
+  note = {R package version 0.20.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/summations/summation_groups_NAVIGATE.csv
+++ b/inst/summations/summation_groups_NAVIGATE.csv
@@ -94,7 +94,6 @@ Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Chemicals;
 Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Iron and Steel;1
 Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Non-Ferrous Metals;1
 Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Non-Metallic Minerals;1
-Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Non-Metallic Minerals|Cement;1
 Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Other Sector;1
 Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Pulp and Paper;1
 Carbon Capture|Industry;Carbon Capture|Industry|Biomass;1


### PR DESCRIPTION
## Purpose of this PR

As
`Emissions|CO2|Industrial Processes|Non-Metallic Minerals` and `Emissions|CO2|Industrial Processes|Non-Metallic Minerals|Cement` both get filled with `Emi|CO2|Industrial Processes|+|Cement`, it leads to double-counting if summed together.

https://github.com/pik-piam/piamInterfaces/blob/c081bb46def95bcfc54496c2b8c80d31de137824/inst/mappings/mapping_NAVIGATE.csv#L204-L205

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
