### PR TITLE
add check whether everything in summation group is also defined in mapping

### DIFF
--- a/inst/summations/summation_groups_AR6.csv
+++ b/inst/summations/summation_groups_AR6.csv
@@ -667,7 +667,6 @@ Secondary Energy|Liquids;Secondary Energy|Liquids|Oil;1
 Secondary Energy|Liquids;Secondary Energy|Liquids|Other;1
 Secondary Energy|Solids;Secondary Energy|Solids|Biomass;1
 Secondary Energy|Solids;Secondary Energy|Solids|Coal;1
-Secondary Energy|Solids;Secondary Energy|Solids|Tranditional Biomass;1
 Final Energy|Industry|Other|Gases;Final Energy|Industry|Other|Gases|Bioenergy;1
 Final Energy|Industry|Other|Gases;Final Energy|Industry|Other|Gases|Fossil;1
 Final Energy|Industry|Other|Gases;Final Energy|Industry|Other|Gases|Hydrogen synfuel;1

--- a/inst/summations/summation_groups_NAVIGATE.csv
+++ b/inst/summations/summation_groups_NAVIGATE.csv
@@ -293,10 +293,8 @@ Emissions|CO2|Energy;Emissions|CO2|Energy|Supply;1
 Emissions|CO2|Energy;Emissions|CO2|Energy|Demand;1
 
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|AFOFI;1
-Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Commercial;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Industry;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Other Sector;1
-Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Residential;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Residential and Commercial;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Transportation;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Bunkers;1
@@ -319,6 +317,9 @@ Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Steel;
 Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Other Sector;1
 Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Pulp and Paper;1
 Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Non-Ferrous Metals;1
+
+Emissions|CO2|Energy|Demand|Residential and Commercial;Emissions|CO2|Energy|Demand|Commercial;1
+Emissions|CO2|Energy|Demand|Residential and Commercial;Emissions|CO2|Energy|Demand|Residential;1
 
 Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Gases;1
 Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Liquids;1

--- a/tests/testthat/test-getSummations.R
+++ b/tests/testthat/test-getSummations.R
@@ -9,5 +9,14 @@ test_that("basic checks on summation Groups", {
     expect_equal(nrow(duplicates), 0)
     expect_true(all(c("parent", "child", "factor") %in% names(summationsData)))
     expect_true(class(summationsData) == "data.frame")
+    mappingData <- try(getMapping(template))
+    if (! inherits(mappingData, "try-error") && ! template %in% "ECEMF") {
+      notinMapping <- setdiff(c(gsub(" [1-9]$", "", summationsData$parent), summationsData$child), mappingData$variable)
+      if (length(notinMapping) > 0) {
+        warning("These elements of summation_groups_", template, " are not defined in mapping_", template, ": ",
+                paste(notinMapping, collapse = ", "))
+      }
+      expect_equal(length(notinMapping), 0)
+    }
   }
 })


### PR DESCRIPTION
## Purpose of this PR

- add check whether everything in summation group is also defined in mapping
- currently not satisfied for ECEMF, so skipping it
- adjust AR6

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
