### PR TITLE
 automate download of iiasatemplate from iiasa server

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40398440'
+ValidationKey: '4187820'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.20.26
-date-released: '2024-08-05'
+version: 0.21.0
+date-released: '2024-08-07'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.20.26
-Date: 2024-08-05
+Version: 0.21.0
+Date: 2024-08-07
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/loadIIASATemplate.R
+++ b/R/loadIIASATemplate.R
@@ -18,6 +18,11 @@
 #' }
 #' @export
 loadIIASATemplate <- function(iiasatemplate) {
+  if (grepl("^https:\\/\\/files\\.ece\\.iiasa\\.ac\\.at\\/.*\\.xlsx$", iiasatemplate)) {
+    tmpfile <- file.path(tempdir(), basename(iiasatemplate))
+    utils::download.file(iiasatemplate, tmpfile, mode = "wb")
+    iiasatemplate <- tmpfile
+  }
   if (! file.exists(iiasatemplate)) {
     stop("# iiasatemplate ", iiasatemplate, " does not exist, unable to load it.")
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.20.26**
+R package **piamInterfaces**, version **0.21.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.20.26, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.21.0, <URL: https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.20.26},
+  note = {R package version 0.21.0},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -29,6 +29,13 @@ for (mapping in c(setdiff(names(mappingNames()), c("AR6", "NAVIGATE", "AR6_NGFS"
   })
 }
 
+test_that("Community template works", {
+  templateurl <- "https://files.ece.iiasa.ac.at/common-definitions/common-definitions-template.xlsx"
+  expect_no_warning(d <- generateIIASASubmission(quitte::quitte_example_data, mapping = "NAVIGATE",
+                                                 outputDirectory = NULL, iiasatemplate = templateurl))
+  expect_true(nrow(d) > 0)
+})
+
 test_that("Correct Prices are selected and plusses ignored", {
   qe <- qeAR6
   vars <- c("Price|Secondary Energy|++|Electricity|Rawdata",


### PR DESCRIPTION
## Purpose of this PR

- fixes #284 
- if you specify `iiasatemplate` as an URL pointing to IIASA, download it to temp file and use that
- works for example for elevate: https://files.ece.iiasa.ac.at/elevate/elevate-template.xlsx
- or the new community template: https://github.com/IAMconsortium/common-definitions/issues/24
