### PR TITLE
 automatically drop aggregated regions 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4387240'
+ValidationKey: '4407403'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.22.0
-date-released: '2024-08-07'
+version: 0.22.1
+date-released: '2024-08-08'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.22.0
-Date: 2024-08-07
+Version: 0.22.1
+Date: 2024-08-08
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -231,6 +231,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
     }
     dropRegi <- unique(setdiff(dropRegi, "auto"))
   }
+  if (length(dropRegi) > 0) message("# Dropping those regions: ", paste(dropRegi, collapse = ", "))
   return(droplevels(filter(mifdata, ! .data$region %in% dropRegi)))
 }
 

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -35,6 +35,8 @@
 #'        If NULL, the user is asked. Multiple mappings are concatenated.
 #' @param removeFromScen regular expression to be removed from scenario name (optional). Example: '_d50|d95'
 #' @param addToScen string to be added as prefix to scenario name (optional)
+#' @param dropRegi regions to be dropped from output. Default is "auto" which drops aggregate regions
+#'        for REMIND EU21. Set to NULL for none. Set c("auto", "World") for dropping EU21 aggregate plus World
 #' @param outputDirectory path to directory for the generated submission (default: output).
 #'        If NULL, no files are written and `logFile` and `outputFilename` have no effect.
 #' @param logFile path to the logfile with warnings as passed to generateMappingfile, checkIIASASubmission
@@ -68,6 +70,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
                                     model = NULL,
                                     removeFromScen = NULL,
                                     addToScen = NULL,
+                                    dropRegi = "auto",
                                     outputDirectory = "output",
                                     outputFilename = "submission.xlsx",
                                     logFile = if (is.null(outputFilename)) NULL else
@@ -136,7 +139,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
    warning("Your data contains no Price|*|Rawdata variables. If it is based on a remind2 version",
            " before 1.111.0 on 2023-05-26, please use piamInterfaces version 0.9.0 or earlier, see PR #128.")
   }
-
+  mifdata <- .dropRegi(mifdata, dropRegi)
   mifdata <- renameOldVariables(mifdata, mapData$piam_variable, logFile = logFile)
   mifdata <- checkFixUnits(mifdata, mapData, logFile = logFile, failOnUnitMismatch = FALSE)
   mifdata <- .setModelAndScenario(mifdata, model, removeFromScen, addToScen)
@@ -218,6 +221,17 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
     }
     message("\n\n# Output file written: ", file.path(outputDirectory, outputFilename))
   }
+}
+
+.dropRegi <- function(mifdata, dropRegi) {
+  if ("auto" %in% dropRegi) {
+    regiEU21 <- c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "NEN", "NES")
+    if (all(regiEU21 %in% levels(mifdata$region))) {
+      dropRegi <- c(dropRegi, "EUR", "NEU", "EU27")
+    }
+    dropRegi <- unique(setdiff(dropRegi, "auto"))
+  }
+  return(droplevels(filter(mifdata, ! .data$region %in% dropRegi)))
 }
 
 .setModelAndScenario <- function(dt, modelname, scenRemove = NULL, scenAdd = NULL) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.22.0**
+R package **piamInterfaces**, version **0.22.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.22.0, <URL: https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.22.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.22.0},
+  note = {R package version 0.22.1},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/man/generateIIASASubmission.Rd
+++ b/man/generateIIASASubmission.Rd
@@ -10,6 +10,7 @@ generateIIASASubmission(
   model = NULL,
   removeFromScen = NULL,
   addToScen = NULL,
+  dropRegi = "auto",
   outputDirectory = "output",
   outputFilename = "submission.xlsx",
   logFile = if (is.null(outputFilename)) NULL else paste0(gsub("\\\\.[a-zA-Z]+$",
@@ -34,6 +35,9 @@ If NULL, the user is asked. Multiple mappings are concatenated.}
 \item{removeFromScen}{regular expression to be removed from scenario name (optional). Example: '_d50|d95'}
 
 \item{addToScen}{string to be added as prefix to scenario name (optional)}
+
+\item{dropRegi}{regions to be dropped from output. Default is "auto" which drops aggregate regions
+for REMIND EU21. Set to NULL for none. Set c("auto", "World") for dropping EU21 aggregate plus World}
 
 \item{outputDirectory}{path to directory for the generated submission (default: output).
 If NULL, no files are written and \code{logFile} and \code{outputFilename} have no effect.}

--- a/tests/testthat/test-dropRegi.R
+++ b/tests/testthat/test-dropRegi.R
@@ -1,0 +1,18 @@
+test_that(".dropRegi works", {
+  regiEU21 <- c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "NEN", "NES")
+  mifdata <- quitte::as.quitte(data.frame(
+    "model" = "REMIND",
+    "scenario" = "Base",
+    "variable" = "FE",
+    "value" = seq(15),
+    "period" = 2005,
+    "region" = c("USA", "EUR", "NEU", "GLO", regiEU21),
+    "unit" = "EJ/yr"
+  ))
+  expect_identical(mifdata, .dropRegi(mifdata, NULL))
+  expect_identical(mifdata, .dropRegi(mifdata, "nonexistent"))
+  mifdataNoENC <- droplevels(filter(mifdata, ! .data$region %in% "ENC"))
+  expect_identical(mifdataNoENC, .dropRegi(mifdataNoENC, "auto"))
+  removedAggregates <- .dropRegi(mifdata, "auto")
+  expect_setequal(levels(removedAggregates$region), setdiff(levels(mifdata$region), c("EUR", "NEU")))
+})

--- a/tests/testthat/test-dropRegi.R
+++ b/tests/testthat/test-dropRegi.R
@@ -13,6 +13,6 @@ test_that(".dropRegi works", {
   expect_identical(mifdata, .dropRegi(mifdata, "nonexistent"))
   mifdataNoENC <- droplevels(filter(mifdata, ! .data$region %in% "ENC"))
   expect_identical(mifdataNoENC, .dropRegi(mifdataNoENC, "auto"))
-  removedAggregates <- .dropRegi(mifdata, "auto")
+  expect_message(removedAggregates <- .dropRegi(mifdata, "auto"), "Dropping those regions")
   expect_setequal(levels(removedAggregates$region), setdiff(levels(mifdata$region), c("EUR", "NEU")))
 })


### PR DESCRIPTION
## Purpose of this PR

- close #262
- in the default "auto" mode, aggregated EU regions are dropped.
- as it is impossible to guess the aggregation details from the data, dropping rules can be added once further regional disaggregations of REMIND are implemented.
- set dropRegi to NULL to disable
