### PR TITLE
let areUnitsIdentical() return TRUE if only spelling of US$ or EUR differs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40324152'
+ValidationKey: '40378500'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.20.24
-date-released: '2024-07-19'
+version: 0.20.25
+date-released: '2024-08-05'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.20.24
-Date: 2024-07-19
+Version: 0.20.25
+Date: 2024-08-05
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -28,14 +28,14 @@ areUnitsIdentical <- function(vec1, vec2) {
     c("Mt CO2-equiv/yr", "Mt CO2eq/yr", "Mt CO2e/yr", "Mt CO2/yr"),
     c("Mt Nr/yr", "Tg N/yr"),
     c("Mt NO2/yr", "Mt NOX/yr"),
+    c("Nr/Nr", "Nr per Nr"),
     c("Percentage", "Percent", "percent", "%"),
     c("unitless", "", "-", "1", "index"),
     c("tDM/cap/yr", "tDM/capita/yr"),
     c("W/m2", "W/m^2"),
     c("USD05", "USD2005", "US$05", "US$2005", "USD2005", "USD_2005"),
     c("USD10", "USD2010", "US$10", "US$2010", "USD2010", "USD_2010"),
-    c("USD_2010/t CO2", "US_2010/t CO2", "US$2010/t CO2"),
-    c("billion USD_2010/yr", "billion US_2010/yr", "billion US$2010/yr"),
+    c("USD05/tCO2", "US$2005/tCO2"),
     # below, exceptionally added units that actually differ for backwards compatibility
     # for 'Energy Service|Residential and Commercial|Floor Space'
     c("bn m2/yr", "billion m2/yr", "bn m2", "billion m2"),
@@ -43,13 +43,15 @@ areUnitsIdentical <- function(vec1, vec2) {
     c("t DM/ha", "t DM/ha/yr", "dm t/ha"),
     # for 'Water|Environmental flow violation volume'
     c("km3/yr", "km3"),
-    # AgMIP
-    c("USD05/tCO2", "US$2005/tCO2"),
-    c("Nr/Nr", "Nr per Nr"),
   NULL)
   areIdentical <- function(x, y) {
-    # literally identical or both found in the same list element above
-    isTRUE(x == y) || any(unlist(lapply(identicalUnits, function(units) all(c(x, y) %in% units))))
+    # literally identical
+    isTRUE(x == y) ||
+    # both found in the same list element above
+    any(unlist(lapply(identicalUnits, function(units) all(c(x, y) %in% units)))) ||
+    # variations of US$ and EUR spellings, otherwise identical
+    isTRUE(sub("US\\$|USD_|USD|US_", "US", x) == sub("US\\$|USD_|USD|US_", "US", y)) ||
+    isTRUE(sub("EUR_", "EUR", x) == sub("EUR_", "EUR", y))
   }
   return(unname(unlist(Map(Vectorize(areIdentical), vec1, vec2))))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.20.24**
+R package **piamInterfaces**, version **0.20.25**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.24, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.25, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.20.24},
+  note = {R package version 0.20.25},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/tests/testthat/test-areUnitsIdentical.R
+++ b/tests/testthat/test-areUnitsIdentical.R
@@ -1,10 +1,21 @@
 test_that("areUnitsIdentical works", {
+  # error if not exactly two vectors given
   expect_error(areUnitsIdentical("%"))
+  expect_error(areUnitsIdentical("%", "percent", "FE/yr"))
+  # does the function work as intended on examples?
   expect_true(areUnitsIdentical("%", "percent"))
   expect_true(all(areUnitsIdentical("%", c("percent", "Percent"))))
   expect_true(all(areUnitsIdentical(c("%", "percent"), "Percent")))
   expect_true(areUnitsIdentical("whatever", "whatever"))
+  expect_true(all(areUnitsIdentical("US$2023", c("USD_2023", "USD2023", "US_2023", "US2023"))))
+  expect_true(all(areUnitsIdentical("US$2023/t CO", c("USD_2023/t CO", "USD2023/t CO", "US_2023/t CO", "US2023/t CO"))))
+  expect_true(all(areUnitsIdentical("billion USD_2010/yr", c("billion US_2010/yr", "billion US$2010/yr"))))
+  expect_true(areUnitsIdentical("EUR2023", "EUR_2023"))
+  expect_true(areUnitsIdentical("EUR2023/t CO2", "EUR_2023/t CO2"))
+  expect_false(areUnitsIdentical("USD__2020", "USD_2020"))
+  expect_false(areUnitsIdentical("billion EUR__2030", "billion EUR2030"))
+  expect_false(areUnitsIdentical("US$2020", "US$1999"))
+  expect_false(areUnitsIdentical("US$2023/t CO2", "US$2023/Mt CO2"))
   expect_false(areUnitsIdentical("%", "FE/yr"))
   expect_false(any(areUnitsIdentical(c("%", "percent"), "FE/yr")))
-  expect_error(areUnitsIdentical("%", "percent", "FE/yr"))
 })


### PR DESCRIPTION
## Purpose of this PR

- Do not care if `billion US2017` or `billion US$2017` etc.
- Substitute the existing variations by the simplest form and compare then.
- Allows to remove some special cases
- Preparation for https://github.com/IAMconsortium/legacy-definitions/issues/12