### PR TITLE
avoid NA+NA+NA output in checkSummations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40003020'
+ValidationKey: '40028955'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.20.10
-date-released: '2024-06-28'
+version: 0.20.11
+date-released: '2024-07-01'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.20.10
-Date: 2024-06-28
+Version: 0.20.11
+Date: 2024-07-01
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummations.R
+++ b/R/checkSummations.R
@@ -222,13 +222,13 @@ checkSummations <- function(mifFile, outputDirectory = ".", template = NULL, sum
         childs <- checkVariables[[p]]
 
         remindchilds <- if (is.null(mapping)) NULL else
-                        mappingData[, remindVar][mappingData$variable == pn]
+                        mappingData[, remindVar][mappingData$variable %in% pn]
         text <- c(text, paste0("\n", str_pad(paste(p, signofdiff), width + 5, "right"), "   ",
                   paste0(paste0(remindchilds, collapse = " + "), " ", signofdiff)[! is.null(remindchilds)]
                   ))
         for (ch in childs) {
           remindch <- if (is.null(mapping)) NULL else
-                      mappingData[, remindVar][mappingData$variable == ch]
+                      mappingData[, remindVar][mappingData$variable %in% ch]
           text <- c(text, paste0("   + ", str_pad(ch, width, "right"),
                     if (! is.null(remindch)) paste0("      + ", paste0(remindch, collapse = " + "))))
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.20.10**
+R package **piamInterfaces**, version **0.20.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.10, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.11, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.20.10},
+  note = {R package version 0.20.11},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_NAVIGATE.csv
+++ b/inst/mappings/mapping_NAVIGATE.csv
@@ -1013,7 +1013,6 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 952;1;energy (final);Final Energy|Transportation|Bus|Hybrid|Liquids;EJ/yr;;;;;;final energy consumption of liquid fuels in the transportation sector by Hybrid Bus;
 953;1;energy (final);Final Energy|Transportation|Bus|Hybrid|Gases;EJ/yr;;;;;;final energy consumption of gases in the transportation sector by Hybrid Bus;
 954;1;energy (final);Final Energy|Transportation|Passenger;EJ/yr;FE|Transport|Pass|Pass|w/o Bunkers;EJ/yr;;;;final energy consumed for passenger transportation;T
-955;1;energy (final);Final Energy|Transportation|Freight;EJ/yr;;;;;;final energy consumed for freight transportation;
 954;1;energy (final);Final Energy|Transportation|Passenger;EJ/yr;FE|Transport|Pass|Road|Bus;EJ/yr;;;;final energy consumed for passenger transportation;T
 954;1;energy (final);Final Energy|Transportation|Passenger;EJ/yr;FE|Transport|Pass|Road|LDV;EJ/yr;;;;final energy consumed for passenger transportation;T
 954;1;energy (final);Final Energy|Transportation|Passenger;EJ/yr;FE|Transport|Pass|Rail;EJ/yr;;;;final energy consumed for passenger transportation;T


### PR DESCRIPTION
## Purpose of this PR

- as `n$variable == "whatever"` creates `NA` if one of the cells is empty.
- remove duplicated line (one mapped, one not) in NAVIGATE template

```
Final Energy|Industry|Solids <                                                FE|w/o Non-energy Use|Industry|Solids + NA + NA + NA <

   + Final Energy|Industry|Solids|Biomass                                        + FE|Industry|Solids|Biomass + NA + NA + NA
   + Final Energy|Industry|Solids|Fossil                                         + FE|Industry|Solids|Fossil + NA + NA + NA
```