### PR TITLE
let test fail on missing units; add missing units; lintr

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40084869'
+ValidationKey: '40108810'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.20.13
-date-released: '2024-07-09'
+version: 0.20.14
+date-released: '2024-07-11'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.20.13
-Date: 2024-07-09
+Version: 0.20.14
+Date: 2024-07-11
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -47,7 +47,7 @@ areUnitsIdentical <- function(vec1, vec2) {
   NULL)
   areIdentical <- function(x, y) {
     # literally identical or both found in the same list element above
-    x == y || any(unlist(lapply(identicalUnits, function(units) all(c(x, y) %in% units))))
+    isTRUE(x == y) || any(unlist(lapply(identicalUnits, function(units) all(c(x, y) %in% units))))
   }
   return(unname(unlist(Map(Vectorize(areIdentical), vec1, vec2))))
 }

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -56,7 +56,11 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                          )
   template$piam_factor[is.na(template$piam_factor)] <- 1
   success <- areUnitsIdentical(template$piam_unit, template$unit) & template$piam_factor %in% c(1, -1)
-  success <- success | is.na(template$piam_variable) | template$piam_variable %in% c("TODO", "Emi|CO2|Energy|+|Waste", "Emi|CO2|Gross|Energy|+|Waste")
+
+  # https://github.com/remindmodel/development_issues/issues/261
+  temporarilyIgnore <- c("Emi|CO2|Energy|+|Waste", "Emi|CO2|Gross|Energy|+|Waste")
+
+  success <- success | is.na(template$piam_variable) | template$piam_variable %in% c("TODO", temporarilyIgnore)
 
   firsterror <- TRUE
   for (sc in scaleConversion) {

--- a/R/variableInfo.R
+++ b/R/variableInfo.R
@@ -37,12 +37,9 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL, remindVar = "piam_
     mappingName <- basename(m)
     remindno <- which(removePlus(varname) == removePlus(mappingData[, remindVar]))
     exportno <- head(which(removePlus(varname) == removePlus(mappingData$variable)), n = 1)
-    if (length(remindno) + length(exportno) == 0) {
-      message("\n### Nothing found in mapping: ", blue, mappingName, nc)
-      next
-    } else {
-      message("\n### Results from mapping: ", blue, mappingName, nc)
-    }
+    nothingfound <- isTRUE(length(remindno) + length(exportno) == 0)
+    message("\n### ", ifelse(nothingfound, "Nothing found in", "Results from"), " mapping: ", blue, mappingName, nc)
+    if (nothingfound) next
     if (m %in% names(summationsNames())) {
       summationGroups <- getSummations(m)
       # print table column names
@@ -89,7 +86,7 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL, remindVar = "piam_
         for (ch in allremindchilds) {
           exportchild <- unique(mappingData$variable[mappingData[, remindVar] %in% ch])
           exportchild <- exportchild[! is.na(exportchild)]
-          message("   . ", str_pad(paste(exportchild, collapse = ", "), width, "right"), "     . ", ch)
+          message("  . ", str_pad(paste(exportchild, collapse = ", "), width + 1, "right"), "     . ", ch)
         }
       }
       message("Units: ", str_pad(paste0(unique(mappingData$unit[no]), collapse = ", "), width, "right"),
@@ -100,9 +97,7 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL, remindVar = "piam_
     mifdata <- quitte::as.quitte(mif)
     message("\n### Variables found in mif file")
     mifchilds <- .getChilds(varname, sort(unique(mifdata$variable)), keepparent = TRUE)
-    for (ch in mifchilds) {
-      message("- ", ch)
-    }
+    message(paste0("- ", mifchilds, collapse = "\n"))
   }
 
   csvdata <- system.file("renamed_piam_variables.csv", package = "piamInterfaces") %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.20.13**
+R package **piamInterfaces**, version **0.20.14**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.13, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.14, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.20.13},
+  note = {R package version 0.20.14},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AR6.csv
+++ b/inst/mappings/mapping_AR6.csv
@@ -1,5 +1,5 @@
 idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-# temporary fix until waste emissions are separated;;;;;;;;;;
+# temporary fix until waste emissions are separated;;;;;;;;;; # https://github.com/remindmodel/development_issues/issues/261
 ;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
 ;Emissions|CO2|Energy|Supply|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
 ;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx

--- a/inst/mappings/mapping_NAVIGATE.csv
+++ b/inst/mappings/mapping_NAVIGATE.csv
@@ -1,5 +1,5 @@
 idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;Comment;Definition;source
-# temporary fix until waste emissions are separated;;;;;;;;;;;
+# temporary fix until waste emissions are separated;;;;;;;;;;; # https://github.com/remindmodel/development_issues/issues/261
 ;;;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
 ;;;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
 ;;;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;Rx
@@ -882,7 +882,7 @@ idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_com
 818;1;energy (final);Final Energy|Residential and Commercial|Solids|Fossil;EJ/yr;FE|Buildings|Solids|+|Fossil;EJ/yr;;;;final energy consumption of fossil solids by the residential & commercial sector;R
 819;2;energy (final);Final Energy|Residential and Commercial|Gases|Biomass;EJ/yr;FE|Buildings|Gases|+|Biomass;EJ/yr;;;;final energy consumption by the residential & commercial sector of biogas, excluding transmission/distribution losses;R
 820;2;energy (final);Final Energy|Residential and Commercial|Gases|Electricity;EJ/yr;FE|Buildings|Gases|+|Hydrogen;EJ/yr;;;;final energy consumption by the residential & commercial sector of synthetic e-fuel gas (power-to-gas), excluding transmission/distribution losses;R
-821;2;energy (final);Final Energy|Residential and Commercial|Gases|Fossil;EJ/yr;FE|Buildings|Gases|+|Fossil;;;;;final energy consumption by the residential & commercial sector of  synthetic or derived gases of fossil origin, excluding transmission/distribution losses;R
+821;2;energy (final);Final Energy|Residential and Commercial|Gases|Fossil;EJ/yr;FE|Buildings|Gases|+|Fossil;EJ/yr;;;;final energy consumption by the residential & commercial sector of  synthetic or derived gases of fossil origin, excluding transmission/distribution losses;R
 822;2;energy (final);Final Energy|Residential and Commercial|Liquids|Biomass;EJ/yr;FE|Buildings|Liquids|+|Biomass;EJ/yr;;;;final energy consumption by the residential & commercial sector of liquid biofuels;R
 823;2;energy (final);Final Energy|Residential and Commercial|Liquids|Electricity;EJ/yr;FE|Buildings|Liquids|+|Hydrogen;EJ/yr;;;;final energy consumption by the residential & commercial sector of liquid efuels (power-to-liquid);R
 824;2;energy (final);Final Energy|Residential and Commercial|Liquids|Fossil;EJ/yr;FE|Buildings|Liquids|+|Fossil;EJ/yr;;;;final energy consumption by the residential & commercial sector of liquids from fossil origin (conventional & unconventional petroleum, coal-to-liquids, gas-to-liquids);R


### PR DESCRIPTION
## Purpose of this PR

- `areUnitsIdentical("EJ/yr", NA)` now returns `FALSE`
- add missing unit
- avoid complaints about cyclomatic complexity

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
