### PR TITLE
 consistent, early use of deletePlus; add docu

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4987500'
+ValidationKey: '5187000'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.25.0
+version: 0.26.0
 date-released: '2024-08-15'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.25.0
+Version: 0.26.0
 Date: 2024-08-15
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkFixUnits.R
+++ b/R/checkFixUnits.R
@@ -9,6 +9,7 @@
 #'        recommended for submission, not used for generating mappings
 #' @param logFile filename of file for logging
 #' @importFrom dplyr filter mutate
+#' @importFrom piamutils deletePlus
 #' @importFrom rlang .data
 #' @importFrom stringr str_split
 #' @return quitte object with adapted mif data
@@ -19,7 +20,9 @@ checkFixUnits <- function(mifdata, template, logFile = NULL, failOnUnitMismatch 
   unitcol <- if (haspiam) "piam_unit" else "unit"
   varcol <- if (haspiam) "piam_variable" else "variable"
 
-  mifdata <- droplevels(as.quitte(mifdata))
+  template[[varcol]] <- deletePlus(template[[varcol]])
+  mifdata <- deletePlus(droplevels(as.quitte(mifdata)))
+
   # try to identify and fix wrong units
   wrongUnits <- data.frame(variable = character(), templateunit = character(), mifunit = character())
   logtext <- NULL

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -55,6 +55,7 @@
 #' @importFrom quitte as.quitte write.IAMCxlsx write.mif
 #' @importFrom dplyr filter mutate distinct inner_join bind_rows tibble
 #' @importFrom gms chooseFromList
+#' @importFrom piamutils deletePlus
 #' @importFrom stringr str_trim
 #' @examples
 #' \dontrun{
@@ -125,13 +126,14 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
   # read in data from mifs ----
 
   # for each directory, include all mif files
-  mifdata <- readMifs(mifs)
+  mifdata <- deletePlus(readMifs(mifs))
 
   dupl <- mifdata %>% select(-"value") %>% filter(duplicated(mifdata)) %>% droplevels()
   if (nrow(dupl) > 0) {
-    stop("Duplicated data found: ",
-         "\n  - Models: ", paste(levels(dupl$model), collapse = ", "),
-         "\n  - Scenarios: ", paste(levels(dupl$scenario), collapse = ", ")
+    warning("Duplicated data found which will lead to wrong calculations for: ",
+         "\n  - Models:    ", paste(levels(dupl$model), collapse = ", "),
+         "\n  - Scenarios: ", paste(levels(dupl$scenario), collapse = ", "),
+         "\n  - Variables: ", paste(levels(dupl$variable), collapse = ", ")
         )
   }
 
@@ -152,7 +154,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
   mifdata <- mifdata %>%
     filter(.data$period %in% timesteps) %>%
     mutate(
-      "piam_variable" = removePlus(str_trim(.data$variable)),
+      "piam_variable" = str_trim(.data$variable),
       "piam_unit" = str_trim(.data$unit)
       ) %>%
     select(-c("variable", "unit")) %>%

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Additionally, some mappings use those columns:
 - `idx`: serial number of `variable`
 - `Tier`: importance of variable. 1 means most important
 - `Comment`: place for comments
-
+- `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 To edit a mapping in `R`, use:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.25.0**
+R package **piamInterfaces**, version **0.26.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.25.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.26.0, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.25.0},
+  note = {R package version 0.26.0},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_ARIADNE.csv
+++ b/inst/mappings/mapping_ARIADNE.csv
@@ -556,7 +556,7 @@ Tier;Category;variable;unit;Definition;piam_variable;piam_unit;piam_factor;Comme
 1;energy (industry);Final Energy|Non-Energy Use|Hydrogen;PJ/yr;Final energy consumption of hydrogen by the non-combustion processes;;;;;0;;
 2;energy (industry);Final Energy|Non-Energy Use|Waste;PJ/yr;Final energy consumption of non-renewable waste by the non-combustion processes;;;;;0;;
 2;energy (industry);Final Energy|Non-Energy Use|Other;PJ/yr;Final energy consumption of other feedstocks by the non-combustion processes (please provide a definition of the feedstocks in this category in the 'comments' tab);;;;;0;;
-2;energy (industry);Final Energy|Non-Energy Use|Chemicals;PJ/yr;Final energy consumption in the chemical sector by the non-combustion processes;FE|Non-energy Use|Industry;EJ/yr;1000;;0;;R
+2;energy (industry);Final Energy|Non-Energy Use|Chemicals;PJ/yr;Final energy consumption in the chemical sector by the non-combustion processes;FE|Non-energy Use|+|Industry;EJ/yr;1000;;0;;R
 2;energy (industry);Final Energy|Non-Energy Use|Chemicals|Gases;PJ/yr;Final energy consumption of gases by the chemical sector by the non-combustion processes;FE|Non-energy Use|Industry|+|Gases;EJ/yr;1000;Currently, all non-energy use in REMIND occurs in the chemicals sector;0;;R
 3;energy (industry);Final Energy|Non-Energy Use|Chemicals|Gases|Natural Gas;PJ/yr;Final energy consumption of natural gas by the chemical sector by the non-combustion processes;;;;;0;;
 3;energy (industry);Final Energy|Non-Energy Use|Chemicals|Gases|Biomass;PJ/yr;Final energy consumption of biogas by the chemical sector by the non-combustion processes;;;;;0;;

--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -9,7 +9,8 @@ for (mapping in c(setdiff(names(mappingNames()), c("AR6", "NAVIGATE", "AR6_NGFS"
 
     data <- data %>% # [seq(min(10, nrow(data))), ] %>%
       filter(!is.na(variable)) %>%
-      mutate(model = "REMIND", scenario = "default", region = "GLO", value = 1)
+      mutate(model = "REMIND", scenario = "default", region = "GLO", value = 1) %>%
+      mutate(variable = deletePlus(.data$variable))
 
     data <- tidyr::crossing(data, year = seq(2005, 2020, 5))
 
@@ -87,8 +88,11 @@ test_that("Correct Prices are selected and plusses ignored", {
 
 test_that("fail on duplicated data", {
   dupl <- rbind(testdata, testdata)
-  expect_error(generateIIASASubmission(dupl, mapping = "AR6", outputFilename = NULL, logFile = NULL),
-               "Duplicated data found")
+  expect_warning(generateIIASASubmission(dupl, mapping = "AR6", outputFilename = NULL, logFile = NULL),
+                 "Duplicated data found")
+  dupl <- rbind(testdata, mutate(testdata, variable = sub("|", "|++|", variable, fixed = TRUE)))
+  expect_warning(generateIIASASubmission(dupl, mapping = "AR6", outputFilename = NULL, logFile = NULL),
+                 "Duplicated data found")
 })
 
 

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -26,13 +26,25 @@ for (mapping in names(mappingNames())) {
     expect_equal(length(movingavg), 0)
 
     # check for duplicated rows
-    duplicates <- select(mappingData, "variable", "piam_variable")
+    duplicates <- mappingData %>%
+      select("variable", "piam_variable") %>%
+      mutate(piam_variable = deletePlus(.data$piam_variable),
+             variable = deletePlus(.data$variable))
     duplicates <- filter(duplicates, duplicated(duplicates))
     if (nrow(duplicates) > 0) {
       warning("Duplicated line in ", mapping, ":\n",
               paste0(duplicates$variable, ";", duplicates$piam_variable, collapse = "\n"))
     }
     expect_equal(nrow(duplicates), 0)
+
+    # check for |+| notation used inconsistenly
+    vars <- setdiff(unique(mappingData$piam_variable), NA)
+    somePlusSomeNot <- vars[table(deletePlus(unique(vars)))[deletePlus(vars)] > 1]
+    if (length(somePlusSomeNot) > 0) {
+      warning("Inconsistent use of |+| notation for these variables:\n",
+              paste(somePlusSomeNot, collapse = ", "))
+    }
+    expect_equal(length(somePlusSomeNot), 0)
 
     # check for inconsistent variable + unit combinations
     nonempty <- dplyr::filter(mappingData, ! is.na(.data$piam_variable), ! .data$piam_variable == "TODO")

--- a/tutorial.md
+++ b/tutorial.md
@@ -32,7 +32,7 @@ Additionally, some mappings use those columns:
 - `idx`: serial number of `variable`
 - `Tier`: importance of variable. 1 means most important
 - `Comment`: place for comments
-
+- `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 To edit a mapping in `R`, use:
 ```


### PR DESCRIPTION
## Purpose of this PR

- I was debugging a weird summation error where a variable was roughly twice what was expected.
- Turns out: `generateIIASASubmission` first checks for duplicates and then removes `deletePlus`
- the data had the same variable with and without + notation and then it was summed up 😝  (which is actually an EDGE-T problem)
- force consistent use of `|+|` notation within each template to make sure the checks find duplicate rows