### PR TITLE
renamed producer price index variable in mapping_AgMIP

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4607757'
+ValidationKey: '4627704'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.23.1
+version: 0.23.2
 date-released: '2024-08-12'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.23.1
+Version: 0.23.2
 Date: 2024-08-12
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.23.1**
+R package **piamInterfaces**, version **0.23.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.23.1, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.23.2, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.23.1},
+  note = {R package version 0.23.2},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AgMIP.csv
+++ b/inst/mappings/mapping_AgMIP.csv
@@ -965,30 +965,30 @@ CAPS.LSP;%;Factor requirement shares|Livestock products|Capital requirement shar
 ENH3.AGR;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;1;NULL;;M
 ENH3.TOT;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;1;NULL;;M
 FSEC_abs.TOT;million;Nutrition|Anthropometrics|People underweight;million people;1;NULL;;M
-XPRP.CRP;Index 2020=100;Prices|Producer Price Index|Crop products;Index 2020=100;1;NULL;;M
-XPRP.RIC;Index 2020=100;Prices|Producer Price Index|Rice;Index 2020=100;1;NULL;;M
-XPRP.WHT;Index 2020=100;Prices|Producer Price Index|Temperate cereals;Index 2020=100;1;NULL;;M
-XPRP.CGR;Index 2020=100;Prices|Producer Price Index|Tropical cereals;Index 2020=100;1;Production|Crops|Cereals|+|Tropical cereals;;M
-XPRP.CGR;Index 2020=100;Prices|Producer Price Index|Maize;Index 2020=100;1;Production|Crops|Cereals|+|Maize;;M
-XPRP.OSD;Index 2020=100;Prices|Producer Price Index|Soybean;Index 2020=100;1;Production|Crops|Oil crops|+|Soybean;;M
-XPRP.OSD;Index 2020=100;Prices|Producer Price Index|Groundnuts;Index 2020=100;1;Production|Crops|Oil crops|+|Groundnuts;;M
-XPRP.OSD;Index 2020=100;Prices|Producer Price Index|Other oil crops incl rapeseed;Index 2020=100;1;Production|Crops|Oil crops|+|Other oil crops incl rapeseed;;M
-XPRP.OSD;Index 2020=100;Prices|Producer Price Index|Oilpalms;Index 2020=100;1;Production|Crops|Oil crops|+|Oilpalms;;M
-XPRP.OSD;Index 2020=100;Prices|Producer Price Index|Sunflower;Index 2020=100;1;Production|Crops|Oil crops|+|Sunflower;;M
-XPRP.SGC;Index 2020=100;Prices|Producer Price Index|Sugar cane;Index 2020=100;1;Production|Crops|Sugar crops|+|Sugar cane;;M
-XPRP.SGC;Index 2020=100;Prices|Producer Price Index|Sugar beet;Index 2020=100;1;Production|Crops|Sugar crops|+|Sugar beet;;M
-XPRP.VFN;Index 2020=100;Prices|Producer Price Index|Fruits Vegetables Nuts;Index 2020=100;1;NULL;;M
-XPRP.PFB;Index 2020=100;Prices|Producer Price Index|Cotton seed;Index 2020=100;1;NULL;;M
-XPRP.ECP;Index 2020=100;Prices|Producer Price Index|Short rotation grasses;Index 2020=100;1;Production|Bioenergy crops|+|Short rotation grasses;;M
-XPRP.ECP;Index 2020=100;Prices|Producer Price Index|Short rotation trees;Index 2020=100;1;Production|Bioenergy crops|+|Short rotation trees;;M
-XPRP.OCR;Index 2020=100;Prices|Producer Price Index|Pulses;Index 2020=100;1;Production|Crops|Other crops|+|Pulses;;M
-XPRP.OCR;Index 2020=100;Prices|Producer Price Index|Potatoes;Index 2020=100;1;Production|Crops|Other crops|+|Potatoes;;M
-XPRP.OCR;Index 2020=100;Prices|Producer Price Index|Tropical roots;Index 2020=100;1;Production|Crops|Other crops|+|Tropical roots;;M
-XPRP.RUM;Index 2020=100;Prices|Producer Price Index|Ruminant meat;Index 2020=100;1;NULL;;M
-XPRP.NRM;Index 2020=100;Prices|Producer Price Index|Monogastric meat;Index 2020=100;1;Production|Livestock products|+|Monogastric meat;;M
-XPRP.NRM;Index 2020=100;Prices|Producer Price Index|Poultry meat;Index 2020=100;1;Production|Livestock products|+|Poultry meat;;M
-XPRP.NRM;Index 2020=100;Prices|Producer Price Index|Eggs;Index 2020=100;1;Production|Livestock products|+|Eggs;;M
-XPRP.DRY;Index 2020=100;Prices|Producer Price Index|Dairy;Index 2020=100;1;Production|Livestock products|+|Dairy;;M
-XPRP.LSP;Index 2020=100;Prices|Producer Price Index|Livestock products;Index 2020=100;1;NULL;;M
-XPRP.FSH;Index 2020=100;Prices|Producer Price Index|Fish;Index 2020=100;1;NULL;;M
-XPRP.AGR;Index 2020=100;Prices|Producer Price Index|All products;Index 2020=100;1;NULL;;M
+XPRP.CRP;Index 2020=100;Prices|Index2020|Agriculture|Producer|Crop products;Index 2020=100;1;NULL;;M
+XPRP.RIC;Index 2020=100;Prices|Index2020|Agriculture|Producer|Rice;Index 2020=100;1;NULL;;M
+XPRP.WHT;Index 2020=100;Prices|Index2020|Agriculture|Producer|Temperate cereals;Index 2020=100;1;NULL;;M
+XPRP.CGR;Index 2020=100;Prices|Index2020|Agriculture|Producer|Tropical cereals;Index 2020=100;1;Production|Crops|Cereals|+|Tropical cereals;;M
+XPRP.CGR;Index 2020=100;Prices|Index2020|Agriculture|Producer|Maize;Index 2020=100;1;Production|Crops|Cereals|+|Maize;;M
+XPRP.OSD;Index 2020=100;Prices|Index2020|Agriculture|Producer|Soybean;Index 2020=100;1;Production|Crops|Oil crops|+|Soybean;;M
+XPRP.OSD;Index 2020=100;Prices|Index2020|Agriculture|Producer|Groundnuts;Index 2020=100;1;Production|Crops|Oil crops|+|Groundnuts;;M
+XPRP.OSD;Index 2020=100;Prices|Index2020|Agriculture|Producer|Other oil crops incl rapeseed;Index 2020=100;1;Production|Crops|Oil crops|+|Other oil crops incl rapeseed;;M
+XPRP.OSD;Index 2020=100;Prices|Index2020|Agriculture|Producer|Oilpalms;Index 2020=100;1;Production|Crops|Oil crops|+|Oilpalms;;M
+XPRP.OSD;Index 2020=100;Prices|Index2020|Agriculture|Producer|Sunflower;Index 2020=100;1;Production|Crops|Oil crops|+|Sunflower;;M
+XPRP.SGC;Index 2020=100;Prices|Index2020|Agriculture|Producer|Sugar cane;Index 2020=100;1;Production|Crops|Sugar crops|+|Sugar cane;;M
+XPRP.SGC;Index 2020=100;Prices|Index2020|Agriculture|Producer|Sugar beet;Index 2020=100;1;Production|Crops|Sugar crops|+|Sugar beet;;M
+XPRP.VFN;Index 2020=100;Prices|Index2020|Agriculture|Producer|Fruits Vegetables Nuts;Index 2020=100;1;NULL;;M
+XPRP.PFB;Index 2020=100;Prices|Index2020|Agriculture|Producer|Cotton seed;Index 2020=100;1;NULL;;M
+XPRP.ECP;Index 2020=100;Prices|Index2020|Agriculture|Producer|Short rotation grasses;Index 2020=100;1;Production|Bioenergy crops|+|Short rotation grasses;;M
+XPRP.ECP;Index 2020=100;Prices|Index2020|Agriculture|Producer|Short rotation trees;Index 2020=100;1;Production|Bioenergy crops|+|Short rotation trees;;M
+XPRP.OCR;Index 2020=100;Prices|Index2020|Agriculture|Producer|Pulses;Index 2020=100;1;Production|Crops|Other crops|+|Pulses;;M
+XPRP.OCR;Index 2020=100;Prices|Index2020|Agriculture|Producer|Potatoes;Index 2020=100;1;Production|Crops|Other crops|+|Potatoes;;M
+XPRP.OCR;Index 2020=100;Prices|Index2020|Agriculture|Producer|Tropical roots;Index 2020=100;1;Production|Crops|Other crops|+|Tropical roots;;M
+XPRP.RUM;Index 2020=100;Prices|Index2020|Agriculture|Producer|Ruminant meat;Index 2020=100;1;NULL;;M
+XPRP.NRM;Index 2020=100;Prices|Index2020|Agriculture|Producer|Monogastric meat;Index 2020=100;1;Production|Livestock products|+|Monogastric meat;;M
+XPRP.NRM;Index 2020=100;Prices|Index2020|Agriculture|Producer|Poultry meat;Index 2020=100;1;Production|Livestock products|+|Poultry meat;;M
+XPRP.NRM;Index 2020=100;Prices|Index2020|Agriculture|Producer|Eggs;Index 2020=100;1;Production|Livestock products|+|Eggs;;M
+XPRP.DRY;Index 2020=100;Prices|Index2020|Agriculture|Producer|Dairy;Index 2020=100;1;Production|Livestock products|+|Dairy;;M
+XPRP.LSP;Index 2020=100;Prices|Index2020|Agriculture|Producer|Livestock products;Index 2020=100;1;NULL;;M
+XPRP.FSH;Index 2020=100;Prices|Index2020|Agriculture|Producer|Fish;Index 2020=100;1;NULL;;M
+XPRP.AGR;Index 2020=100;Prices|Index2020|Agriculture|Producer|All products;Index 2020=100;1;NULL;;M

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -192,3 +192,30 @@ Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|BEV;Stock|Trans
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|FCEV;Stock|Transport|LDV|Subcompact Car|FCEV
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Hybrid electric;Stock|Transport|LDV|Subcompact Car|Hybrid Electric
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Liquids;Stock|Transport|LDV|Subcompact Car|Liquids
+Prices|Index2020|Agriculture|Producer|Crop products;Prices|Producer Price Index|Crop products
+Prices|Index2020|Agriculture|Producer|Rice;Prices|Producer Price Index|Rice
+Prices|Index2020|Agriculture|Producer|Temperate cereals;Prices|Producer Price Index|Temperate cereals
+Prices|Index2020|Agriculture|Producer|Tropical cereals;Prices|Producer Price Index|Tropical cereals
+Prices|Index2020|Agriculture|Producer|Maize;Prices|Producer Price Index|Maize
+Prices|Index2020|Agriculture|Producer|Soybean;Prices|Producer Price Index|Soybean
+Prices|Index2020|Agriculture|Producer|Groundnuts;Prices|Producer Price Index|Groundnuts
+Prices|Index2020|Agriculture|Producer|Other oil crops incl rapeseed;Prices|Producer Price Index|Other oil crops incl rapeseed
+Prices|Index2020|Agriculture|Producer|Oilpalms;Prices|Producer Price Index|Oilpalms
+Prices|Index2020|Agriculture|Producer|Sunflower;Prices|Producer Price Index|Sunflower
+Prices|Index2020|Agriculture|Producer|Sugar cane;Prices|Producer Price Index|Sugar cane
+Prices|Index2020|Agriculture|Producer|Sugar beet;Prices|Producer Price Index|Sugar beet
+Prices|Index2020|Agriculture|Producer|Fruits Vegetables Nuts;Prices|Producer Price Index|Fruits Vegetables Nuts
+Prices|Index2020|Agriculture|Producer|Cotton seed;Prices|Producer Price Index|Cotton seed
+Prices|Index2020|Agriculture|Producer|Short rotation grasses;Prices|Producer Price Index|Short rotation grasses
+Prices|Index2020|Agriculture|Producer|Short rotation trees;Prices|Producer Price Index|Short rotation trees
+Prices|Index2020|Agriculture|Producer|Pulses;Prices|Producer Price Index|Pulses
+Prices|Index2020|Agriculture|Producer|Potatoes;Prices|Producer Price Index|Potatoes
+Prices|Index2020|Agriculture|Producer|Tropical roots;Prices|Producer Price Index|Tropical roots
+Prices|Index2020|Agriculture|Producer|Ruminant meat;Prices|Producer Price Index|Ruminant meat
+Prices|Index2020|Agriculture|Producer|Monogastric meat;Prices|Producer Price Index|Monogastric meat
+Prices|Index2020|Agriculture|Producer|Poultry meat;Prices|Producer Price Index|Poultry meat
+Prices|Index2020|Agriculture|Producer|Eggs;Prices|Producer Price Index|Eggs
+Prices|Index2020|Agriculture|Producer|Dairy;Prices|Producer Price Index|Dairy
+Prices|Index2020|Agriculture|Producer|Livestock products;Prices|Producer Price Index|Livestock products
+Prices|Index2020|Agriculture|Producer|Fish;Prices|Producer Price Index|Fish
+Prices|Index2020|Agriculture|Producer|All products;Prices|Producer Price Index|Producer|All products


### PR DESCRIPTION
## Purpose of this PR
- the variable name produced by reportProducerPriceIndex(gdx) has changed and needed to be updated in the AgMIP mapping file

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
