### PR TITLE
remove Emi|CO2|Waste hotfix from AR6+NAVIGATE 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5207994'
+ValidationKey: '5227948'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.26.1
+version: 0.26.2
 date-released: '2024-08-19'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.26.1
+Version: 0.26.2
 Date: 2024-08-19
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -66,11 +66,7 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                          )
   template$piam_factor[is.na(template$piam_factor)] <- 1
   success <- areUnitsIdentical(template$piam_unit, template$unit) & template$piam_factor %in% c(1, -1)
-
-  # https://github.com/remindmodel/development_issues/issues/261
-  temporarilyIgnore <- c("Emi|CO2|Energy|+|Waste", "Emi|CO2|Gross|Energy|+|Waste")
-
-  success <- success | is.na(template$piam_variable) | template$piam_variable %in% c("TODO", temporarilyIgnore)
+  success <- success | is.na(template$piam_variable)
 
   firsterror <- TRUE
   for (sc in scaleConversion) {

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -109,7 +109,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint cyclocomp_linter
 
   for (i in seq_along(mapping)) {
     t <- getMapping(mapping[i]) %>%
-      filter(.data$piam_variable != "", !is.na(.data$piam_variable), .data$piam_variable != "TODO") %>%
+      filter(! .data$piam_variable %in% "", ! is.na(.data$piam_variable)) %>%
       mutate(
         "piam_variable" = removePlus(.data$piam_variable),
         "piam_factor" = ifelse(is.na(.data$piam_factor), 1, as.numeric(.data$piam_factor))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.26.1**
+R package **piamInterfaces**, version **0.26.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -107,7 +107,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.26.1, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.26.2, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -116,7 +116,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.26.1},
+  note = {R package version 0.26.2},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_AR6.csv
+++ b/inst/mappings/mapping_AR6.csv
@@ -1,10 +1,4 @@
 idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-# temporary fix until waste emissions are separated;;;;;;;;;; # https://github.com/remindmodel/development_issues/issues/261
-;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-;Emissions|CO2|Energy|Supply|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
-;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
-#;;;;;;;;;;
 0;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Fertilizer;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure From Stubble Grazing;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
@@ -141,7 +135,7 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comm
 116;Forcing|Tropospheric Ozone;W/m2;Forcing|Tropospheric Ozone;W/m2;;;;;total radiative forcing from tropospheric ozone;C
 117;Temperature|Global Mean;°C;MAGICC7 AR6|Surface Temperature (GSAT)|50.0th Percentile;K;;;;;change in global mean surface temperature relative to pre-industrial,reported by the model. Please specify which climate model was used in comments tab;C
 118;Capital Formation;billion US$2010/yr;Investments;billion US$2005/yr;1.12;;;might not fit completely;net additions to the physical capital stock;R
-119;Capital Stock;billion US$2010/yr;;;;;;Capital Stock|Non-ESM is actually a cumulative value in REMIND;TODO: report yearly value,Macroeconomic capital stock;
+119;Capital Stock;billion US$2010/yr;;;;;;Capital Stock|Non-ESM is actually a cumulative value in REMIND, report yearly value;Macroeconomic capital stock;
 120;Consumption;billion US$2010/yr;Consumption;billion US$2005/yr;1.12;;;quality depends on capital market realization (switch);total consumption of all goods,by all consumers in a region;R
 121;Discount rate|Residential and Commercial;%;;;;;;;Discount rate for investments into residential and commercial buildings;
 122;Discount rate|Economy;%;;;;;;;Economy wide discount rate: real interest rate of capital;

--- a/inst/mappings/mapping_AR6_MAgPIE.csv
+++ b/inst/mappings/mapping_AR6_MAgPIE.csv
@@ -131,7 +131,7 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;source;internal_comment;Co
 116;Forcing|Tropospheric Ozone;W/m2;;;;;;;total radiative forcing from tropospheric ozone
 117;Temperature|Global Mean;°C;;;;;;;change in global mean surface temperature relative to pre-industrial,reported by the model. Please specify which climate model was used in comments tab
 118;Capital Formation;billion US$2010/yr;;;;;;might not fit completely;net additions to the physical capital stock
-119;Capital Stock;billion US$2010/yr;;;;;;Capital Stock|Non-ESM is actually a cumulative value in REMIND;TODO: report yearly value,Macroeconomic capital stock
+119;Capital Stock;billion US$2010/yr;;;;;;Capital Stock|Non-ESM is actually a cumulative value in REMIND, report yearly value;Macroeconomic capital stock
 120;Consumption;billion US$2010/yr;;;;;;quality depends on capital market realization (switch);total consumption of all goods,by all consumers in a region
 121;Discount rate|Residential and Commercial;%;;;;;;;Discount rate for investments into residential and commercial buildings
 122;Discount rate|Economy;%;;;;;;;Economy wide discount rate: real interest rate of capital
@@ -1670,14 +1670,14 @@ idx;variable;unit;piam_variable;piam_unit;piam_factor;source;internal_comment;Co
 1569;OM Cost|Fixed|Liquids|Gas|w/o CCS;US$2010/kW/yr;;;;;;;Annual fixed operation & maintainance cost of a new gas to liquids plant w/o CCS. If more than one GTL technology is modelled,modellers should report fixed O&M costs  for each represented GTL technology by adding variables OM Cost|Fixed|Liquids|Gas|w/o CCS|2,... OM Cost|Fixed|Liquids|Gas|w/o CCS|N (with N = number of represented technologies) (matching the assignment of plant types to technologies in the reporting of capital costs as documented in the comments sheet).
 1570;OM Cost|Fixed|Liquids|Oil;US$2010/kW/yr;;;;;;;Annual fixed operation & maintainance cost of a new oil refining plant. If more than one refinery technology is modelled,modellers should report fixed O&M costs  for each represented refinery technology by adding variables OM Cost|Fixed|Liquids|Oil|2,... OM Cost|Fixed|Liquids|Oil|N (with N = number of represented technologies) (matching the assignment of plant types to technologies in the reporting of capital costs as documented in the comments sheet).
 1571;Export|Agriculture;billion US$2010/yr;;;;;;;export of agricultural commodities measured in monetary units.
-1572;Export|Energy;billion US$2010/yr;TODO;;;;;Export of primary energy can be computed from REMIND;export of energy commodities measured in monetary units.
+1572;Export|Energy;billion US$2010/yr;;;;;;Export of primary energy can be computed from REMIND;export of energy commodities measured in monetary units.
 1573;Export|Industry;billion US$2010/yr;;;;;;;export of industrial (non-energy) commodities measured in monetary units.
 1574;Export|Industry|Energy;billion US$2010/yr;;;;;;;export of energy commodities measured in monetary units.
 1575;Export|Industry|Energy Intensive;billion US$2010/yr;;;;;;;export of energy intensive commodities measured in monetary units.
 1576;Export|Industry|Manufacturing;billion US$2010/yr;;;;;;;export of manufacturing goods measured in monetary units.
 1577;Export|Other;billion US$2010/yr;;;;;;;export of other commodities measured in monetary units (please provide a definition of the sources in this category in the 'comments' tab).
 1578;Import|Agriculture;billion US$2010/yr;;;;;;;import of agricultural commodities measured in monetary units.
-1579;Import|Energy;billion US$2010/yr;TODO;;;;;Import of primary energy can be computed from REMIND;import of energy commodities measured in monetary units.
+1579;Import|Energy;billion US$2010/yr;;;;;;;import of energy commodities measured in monetary units.
 1580;Import|Industry;billion US$2010/yr;;;;;;;import of industrial (non-energy) commodities measured in monetary units.
 1581;Import|Industry|Energy;billion US$2010/yr;;;;;;;Import of energy commodities measured in monetary units.
 1582;Import|Industry|Energy Intensive;billion US$2010/yr;;;;;;;Import of energy intensive commodities measured in monetary units.

--- a/inst/mappings/mapping_NAVIGATE.csv
+++ b/inst/mappings/mapping_NAVIGATE.csv
@@ -1,14 +1,4 @@
 idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;Comment;Definition;source
-# temporary fix until waste emissions are separated;;;;;;;;;;; # https://github.com/remindmodel/development_issues/issues/261
-;;;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
-;;;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
-;;;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;Rx
-;;;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;Rx
-;;;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
-;;;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.2;;;;Rx
-;;;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;Rx
-
-#;;;;;;;;;;;
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M

--- a/tests/testthat/test-checkVarNames.R
+++ b/tests/testthat/test-checkVarNames.R
@@ -15,7 +15,7 @@ for (mapping in names(mappingNames())) {
   test_that(paste0("checkVarNames in mapping ", mapping), {
     mappingData <- getMapping(mapping)
     expect_no_warning(checkVarNames(paste0(mappingData$variable, " (", mappingData$unit, ")")))
-    mpiam <- dplyr::filter(mappingData, ! is.na(.data$piam_variable), .data$piam_variable != "TODO")
+    mpiam <- dplyr::filter(mappingData, ! is.na(.data$piam_variable))
     expect_no_warning(checkVarNames(paste0(mpiam$piam_variable, " (", mpiam$piam_unit, ")")))
   })
 }

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -48,7 +48,7 @@ for (mapping in names(mappingNames())) {
     expect_equal(length(somePlusSomeNot), 0)
 
     # check for inconsistent variable + unit combinations
-    nonempty <- dplyr::filter(mappingData, ! is.na(.data$piam_variable), ! .data$piam_variable == "TODO")
+    nonempty <- dplyr::filter(mappingData, ! is.na(.data$piam_variable))
     allVarUnit <- paste0(nonempty$piam_variable, " (", nonempty$piam_unit, ")")
     unclearVar <- nonempty$piam_variable[duplicated(nonempty$piam_variable) & ! duplicated(allVarUnit)]
     unclearVarUnit <- sort(unique(allVarUnit[nonempty$piam_variable %in% unclearVar]))
@@ -104,7 +104,7 @@ for (mapping in names(mappingNames())) {
 
       # check for piam_variable without source if source is supplied
       varWithoutSource <- mappingData %>%
-        filter(! is.na(.data$piam_variable), ! .data$piam_variable %in% "TODO", is.na(.data$source)) %>%
+        filter(! is.na(.data$piam_variable), is.na(.data$source)) %>%
         pull("piam_variable") %>%
         unique()
       if (length(varWithoutSource) > 0) {


### PR DESCRIPTION
## Purpose of this PR

- fixes https://github.com/remindmodel/development_issues/issues/261
- was fixed with https://github.com/pik-piam/remind2/pull/641
- if you come with an older mif where Waste is not included in the parent categories, you will get summation errors. So rather use an older piamInterfaces version then



## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
