### PR TITLE
allow Whatever|* in renamed_piam_variables.csv

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4627704'
+ValidationKey: '4787520'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.23.2
-date-released: '2024-08-12'
+version: 0.24.0
+date-released: '2024-08-13'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.23.2
-Date: 2024-08-12
+Version: 0.24.0
+Date: 2024-08-13
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkSummationsRegional.R
+++ b/R/checkSummationsRegional.R
@@ -43,16 +43,16 @@ checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions =
   unit <- c("", "%", "% of Total GDP", "% pa", "%/yr", "$/GJ", "1", "arbitrary unit", "arbitrary unit/yr",
             "billionDpktU", "billionDpTWyr", "cm/capita", "DM per live animal", "GE per GE",
             "GJ/cap/yr", "GJ/t", "hectares per capita", "index", "Index",
-            "kcal/cap/day", "kcal/capita/day", "kcal/kcal", "m3/ha", "MJ/t",
-            "Mt CO2-equiv/EJ", "Mt CO2-equiv/Mt", "Mt CO2/EJ", "Mt Nr/Mt Nr", "Nr per Nr", "percent",
+            "kcal/cap/day", "kcal/capita/day", "kcal/kcal", "m3/ha", "MJ/t", "MJ/vehkm",
+            "Mt CO2-equiv/EJ", "Mt CO2-equiv/Mt", "Mt CO2/Mt", "Mt CO2/EJ", "Mt Nr/Mt Nr", "Nr per Nr", "percent",
             "Percent", "protein/capita/day", "ratio", "share", "share of total land", "t DM/ha", "t DM/ha/yr",
             "tC/ha", "tC/tC", "tDM/capita/yr", "tDM/cap/yr", "unitless", "years")
   curr <- c("USD", paste0("USDMER", years), paste0("USD", years), paste0("US$", years), paste0("USD_", years),
             paste0("EUR_", years), paste0("EUR", years))
   usecurr <- c("EJ/billion __", "MJ/__", "Mt CO2-equiv/__", "t/million __", "tr __/input unit", "tr__/Input",
                "__ PPP/cap/yr", "k__/per capita", "__/capita", "__/EJ", "__/GJ", "__/h", "__/ha", "__/tDM",
-               "__/worker", "__/GJ", "__/kW", "__/kW/yr", "__/t CH4", "__/t CO2", "__/t N2O",
-               "__/tCH4", "__/tCO2", "__/tCO2 yr", "__/tN2O", "__/__", "__/yr", "__/cap/yr")
+               "__/worker", "__/GJ", "__/kW", "__/kW/yr", "__/t CH4", "__/t CO2", "_/t CO2/yr", "__/t N2O",
+               "__/tCH4", "__/tCO2", "__/tCO2 yr", "__/t CO2/yr", "__/tN2O", "__/__", "__/yr", "__/cap/yr")
   unit <- unique(c(index, unit, unlist(lapply(curr, function(x) gsub("__", x, usecurr)))))
 
   # if intensiveUnits or skipUnits contain 'TRUE', add this list of intensive units to them
@@ -89,10 +89,10 @@ checkSummationsRegional <- function(mifFile, parentRegion = NULL, childRegions =
   sumCheck <- left_join(sumChilds, filter(total, ! .data$unit %in% intensiveUnits),
                         by = c("model", "scenario", "variable", "period", "unit")) %>%
     mutate(
-      absdiff = .data$checkSum - .data$total,
+      diff = .data$checkSum - .data$total,
       reldiff = 100 * (.data$checkSum - .data$total) / .data$total
     ) %>%
-    filter(abs(.data$reldiff) >= relDiff, abs(.data$absdiff) >= absDiff) %>%
+    filter(abs(.data$reldiff) >= relDiff, abs(.data$diff) >= absDiff) %>%
     droplevels()
 
   sumCheckVars <- levels(sumCheck$variable)

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -1,5 +1,13 @@
 #' Check unit factor in template
 #'
+#' This function checks whether the piam_factor in a mapping fits unit and piam_unit.
+#' It does the following:
+#' 1. check whether the units are identical based on areUnitsIdentical() and piam_factor is 1 or -1.
+#' 2. based on scaleConversion defined below, check whether manually added factors are satisfied
+#'    This works based on regex matching, so for example 1000 TW = 1 PW is matched by the c("1000", "T", "P") line.
+#' If the tests fail because of a new unit, you can add them below. If the units are really identical except for
+#' spelling, better add them to areUnitsIdentical.R
+#'
 #' @md
 #' @author Oliver Richters
 #' @param template object provided by loadIIASAtemplate()
@@ -16,8 +24,10 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
   errortext <- NULL
   colnames(template) <- tolower(names(template))
 
+  # if units are really identical, better add them to areUnitsIdentical.R
   # check whether scales are correctly transformed. c(piam_factor, unit, piam_unit)
-  # the first line checks that mapping "billion whatever" to "million whatever" uses a factor 1000 etc.
+  # For example, line 7 check that mapping "billion whatever" to "million whatever" uses a factor 1000 etc.
+  # This uses regex matching, so "1000 million US$" = "1 billion US$" is covered by that as well.
   scaleConversion <- list(
                           c("1", "million", "Million vehicles"),
                           c("1", "Index (2020 = 1)", "1"),

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -269,7 +269,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
 
 # resolve the weight column if present else return
 .resolveWeights <- function(dataframe, weightSource) {
-  if (all(dataframe$piam_weight == "NULL") || all(is.na(dataframe$piam_weight))) {
+  if (all(dataframe$piam_weight %in% c("NULL", NA))) {
     message("No weights to resolve. Skipping.")
     return(dataframe)
   } else {

--- a/R/renameOldVariables.R
+++ b/R/renameOldVariables.R
@@ -44,18 +44,18 @@ getExpandRenamedVariables <- function(variables) {
 
   csvdataNew <- NULL
   for (i in seq_len(nrow(csvdata))) {
-    # prepare strings for grepping by adding escape characters and "."
+    # if both end with *, replace by options taken from 'variables'
     if (all(grepl("\\*$", c(csvdata$piam_variable[i], csvdata$old_name[i])))) {
-      matchOld <- sub(".$", "", csvdata$old_name[i])
+      matchOld <- sub("\\*$", "", csvdata$old_name[i])
       postfix <- gsub(matchOld, "", grep(matchOld, variables, fixed = TRUE, value = TRUE), fixed = TRUE)
+      csvdataNew <- rbind(
+        csvdataNew,
+        data.frame(piam_variable = paste0(gsub("\\*$", "", csvdata$piam_variable[i]), postfix),
+                   old_name = paste0(gsub("\\*$", "", csvdata$old_name[i]), postfix))
+      )
     } else {
-      postfix <- ""
+      csvdataNew <- rbind(csvdataNew, csvdata[i, ])
     }
-    csvdataNew <- rbind(
-      csvdataNew,
-      data.frame(piam_variable = paste0(gsub("\\*$", "", csvdata$piam_variable[i]), postfix),
-                 old_name = paste0(gsub("\\*$", "", csvdata$old_name[i]), postfix))
-    )
   }
   return(filter(csvdataNew, .data$old_name %in% variables))
 }

--- a/R/renameOldVariables.R
+++ b/R/renameOldVariables.R
@@ -6,14 +6,14 @@
 #' @param variables the list of requested variables
 #' @param logFile filename of file for logging
 #' @importFrom dplyr filter
-#' @importFrom piamutils deletePnus
-#' @importFrom rlang .datan
+#' @importFrom piamutils deletePlus
+#' @importFrom rlang .data
 #' @importFrom tibble as_tibble
 #' @return quitte object with adapted mif data
 #' @export
 
 renameOldVariables <- function(mifdata, variables, logFile = NULL) {
-  mifdata <- as.quitte(mifdata)
+  mifdata <- deletePlus(as.quitte(mifdata))
 
   toadd <- unique(setdiff(variables, levels(mifdata$variable)))
   csvdata <- getExpandRenamedVariables(levels(mifdata$variable)) %>%
@@ -22,7 +22,7 @@ renameOldVariables <- function(mifdata, variables, logFile = NULL) {
   names(old2new) <- csvdata$old_name
   for (v in names(old2new)) {
     mifdata <- mifdata %>%
-      mutate(variable = factor(ifelse(deletePlus(.data$variable) %in% v, old2new[[v]], deletePlus(as.character(.data$variable)))))
+      mutate(variable = factor(ifelse(.data$variable %in% v, old2new[[v]], as.character(.data$variable))))
   }
 
   if (length(old2new) > 0 && ! isFALSE(logFile)) {
@@ -43,7 +43,7 @@ getExpandRenamedVariables <- function(variables) {
   variables <- deletePlus(variables)
 
   csvdataNew <- NULL
-  for (i in seq(nrow(csvdata))) {
+  for (i in seq_len(nrow(csvdata))) {
     # prepare strings for grepping by adding escape characters and "."
     if (all(grepl("\\*$", c(csvdata$piam_variable[i], csvdata$old_name[i])))) {
       matchOld <- sub(".$", "", csvdata$old_name[i])

--- a/R/renameOldVariables.R
+++ b/R/renameOldVariables.R
@@ -41,9 +41,8 @@ getExpandRenamedVariables <- function(variables) {
     mutate(piam_variable = deletePlus(.data$piam_variable),
            old_name = deletePlus(.data$old_name))
   variables <- deletePlus(variables)
-  varExpand <- filter(csvdata, grepl("\\*$", csvdata$piam_variable))
-  csvdataNew <- NULL
 
+  csvdataNew <- NULL
   for (i in seq(nrow(csvdata))) {
     # prepare strings for grepping by adding escape characters and "."
     if (all(grepl("\\*$", c(csvdata$piam_variable[i], csvdata$old_name[i])))) {

--- a/R/renameOldVariables.R
+++ b/R/renameOldVariables.R
@@ -22,7 +22,7 @@ renameOldVariables <- function(mifdata, variables, logFile = NULL) {
   names(old2new) <- csvdata$old_name
   for (v in names(old2new)) {
     mifdata <- mifdata %>%
-      mutate(variable = factor(ifelse(.data$variable == v, old2new[[v]], as.character(.data$variable))))
+      mutate(variable = factor(ifelse(deletePlus(.data$variable) %in% v, old2new[[v]], deletePlus(as.character(.data$variable)))))
   }
 
   if (length(old2new) > 0 && ! isFALSE(logFile)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.23.2**
+R package **piamInterfaces**, version **0.24.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.23.2, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.24.0, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.23.2},
+  note = {R package version 0.24.0},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AR6_NGFS.csv
+++ b/inst/mappings/mapping_AR6_NGFS.csv
@@ -1,5 +1,4 @@
 variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-Test;K;Temperature|Global Mean;K;2;;;;;
 Emissions|Kyoto Gases|AFOLU;Mt CO2-equiv/yr;Emi|GHG|AFOLU;Mt CO2eq/yr;1;;;;;R
 Emissions|Kyoto Gases|Industry;Mt CO2-equiv/yr;Emi|GHG|Industry;Mt CO2eq/yr;1;;;;;R
 Emissions|Kyoto Gases|Transportation;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Transport;Mt CO2eq/yr;1;;;;;R

--- a/inst/mappings/mapping_AR6_NGFS.csv
+++ b/inst/mappings/mapping_AR6_NGFS.csv
@@ -1,27 +1,28 @@
-idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-;Emissions|Kyoto Gases|AFOLU;Mt CO2-equiv/yr;Emi|GHG|AFOLU;Mt CO2eq/yr;1;;;;;R
-;Emissions|Kyoto Gases|Industry;Mt CO2-equiv/yr;Emi|GHG|Industry;Mt CO2eq/yr;1;;;;;R
-;Emissions|Kyoto Gases|Transportation;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Transport;Mt CO2eq/yr;1;;;;;R
-;Emissions|Kyoto Gases|Residential and Commercial;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Buildings;Mt CO2eq/yr;1;;;;;R
-;Emissions|Kyoto Gases|Supply;Mt CO2-equiv/yr;Emi|GHG|Energy|+|Supply;Mt CO2eq/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Liquids|Biomass;EJ/yr;FE|Buildings|Liquids|+|Biomass;EJ/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Liquids|Hydrogen;EJ/yr;FE|Buildings|Liquids|+|Hydrogen;EJ/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Liquids|Oil;EJ/yr;FE|Buildings|Liquids|+|Fossil;EJ/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Gases|Biomass;EJ/yr;FE|Buildings|Gases|+|Biomass;EJ/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Gases|Hydrogen;EJ/yr;FE|Buildings|Gases|+|Hydrogen;EJ/yr;1;;;;;R
-;Final Energy|Residential and Commercial|Gases|Natural Gas;EJ/yr;FE|Buildings|Gases|+|Fossil;EJ/yr;1;;;;;R
-;Revenue|Government|Tax|Carbon;billion US$2010/yr;Revenue|Government|Tax|Carbon;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing (weighted aggregation of carbon price by region/sector multiplied by GHG emissions);R
-;Revenue|Government|Tax|Carbon|Demand|Residential and Commercial;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Buildings;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on buildings sector emissions (carbon price by region multiplied by GHG emissions);R
-;Revenue|Government|Tax|Carbon|Demand|Industry;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Industry;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on industry sector emissions (carbon price by region multiplied by GHG emissions);R
-;Revenue|Government|Tax|Carbon|Demand|Transportation;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Transport;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on transport sector emissions (carbon price by region multiplied by GHG emissions);R
-;Revenue|Government|Tax|Carbon|Supply;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Supply;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on the supply sector emissions (carbon price by region multiplied by GHG emissions);R
-;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
-;GDP|PPP|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
-;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;Rx
-;GDP|MER|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
-;GDP|MER|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
-;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;Rx
-;Emissions|NH3;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;;;add that temporarily until Emi|NH3 is fixed;;;M
-;Emissions|NH3|AFOLU;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;;;add that temporarily until Emi|NH3 is fixed;;;M
-;Emissions|CO2|Energy|Supply|Extraction;Mt CO2/yr;Emi|CO2|Energy|Supply|Extraction;Mt CO2/yr;1;;;;energy-related CO2 emissions from extraction processes;R
-;Final Energy|Transportation|Liquids|Hydrogen;EJ/yr;FE|Transport|Liquids|Hydrogen;EJ/yr;1;;;;Final energy, in the form of synfuel generated from Hydrogen;R
+variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+Test;K;Temperature|Global Mean;K;2;;;;;
+Emissions|Kyoto Gases|AFOLU;Mt CO2-equiv/yr;Emi|GHG|AFOLU;Mt CO2eq/yr;1;;;;;R
+Emissions|Kyoto Gases|Industry;Mt CO2-equiv/yr;Emi|GHG|Industry;Mt CO2eq/yr;1;;;;;R
+Emissions|Kyoto Gases|Transportation;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Transport;Mt CO2eq/yr;1;;;;;R
+Emissions|Kyoto Gases|Residential and Commercial;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Buildings;Mt CO2eq/yr;1;;;;;R
+Emissions|Kyoto Gases|Supply;Mt CO2-equiv/yr;Emi|GHG|Energy|+|Supply;Mt CO2eq/yr;1;;;;;R
+Final Energy|Residential and Commercial|Liquids|Biomass;EJ/yr;FE|Buildings|Liquids|+|Biomass;EJ/yr;1;;;;;R
+Final Energy|Residential and Commercial|Liquids|Hydrogen;EJ/yr;FE|Buildings|Liquids|+|Hydrogen;EJ/yr;1;;;;;R
+Final Energy|Residential and Commercial|Liquids|Oil;EJ/yr;FE|Buildings|Liquids|+|Fossil;EJ/yr;1;;;;;R
+Final Energy|Residential and Commercial|Gases|Biomass;EJ/yr;FE|Buildings|Gases|+|Biomass;EJ/yr;1;;;;;R
+Final Energy|Residential and Commercial|Gases|Hydrogen;EJ/yr;FE|Buildings|Gases|+|Hydrogen;EJ/yr;1;;;;;R
+Final Energy|Residential and Commercial|Gases|Natural Gas;EJ/yr;FE|Buildings|Gases|+|Fossil;EJ/yr;1;;;;;R
+Revenue|Government|Tax|Carbon;billion US$2010/yr;Revenue|Government|Tax|Carbon;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing (weighted aggregation of carbon price by region/sector multiplied by GHG emissions);R
+Revenue|Government|Tax|Carbon|Demand|Residential and Commercial;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Buildings;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on buildings sector emissions (carbon price by region multiplied by GHG emissions);R
+Revenue|Government|Tax|Carbon|Demand|Industry;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Industry;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on industry sector emissions (carbon price by region multiplied by GHG emissions);R
+Revenue|Government|Tax|Carbon|Demand|Transportation;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Demand|Transport;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on transport sector emissions (carbon price by region multiplied by GHG emissions);R
+Revenue|Government|Tax|Carbon|Supply;billion US$2010/yr;Revenue|Government|Tax|Carbon|+|Supply;billion US$2005/yr;1.12;;;;Total government revenue from carbon pricing on the supply sector emissions (carbon price by region multiplied by GHG emissions);R
+GDP|PPP|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
+GDP|PPP|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|PPP|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
+GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|PPP|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;Rx
+GDP|MER|including medium chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including medium chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
+GDP|MER|including high chronic physical risk damage estimate;billion US$2010/yr;GDP|MER|including high chronic physical risk damage estimate;billion US$2005/yr;1.12;;;;;Rx
+GDP|MER|w/ Macro-Economic Climate Damage;billion US$2010/yr;GDP|MER|w/ Macro-Economic Climate Damage;billion US$2005/yr;1.12;;;;;Rx
+Emissions|NH3;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;;;add that temporarily until Emi|NH3 is fixed;;;M
+Emissions|NH3|AFOLU;Mt NH3/yr;Emissions|NH3|Land;Mt NH3/yr;;;add that temporarily until Emi|NH3 is fixed;;;M
+Emissions|CO2|Energy|Supply|Extraction;Mt CO2/yr;Emi|CO2|Energy|Supply|Extraction;Mt CO2/yr;1;;;;energy-related CO2 emissions from extraction processes;R
+Final Energy|Transportation|Liquids|Hydrogen;EJ/yr;FE|Transport|Liquids|Hydrogen;EJ/yr;1;;;;Final energy, in the form of synfuel generated from Hydrogen;R

--- a/inst/mappings/mapping_ECEMF.csv
+++ b/inst/mappings/mapping_ECEMF.csv
@@ -655,10 +655,10 @@ Secondary Energy|Gases|Gas;EJ/yr;;;;;;;
 Secondary Energy|Heat;EJ/yr;SE|Heat;EJ/yr;1;;;;R
 Secondary Energy|Heat|Biomass;EJ/yr;SE|Heat|+|Biomass;EJ/yr;1;;;;R
 Secondary Energy|Heat|Coal;EJ/yr;;;;;;;
-Secondary Energy|Heat|Gas;EJ/yr;;EJ/yr;1;;;;
+Secondary Energy|Heat|Gas;EJ/yr;;EJ/yr;;;;;
 Secondary Energy|Heat|Fossil;EJ/yr;SE|Heat|+|Coal;EJ/yr;1;;;;R
 Secondary Energy|Heat|Fossil;EJ/yr;SE|Heat|+|Gas;EJ/yr;1;;;;R
-Secondary Energy|Heat|Fossil;EJ/yr;;EJ/yr;1;;;;
+Secondary Energy|Heat|Fossil;EJ/yr;;EJ/yr;;;;;
 Secondary Energy|Heat|Geothermal;EJ/yr;SE|Heat|+|Geothermal;EJ/yr;1;;;;R
 Secondary Energy|Heat|Nuclear;EJ/yr;;;;;;;
 Secondary Energy|Heat|Oil;EJ/yr;;;;;;;

--- a/inst/mappings/mapping_ESABCC.csv
+++ b/inst/mappings/mapping_ESABCC.csv
@@ -648,10 +648,10 @@ Secondary Energy|Gases|Gas;EJ/yr;;;;;;;
 Secondary Energy|Heat;EJ/yr;SE|Heat;EJ/yr;1;;;;R
 Secondary Energy|Heat|Biomass;EJ/yr;SE|Heat|+|Biomass;EJ/yr;1;;;;R
 Secondary Energy|Heat|Coal;EJ/yr;;;;;;;
-Secondary Energy|Heat|Gas;EJ/yr;;EJ/yr;1;;;;
+Secondary Energy|Heat|Gas;EJ/yr;;EJ/yr;;;;;
 Secondary Energy|Heat|Fossil;EJ/yr;SE|Heat|+|Coal;EJ/yr;1;;;;R
 Secondary Energy|Heat|Fossil;EJ/yr;SE|Heat|+|Gas;EJ/yr;1;;;;R
-Secondary Energy|Heat|Fossil;EJ/yr;;EJ/yr;1;;;;
+Secondary Energy|Heat|Fossil;EJ/yr;;EJ/yr;;;;;
 Secondary Energy|Heat|Geothermal;EJ/yr;SE|Heat|+|Geothermal;EJ/yr;1;;;;R
 Secondary Energy|Heat|Nuclear;EJ/yr;;;;;;;
 Secondary Energy|Heat|Oil;EJ/yr;;;;;;;

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -16,7 +16,7 @@ Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Re
 
 # magpie4 reporting variables for cropland changed with magpie4 2.3.2
 Resources|Land Cover|Cropland|Croparea|*;Resources|Land Cover|Cropland|*
-
+# https://github.com/pik-piam/magpie4/commit/2847a13e5c171b9dc78dccdc7d6a085e8c8d74d3
 Prices|Index2020|Agriculture|Producer*;Prices|Producer Price Index*
 
 #Changes from edgeT refactoring
@@ -97,30 +97,3 @@ Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|BEV;Stock|Trans
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|FCEV;Stock|Transport|LDV|Subcompact Car|FCEV
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Hybrid electric;Stock|Transport|LDV|Subcompact Car|Hybrid Electric
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Liquids;Stock|Transport|LDV|Subcompact Car|Liquids
-Prices|Index2020|Agriculture|Producer|Crop products;Prices|Producer Price Index|Crop products
-Prices|Index2020|Agriculture|Producer|Rice;Prices|Producer Price Index|Rice
-Prices|Index2020|Agriculture|Producer|Temperate cereals;Prices|Producer Price Index|Temperate cereals
-Prices|Index2020|Agriculture|Producer|Tropical cereals;Prices|Producer Price Index|Tropical cereals
-Prices|Index2020|Agriculture|Producer|Maize;Prices|Producer Price Index|Maize
-Prices|Index2020|Agriculture|Producer|Soybean;Prices|Producer Price Index|Soybean
-Prices|Index2020|Agriculture|Producer|Groundnuts;Prices|Producer Price Index|Groundnuts
-Prices|Index2020|Agriculture|Producer|Other oil crops incl rapeseed;Prices|Producer Price Index|Other oil crops incl rapeseed
-Prices|Index2020|Agriculture|Producer|Oilpalms;Prices|Producer Price Index|Oilpalms
-Prices|Index2020|Agriculture|Producer|Sunflower;Prices|Producer Price Index|Sunflower
-Prices|Index2020|Agriculture|Producer|Sugar cane;Prices|Producer Price Index|Sugar cane
-Prices|Index2020|Agriculture|Producer|Sugar beet;Prices|Producer Price Index|Sugar beet
-Prices|Index2020|Agriculture|Producer|Fruits Vegetables Nuts;Prices|Producer Price Index|Fruits Vegetables Nuts
-Prices|Index2020|Agriculture|Producer|Cotton seed;Prices|Producer Price Index|Cotton seed
-Prices|Index2020|Agriculture|Producer|Short rotation grasses;Prices|Producer Price Index|Short rotation grasses
-Prices|Index2020|Agriculture|Producer|Short rotation trees;Prices|Producer Price Index|Short rotation trees
-Prices|Index2020|Agriculture|Producer|Pulses;Prices|Producer Price Index|Pulses
-Prices|Index2020|Agriculture|Producer|Potatoes;Prices|Producer Price Index|Potatoes
-Prices|Index2020|Agriculture|Producer|Tropical roots;Prices|Producer Price Index|Tropical roots
-Prices|Index2020|Agriculture|Producer|Ruminant meat;Prices|Producer Price Index|Ruminant meat
-Prices|Index2020|Agriculture|Producer|Monogastric meat;Prices|Producer Price Index|Monogastric meat
-Prices|Index2020|Agriculture|Producer|Poultry meat;Prices|Producer Price Index|Poultry meat
-Prices|Index2020|Agriculture|Producer|Eggs;Prices|Producer Price Index|Eggs
-Prices|Index2020|Agriculture|Producer|Dairy;Prices|Producer Price Index|Dairy
-Prices|Index2020|Agriculture|Producer|Livestock products;Prices|Producer Price Index|Livestock products
-Prices|Index2020|Agriculture|Producer|Fish;Prices|Producer Price Index|Fish
-Prices|Index2020|Agriculture|Producer|All products;Prices|Producer Price Index|Producer|All products

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -3,29 +3,7 @@ piam_variable                                 ;old_name
 FE|Transport|Pass|w/o Bunkers                 ;FE|Transport|Pass|w/o bunkers
 
 # renamed in https://github.com/pik-piam/remind2/pull/579
-Energy Investments|Electricity|Biomass        ;Energy Investments|Elec|Biomass
-Energy Investments|Electricity|Biomass|w/ CC  ;Energy Investments|Elec|Biomass|w/ CC
-Energy Investments|Electricity|Biomass|w/o CC ;Energy Investments|Elec|Biomass|w/o CC
-Energy Investments|Electricity|Coal           ;Energy Investments|Elec|Coal
-Energy Investments|Electricity|Coal|w/ CC     ;Energy Investments|Elec|Coal|w/ CC
-Energy Investments|Electricity|Coal|w/o CC    ;Energy Investments|Elec|Coal|w/o CC
-Energy Investments|Electricity|Fossil         ;Energy Investments|Elec|Fossil
-Energy Investments|Electricity|Gas            ;Energy Investments|Elec|Gas
-Energy Investments|Electricity|Gas|w/ CC      ;Energy Investments|Elec|Gas|w/ CC
-Energy Investments|Electricity|Gas|w/o CC     ;Energy Investments|Elec|Gas|w/o CC
-Energy Investments|Electricity|Geothermal     ;Energy Investments|Elec|Geothermal
-Energy Investments|Electricity|Grid           ;Energy Investments|Elec|Grid
-Energy Investments|Electricity|Hydro          ;Energy Investments|Elec|Hydro
-Energy Investments|Electricity|Hydrogen       ;Energy Investments|Elec|Hydrogen
-Energy Investments|Electricity|Non-Bio Re     ;Energy Investments|Elec|Non-Bio Re
-Energy Investments|Electricity|Non-Fossil     ;Energy Investments|Elec|Non-Fossil
-Energy Investments|Electricity|Nuclear        ;Energy Investments|Elec|Nuclear
-Energy Investments|Electricity|Oil            ;Energy Investments|Elec|Oil
-Energy Investments|Electricity|Oil|w/ CC      ;Energy Investments|Elec|Oil|w/ CC
-Energy Investments|Electricity|Oil|w/o CC     ;Energy Investments|Elec|Oil|w/o CC
-Energy Investments|Electricity|Solar          ;Energy Investments|Elec|Solar
-Energy Investments|Electricity|Storage        ;Energy Investments|Elec|Storage
-Energy Investments|Electricity|Wind           ;Energy Investments|Elec|Wind
+Energy Investments|Electricity|*;Energy Investments|Elec|*
 
 # map MAGICC6 variables to new MAGICC7 names
 MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile     ;Temperature|Global Mean
@@ -37,82 +15,9 @@ MAGICC7 AR6|Atmospheric Concentrations|N2O|50.0th Percentile ;Concentration|N2O
 Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Resources|Nitrogen|Cropland Budget|Inputs|Manure
 
 # magpie4 reporting variables for cropland changed with magpie4 2.3.2
-Resources|Land Cover|Cropland|Croparea|+|Bioenergy crops;Resources|Land Cover|Cropland|+|Bioenergy crops
-Resources|Land Cover|Cropland|Croparea|+|Crops;Resources|Land Cover|Cropland|+|Crops
-Resources|Land Cover|Cropland|Croparea|+|Fallow Cropland;Resources|Land Cover|Cropland|+|Fallow Cropland
-Resources|Land Cover|Cropland|Croparea|+|Forage;Resources|Land Cover|Cropland|+|Forage
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|+|Short rotation grasses;Resources|Land Cover|Cropland|Bioenergy crops|+|Short rotation grasses
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|+|Short rotation trees;Resources|Land Cover|Cropland|Bioenergy crops|+|Short rotation trees
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|irrigated;Resources|Land Cover|Cropland|Bioenergy crops|irrigated
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|rainfed;Resources|Land Cover|Cropland|Bioenergy crops|rainfed
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|Short rotation grasses|irrigated;Resources|Land Cover|Cropland|Bioenergy crops|Short rotation grasses|irrigated
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|Short rotation grasses|rainfed;Resources|Land Cover|Cropland|Bioenergy crops|Short rotation grasses|rainfed
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|Short rotation trees|irrigated;Resources|Land Cover|Cropland|Bioenergy crops|Short rotation trees|irrigated
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops|Short rotation trees|rainfed;Resources|Land Cover|Cropland|Bioenergy crops|Short rotation trees|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|+|Cereals;Resources|Land Cover|Cropland|Crops|+|Cereals
-Resources|Land Cover|Cropland|Croparea|Crops|+|Oil crops;Resources|Land Cover|Cropland|Crops|+|Oil crops
-Resources|Land Cover|Cropland|Croparea|Crops|+|Other crops;Resources|Land Cover|Cropland|Crops|+|Other crops
-Resources|Land Cover|Cropland|Croparea|Crops|+|Sugar crops;Resources|Land Cover|Cropland|Crops|+|Sugar crops
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|+|Maize;Resources|Land Cover|Cropland|Crops|Cereals|+|Maize
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|+|Rice;Resources|Land Cover|Cropland|Crops|Cereals|+|Rice
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|+|Temperate cereals;Resources|Land Cover|Cropland|Crops|Cereals|+|Temperate cereals
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|+|Tropical cereals;Resources|Land Cover|Cropland|Crops|Cereals|+|Tropical cereals
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|irrigated;Resources|Land Cover|Cropland|Crops|Cereals|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Maize|irrigated;Resources|Land Cover|Cropland|Crops|Cereals|Maize|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Maize|rainfed;Resources|Land Cover|Cropland|Crops|Cereals|Maize|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|rainfed;Resources|Land Cover|Cropland|Crops|Cereals|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Rice|irrigated;Resources|Land Cover|Cropland|Crops|Cereals|Rice|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Rice|rainfed;Resources|Land Cover|Cropland|Crops|Cereals|Rice|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Temperate cereals|irrigated;Resources|Land Cover|Cropland|Crops|Cereals|Temperate cereals|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Temperate cereals|rainfed;Resources|Land Cover|Cropland|Crops|Cereals|Temperate cereals|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Tropical cereals|irrigated;Resources|Land Cover|Cropland|Crops|Cereals|Tropical cereals|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Cereals|Tropical cereals|rainfed;Resources|Land Cover|Cropland|Crops|Cereals|Tropical cereals|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|irrigated;Resources|Land Cover|Cropland|Crops|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Cotton seed;Resources|Land Cover|Cropland|Crops|Oil crops|+|Cotton seed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Groundnuts;Resources|Land Cover|Cropland|Crops|Oil crops|+|Groundnuts
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Oilpalms;Resources|Land Cover|Cropland|Crops|Oil crops|+|Oilpalms
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Other oil crops incl rapeseed;Resources|Land Cover|Cropland|Crops|Oil crops|+|Other oil crops incl rapeseed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Soybean;Resources|Land Cover|Cropland|Crops|Oil crops|+|Soybean
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|+|Sunflower;Resources|Land Cover|Cropland|Crops|Oil crops|+|Sunflower
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Cotton seed|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Cotton seed|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Cotton seed|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Cotton seed|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Groundnuts|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Groundnuts|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Groundnuts|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Groundnuts|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Oilpalms|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Oilpalms|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Oilpalms|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Oilpalms|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Other oil crops incl rapeseed|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Other oil crops incl rapeseed|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Other oil crops incl rapeseed|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Other oil crops incl rapeseed|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Soybean|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Soybean|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Soybean|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Soybean|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Sunflower|irrigated;Resources|Land Cover|Cropland|Crops|Oil crops|Sunflower|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Oil crops|Sunflower|rainfed;Resources|Land Cover|Cropland|Crops|Oil crops|Sunflower|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|+|Fruits Vegetables Nuts;Resources|Land Cover|Cropland|Crops|Other crops|+|Fruits Vegetables Nuts
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|+|Potatoes;Resources|Land Cover|Cropland|Crops|Other crops|+|Potatoes
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|+|Pulses;Resources|Land Cover|Cropland|Crops|Other crops|+|Pulses
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|+|Tropical roots;Resources|Land Cover|Cropland|Crops|Other crops|+|Tropical roots
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Fruits Vegetables Nuts|irrigated;Resources|Land Cover|Cropland|Crops|Other crops|Fruits Vegetables Nuts|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Fruits Vegetables Nuts|rainfed;Resources|Land Cover|Cropland|Crops|Other crops|Fruits Vegetables Nuts|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|irrigated;Resources|Land Cover|Cropland|Crops|Other crops|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Potatoes|irrigated;Resources|Land Cover|Cropland|Crops|Other crops|Potatoes|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Potatoes|rainfed;Resources|Land Cover|Cropland|Crops|Other crops|Potatoes|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Pulses|irrigated;Resources|Land Cover|Cropland|Crops|Other crops|Pulses|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Pulses|rainfed;Resources|Land Cover|Cropland|Crops|Other crops|Pulses|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|rainfed;Resources|Land Cover|Cropland|Crops|Other crops|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Tropical roots|irrigated;Resources|Land Cover|Cropland|Crops|Other crops|Tropical roots|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Other crops|Tropical roots|rainfed;Resources|Land Cover|Cropland|Crops|Other crops|Tropical roots|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|rainfed;Resources|Land Cover|Cropland|Crops|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|+|Sugar beet;Resources|Land Cover|Cropland|Crops|Sugar crops|+|Sugar beet
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|+|Sugar cane;Resources|Land Cover|Cropland|Crops|Sugar crops|+|Sugar cane
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|irrigated;Resources|Land Cover|Cropland|Crops|Sugar crops|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|rainfed;Resources|Land Cover|Cropland|Crops|Sugar crops|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|Sugar beet|irrigated;Resources|Land Cover|Cropland|Crops|Sugar crops|Sugar beet|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|Sugar beet|rainfed;Resources|Land Cover|Cropland|Crops|Sugar crops|Sugar beet|rainfed
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|Sugar cane|irrigated;Resources|Land Cover|Cropland|Crops|Sugar crops|Sugar cane|irrigated
-Resources|Land Cover|Cropland|Croparea|Crops|Sugar crops|Sugar cane|rainfed;Resources|Land Cover|Cropland|Crops|Sugar crops|Sugar cane|rainfed
-Resources|Land Cover|Cropland|Croparea|Forage|irrigated;Resources|Land Cover|Cropland|Forage|irrigated
-Resources|Land Cover|Cropland|Croparea|Forage|rainfed;Resources|Land Cover|Cropland|Forage|rainfed
+Resources|Land Cover|Cropland|Croparea|*;Resources|Land Cover|Cropland|*
+
+Prices|Index2020|Agriculture|Producer*;Prices|Producer Price Index*
 
 #Changes from edgeT refactoring
 Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping;Emi|CO2|Transport|Freight|International Shipping|Demand

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -15,7 +15,10 @@ MAGICC7 AR6|Atmospheric Concentrations|N2O|50.0th Percentile ;Concentration|N2O
 Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Resources|Nitrogen|Cropland Budget|Inputs|Manure
 
 # magpie4 reporting variables for cropland changed with magpie4 2.3.2
-Resources|Land Cover|Cropland|Croparea|*;Resources|Land Cover|Cropland|*
+Resources|Land Cover|Cropland|Croparea|Bioenergy crops*;Resources|Land Cover|Cropland|Bioenergy crops*
+Resources|Land Cover|Cropland|Croparea|Crops*;Resources|Land Cover|Cropland|Crops*
+Resources|Land Cover|Cropland|Croparea|Fallow Cropland*;Resources|Land Cover|Cropland|Fallow Cropland*
+Resources|Land Cover|Cropland|Croparea|Forage*;Resources|Land Cover|Cropland|Forage*
 # https://github.com/pik-piam/magpie4/commit/2847a13e5c171b9dc78dccdc7d6a085e8c8d74d3
 Prices|Index2020|Agriculture|Producer*;Prices|Producer Price Index*
 

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -1,9 +1,11 @@
 piam_variable                                 ;old_name
+# you are allowed to add a wildcard *, but only at the end of both columns simultaneously
+
 # temporary, can be removed after EDGE-T refactoring
-FE|Transport|Pass|w/o Bunkers                 ;FE|Transport|Pass|w/o bunkers
+FE|Transport|Pass|w/o Bunkers          ;FE|Transport|Pass|w/o bunkers
 
 # renamed in https://github.com/pik-piam/remind2/pull/579
-Energy Investments|Electricity|*;Energy Investments|Elec|*
+Energy Investments|Electricity|*       ;Energy Investments|Elec|*
 
 # map MAGICC6 variables to new MAGICC7 names
 MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile     ;Temperature|Global Mean
@@ -15,14 +17,15 @@ MAGICC7 AR6|Atmospheric Concentrations|N2O|50.0th Percentile ;Concentration|N2O
 Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Resources|Nitrogen|Cropland Budget|Inputs|Manure
 
 # magpie4 reporting variables for cropland changed with magpie4 2.3.2
-Resources|Land Cover|Cropland|Croparea|Bioenergy crops*;Resources|Land Cover|Cropland|Bioenergy crops*
-Resources|Land Cover|Cropland|Croparea|Crops*;Resources|Land Cover|Cropland|Crops*
-Resources|Land Cover|Cropland|Croparea|Fallow Cropland*;Resources|Land Cover|Cropland|Fallow Cropland*
-Resources|Land Cover|Cropland|Croparea|Forage*;Resources|Land Cover|Cropland|Forage*
-# https://github.com/pik-piam/magpie4/commit/2847a13e5c171b9dc78dccdc7d6a085e8c8d74d3
-Prices|Index2020|Agriculture|Producer*;Prices|Producer Price Index*
+Resources|Land Cover|Cropland|Croparea|Bioenergy crops* ;Resources|Land Cover|Cropland|Bioenergy crops*
+Resources|Land Cover|Cropland|Croparea|Crops*           ;Resources|Land Cover|Cropland|Crops*
+Resources|Land Cover|Cropland|Croparea|Fallow Cropland* ;Resources|Land Cover|Cropland|Fallow Cropland*
+Resources|Land Cover|Cropland|Croparea|Forage*          ;Resources|Land Cover|Cropland|Forage*
 
-#Changes from edgeT refactoring
+# https://github.com/pik-piam/magpie4/commit/2847a13e5c171b9dc78dccdc7d6a085e8c8d74d3
+Prices|Index2020|Agriculture|Producer*                  ;Prices|Producer Price Index*
+
+# Changes from edgeT refactoring v2.0
 Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping;Emi|CO2|Transport|Freight|International Shipping|Demand
 Emi|CO2|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Emi|CO2|Transport|Pass|Aviation|International|Demand
 Emi|CO2|Energy|Demand|Transport|Freight;Emi|CO2|Transport|Freight|w/o bunkers|Demand

--- a/man/checkUnitFactor.Rd
+++ b/man/checkUnitFactor.Rd
@@ -18,7 +18,15 @@ recommended for submission, not used for checking mapping}
 quitte object with adapted mif data
 }
 \description{
-Check unit factor in template
+This function checks whether the piam_factor in a mapping fits unit and piam_unit.
+It does the following:
+\enumerate{
+\item check whether the units are identical based on areUnitsIdentical() and piam_factor is 1 or -1.
+\item based on scaleConversion defined below, check whether manually added factors are satisfied
+This works based on regex matching, so for example 1000 TW = 1 PW is matched by the c("1000", "T", "P") line.
+If the tests fail because of a new unit, you can add them below. If the units are really identical except for
+spelling, better add them to areUnitsIdentical.R
+}
 }
 \author{
 Oliver Richters

--- a/tests/testthat/test-checkSummationsRegional.R
+++ b/tests/testthat/test-checkSummationsRegional.R
@@ -22,6 +22,8 @@ test_that("checkSummations works", {
     "unit" = c("EJ/yr", "US$2010/EJ")
   ))
   expect_no_warning(d <- checkSummationsRegional(mifdata))
+  expect_true("diff" %in% colnames(d)) # needed for REMIND
+  expect_true("reldiff" %in% colnames(d)) # needed for REMIND
   expect_equal(nrow(d), 2)
   expect_true(all(variables %in% levels(d$variable)))
 

--- a/tests/testthat/test-checkUnitFactor.R
+++ b/tests/testthat/test-checkUnitFactor.R
@@ -16,7 +16,8 @@ test_that("checkUnitFactor works", {
     c("Emissions|N2O", "kt N2O/yr", "Mt N2O/yr", "1000"),
     c("FE", "MJ", "GJ", "1000"),
     c("GDP", "US$2010", "US$2005", "1.12"),
-    c("Trade", "EUR_2020", "US$2005", "1.17")
+    c("Trade", "EUR_2020", "US$2005", "1.17"),
+    c("Price", "Index 2020=100", "1", "1")
   )
   for (w in wrong) {
     mapping <- data.frame(Variable = character(), Unit = character(),

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -15,6 +15,14 @@ for (mapping in names(mappingNames())) {
     }
     expect_true(length(conflictsigns) == 0, label = paste0(mapping, " has no merge conflicts"))
 
+    # look for Moving Avg prices
+    movingavg <- grep("^Price\\|.*\\|Moving Avg$", mappingData$piam_variable, value = TRUE)
+    if (length(movingavg) > 0) {
+      warning("These variables use 'Price|*|Moving Avg' which is deprecated since remind2 1.111.0 on 2023-05-26.\n",
+              "Please remove '|Moving Avg' to get a moving average with some fixes:\n", paste(movingavg, collapse = ", "))
+    }
+    expect_equal(length(movingavg), 0)
+
     # check for duplicated rows
     duplicates <- select(mappingData, "variable", "piam_variable")
     duplicates <- filter(duplicates, duplicated(duplicates))

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -15,11 +15,13 @@ for (mapping in names(mappingNames())) {
     }
     expect_true(length(conflictsigns) == 0, label = paste0(mapping, " has no merge conflicts"))
 
-    # look for Moving Avg prices
-    movingavg <- grep("^Price\\|.*\\|Moving Avg$", mappingData$piam_variable, value = TRUE)
+    # look for Moving Avg prices in REMIND variables
+    movingavg <- mappingData %>%
+      filter(grepl("^Price\\|.*\\|Moving Avg", .data$piam_variable), .data$source %in% c("R", "Rx")) %>%
+      pull("variable")
     if (length(movingavg) > 0) {
       warning("These variables use 'Price|*|Moving Avg' which is deprecated since remind2 1.111.0 on 2023-05-26.\n",
-              "Please remove '|Moving Avg' to get a moving average with some fixes:\n", paste(movingavg, collapse = ", "))
+              "Please remove '|Moving Avg' to use a fixed moving average:\n", paste(movingavg, collapse = ", "))
     }
     expect_equal(length(movingavg), 0)
 

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -56,6 +56,16 @@ for (mapping in names(mappingNames())) {
     }
     expect_true(nrow(unitfails) == 0)
 
+    # check if piam_factor is supplied without variable
+    factorWithoutVar <- mappingData %>%
+      filter(! is.na(.data$piam_factor), is.na(.data$piam_variable)) %>%
+      pull("variable")
+    if (length(factorWithoutVar) > 0) {
+      warning("These variables in mapping ", mapping, " have a piam_factor, but nothing specified in piam_variable:\n",
+              paste(factorWithoutVar, collapse = "\n"))
+    }
+    expect_true(length(factorWithoutVar) == 0)
+
     # checks only if source is supplied
     if ("source" %in% colnames(mappingData)) {
       # check for empty piam_variable with source

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -19,7 +19,8 @@ for (mapping in names(mappingNames())) {
     duplicates <- select(mappingData, "variable", "piam_variable")
     duplicates <- filter(duplicates, duplicated(duplicates))
     if (nrow(duplicates) > 0) {
-      warning("Duplicated line in ", mapping, ":\n", paste0(duplicates$variable, ";", duplicates$piam_variable, collapse = "\n"))
+      warning("Duplicated line in ", mapping, ":\n",
+              paste0(duplicates$variable, ";", duplicates$piam_variable, collapse = "\n"))
     }
     expect_equal(nrow(duplicates), 0)
 

--- a/tests/testthat/test-renameOldVariables.R
+++ b/tests/testthat/test-renameOldVariables.R
@@ -4,7 +4,7 @@ test_that("renameOldVariables() works", {
   expect_message(newvar <- renameOldVariables(oldvar, variables = newtemperature),
                  "Automatically adjusted variables based")
   expect_true(newtemperature %in% levels(newvar$variable))
-  expect_false("Temperature|Globa Mean" %in% levels(newvar$variable))
+  expect_false("Temperature|Global Mean" %in% levels(newvar$variable))
   expect_identical(nrow(oldvar), nrow(newvar))
 
   oldname <- "Resources|Land Cover|Cropland|Bioenergy crops|+|Short rotation grasses"

--- a/tests/testthat/test-renameOldVariables.R
+++ b/tests/testthat/test-renameOldVariables.R
@@ -3,8 +3,8 @@ test_that("renameOldVariables() works", {
   newtemperature <- "MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile"
   expect_message(newvar <- renameOldVariables(oldvar, variables = newtemperature),
                  "Automatically adjusted variables based")
-  expect_true(newtemperature %in% levels(newvar$variable))
-  expect_false("Temperature|Global Mean" %in% levels(newvar$variable))
+  expect_true(newtemperature %in% newvar$variable)
+  expect_false("Temperature|Global Mean" %in% newvar$variable)
   expect_identical(nrow(oldvar), nrow(newvar))
 
   oldname <- "Resources|Land Cover|Cropland|Bioenergy crops|+|Short rotation grasses"
@@ -12,8 +12,8 @@ test_that("renameOldVariables() works", {
   levels(oldvar$variable)[[1]] <- oldname
   expect_message(newvar <- renameOldVariables(oldvar, variables = newname),
                  "Automatically adjusted variables based")
-  expect_true(newname %in% levels(newvar$variable))
-  expect_false(oldname %in% levels(newvar$variable))
+  expect_true(newname %in% newvar$variable)
+  expect_false(deletePlus(oldname) %in% deletePlus(newvar$variable))
   expect_identical(nrow(oldvar), nrow(newvar))
 
   levels(oldvar$variable)[[1]] <- "Energy Investments|Elec|Wind"

--- a/tests/testthat/test-renameOldVariables.R
+++ b/tests/testthat/test-renameOldVariables.R
@@ -1,3 +1,18 @@
+test_that("renamed_piam_variables wildcards match", {
+  csvdata <- system.file("renamed_piam_variables.csv", package = "piamInterfaces") %>%
+    read.csv2(comment.char = "#", strip.white = TRUE) %>%
+    as_tibble()
+  inconsistentAsterisk <- filter(csvdata) %>%
+    filter(grepl("\\*", .data$piam_variable) | grepl("\\*", .data$old_name)) %>%
+    filter(! grepl("^[^\\*]+\\*$", .data$piam_variable) | ! grepl("^[^\\*]+\\*$", .data$old_name))
+  if (nrow(inconsistentAsterisk) > 0) {
+    warning("In inst/renamed_piam_variables.csv, you can have either no * at all or an * at the end of both columns.\n",
+            "These lines do not match this pattern:\n",
+            paste(inconsistentAsterisk$old_name, "->", inconsistentAsterisk$piam_variable, collapse = "\n"))
+  }
+  expect_true(nrow(inconsistentAsterisk) == 0)
+})
+
 test_that("renameOldVariables() works", {
   oldvar <- qeAR6
   newtemperature <- "MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile"

--- a/tests/testthat/test-renameOldVariables.R
+++ b/tests/testthat/test-renameOldVariables.R
@@ -1,5 +1,21 @@
 test_that("renameOldVariables() works", {
   oldvar <- qeAR6
+  newtemperature <- "MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile"
+  expect_message(newvar <- renameOldVariables(oldvar, variables = newtemperature),
+                 "Automatically adjusted variables based")
+  expect_true(newtemperature %in% levels(newvar$variable))
+  expect_false("Temperature|Globa Mean" %in% levels(newvar$variable))
+  expect_identical(nrow(oldvar), nrow(newvar))
+
+  oldname <- "Resources|Land Cover|Cropland|Bioenergy crops|+|Short rotation grasses"
+  newname <- "Resources|Land Cover|Cropland|Croparea|Bioenergy crops|Short rotation grasses"
+  levels(oldvar$variable)[[1]] <- oldname
+  expect_message(newvar <- renameOldVariables(oldvar, variables = newname),
+                 "Automatically adjusted variables based")
+  expect_true(newname %in% levels(newvar$variable))
+  expect_false(oldname %in% levels(newvar$variable))
+  expect_identical(nrow(oldvar), nrow(newvar))
+
   levels(oldvar$variable)[[1]] <- "Energy Investments|Elec|Wind"
   expect_message(newvar <- renameOldVariables(oldvar, variables = "Energy Investments|Electricity|Wind"),
                  "Automatically adjusted variables based")
@@ -8,12 +24,11 @@ test_that("renameOldVariables() works", {
   expect_identical(droplevels(select(quitteSort(oldvar), -"variable")),
                    droplevels(select(quitteSort(newvar), -"variable")))
 })
+
 test_that("no renamed_piam_variable used in mapping", {
   for (n in names(mappingNames())) {
-    oldvars <- system.file("renamed_piam_variables.csv", package = "piamInterfaces") %>%
-      read.csv2(comment.char = "#", strip.white = TRUE) %>%
-      as_tibble() %>%
-      filter(.data$old_name %in% getMapping(n)$piam_variable)
+    mapvars <- getMapping(n)$piam_variable
+    oldvars <- getExpandRenamedVariables(mapvars)
     if (nrow(oldvars) > 0) {
       warning("In mapping_", n, ".csv, those variables are stated as renamed in inst/renamed_piam_variables.csv and",
               " should use the new name.\nIf the old variable name is passed in the data, it will work anyway:\n",


### PR DESCRIPTION
## Purpose of this PR

- renamed_piam_variables.csv became very crowded with a lot of repetition
- it was suggested already a while ago to allow for some sort of wildcard
- based on [piamValidation::expandVariables](https://github.com/orichters/piamValidation/blob/6d17a4a2e1964ecb0b19c032e6cb4df58e844bb4/R/importFunctions.R#L114), I implemented a simple regex matching
- It only allows a single `*` at the end of both column cells
- fix #322
- add some documentation
- remove empty idx column in NGFS mapping
- remove some useless piam_factors where no piam_variable is given