### PR TITLE
unit changes for import pricing

### DIFF
--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -34,6 +34,8 @@ areUnitsIdentical <- function(vec1, vec2) {
     c("W/m2", "W/m^2"),
     c("USD05", "USD2005", "US$05", "US$2005", "USD2005", "USD_2005"),
     c("USD10", "USD2010", "US$10", "US$2010", "USD2010", "USD_2010"),
+    c("USD_2010/t CO2", "US_2010/t CO2",  "US$2010/t CO2"),
+    c("billion USD_2010/yr", "billion USD_2010/yr", "billion US$2010/yr"),
     # below, exceptionally added units that actually differ for backwards compatibility
     # for 'Energy Service|Residential and Commercial|Floor Space'
     c("bn m2/yr", "billion m2/yr", "bn m2", "billion m2"),

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -35,6 +35,7 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                           c("1000", "k", "M"),
                           # conversion factors taken from ECEMF Model Comparison Protocol, DOI:10.5281/zenodo.6811317
                           c("1.12", "US$2010", "US$2005"),
+                          c("1.12", "USD_2010", "US$2005"),
                           c("1.12", "US$2010", "US$05"),
                           c("1.12", "US$2010/t CO2", "US$2005/tCO2"),
                           c("0.00112", "billion US$2010/yr", "million US$05 PPP/yr"),

--- a/inst/mappings/mapping_ELEVATE.csv
+++ b/inst/mappings/mapping_ELEVATE.csv
@@ -1,6 +1,6 @@
 idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-;Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2005/t CO2;1.12;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
-;Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2005/yr;1.12;;;;government revenue from import taxes;R
+;Price|Imported Carbon;USD_2010/t CO2;Price|Carbon|Imported;US$2005/t CO2;1.12;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
+;Revenue|government|Import Tax;billion USD_2010/yr;Net Taxes|Primary energy import;billion US$2005/yr;1.12;;;;government revenue from import taxes;R
 ;Resource|Extraction|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R
 ;Resource|Extraction|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;R
 ;Resource|Extraction|Oil;EJ/yr;Res|Extraction|Oil;EJ/yr;1;;;;Extracted oil;R


### PR DESCRIPTION
## Purpose of this PR

- unit spelling changes for the current ELEVATE WP2.3 template:
Price|Carbon|Imported: from `US$2010/t` to `USD_2010/t`
Revenue|government|Import Tax: from `billion US$2010` to `billion USD_2010/yr`

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
