### PR TITLE
fail tests in case of , as piam_factor decimal seperator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Encoding: UTF-8
 RoxygenNote: 7.3.2
 Config/testthat/parallel: true
 Config/testthat/edition: 3
-Config/testthat/start-first: plotIntercomparison, checkSummations, generateIIASASubmission
+Config/testthat/start-first: plotIntercomparison, generateIIASASubmission, checkSummations

--- a/R/areUnitsIdentical.R
+++ b/R/areUnitsIdentical.R
@@ -8,7 +8,7 @@
 #' @export
 areUnitsIdentical <- function(vec1, vec2 = NULL) {
   if (is.null(vec2)) vec2 <- head(vec1)
-  # only add units that actually have the same meaning, just different spelling
+  # add abbreviations here that are used in the units
   abbreviations <- list(
     "bn" = "billion",
     "US" = "US\\$|USD_|USD|US_",
@@ -21,6 +21,7 @@ areUnitsIdentical <- function(vec1, vec2 = NULL) {
     "%" = "Percentage|Percent|percent",
     "cap" = "capita"
   )
+  # only add units that actually have the same meaning, just different spelling
   identicalUnits <- list(
     c("\u00B0C", "\u00C2\u00B0C", "K"),
     c("Gtkm/yr", "bn tkm/yr"),
@@ -38,22 +39,34 @@ areUnitsIdentical <- function(vec1, vec2 = NULL) {
     c("W/m2", "W/m^2"),
     # below, exceptionally added units that actually differ for backwards compatibility
     # for 'Energy Service|Residential and Commercial|Floor Space'
-    c("bn m2/yr", "billion m2/yr", "bn m2", "billion m2"),
+    c("bn m2/yr", "bn m2"),
     # for 'Productivity|Yield' and subvariables
     c("t DM/ha", "t DM/ha/yr", "dm t/ha"),
     # for 'Water|Environmental flow violation volume'
     c("km3/yr", "km3"),
   NULL)
-  areIdentical <- function(x, y) {
+
+  # function to apply abbreviations
+  .abbreviateUnit <- function(unit) {
+    for (abb in names(abbreviations)) {
+      unit <- gsub(abbreviations[abb], abb, unit)
+    }
+    return(unit)
+  }
+
+  # apply abbreviations
+  vec1 <- .abbreviateUnit(vec1)
+  vec2 <- .abbreviateUnit(vec2)
+  identicalUnits <- lapply(identicalUnits, .abbreviateUnit)
+
+  # function to check identity
+  .areIdentical <- function(x, y) {
     # literally identical
     isTRUE(x == y) ||
-    # both found in the same list element above
+    # both found in the same list element of identicalUnits above
     any(unlist(lapply(identicalUnits, function(units) all(c(x, y) %in% units))))
   }
-  for (abb in names(abbreviations)) {
-    vec1 <- gsub(abbreviations[abb], abb, vec1)
-    vec2 <- gsub(abbreviations[abb], abb, vec2)
-    identicalUnits <- lapply(identicalUnits, function(x) gsub(abbreviations[abb], abb, x))
-  }
-  return(unname(unlist(Map(Vectorize(areIdentical), vec1, vec2))))
+
+  # check identity on vectors
+  return(unname(unlist(Map(Vectorize(.areIdentical), vec1, vec2))))
 }

--- a/R/checkVarNames.R
+++ b/R/checkVarNames.R
@@ -7,17 +7,17 @@
 #' @export
 checkVarNames <- function(vars) {
 
-  barspace <- grep("[\\| ]{2}|^[\\| ]|[\\| ]$", vars, value = TRUE)
+  barspace <- unique(grep("[\\| ]{2}|^[\\| ]|[\\| ]$", vars, value = TRUE))
   if (length(barspace) > 0) {
     warning("These variable names have wrong bars and spaces: ", paste(barspace, collapse = ", "))
   }
 
-  naVar <- grep("[\\|\\( ]NA[\\|\\) ]|^NA", vars, value = TRUE)
+  naVar <- unique(grep("[\\|\\( ]NA[\\|\\) ]|^NA", vars, value = TRUE))
   if (length(naVar) > 0) {
     warning("These variables and units contain NA: ", paste(naVar, collapse = ", "))
   }
 
-  noUnit <- grep(" \\(.*\\)$", vars, value = TRUE, invert = TRUE)
+  noUnit <- unique(grep(" \\(.*\\)$", vars, value = TRUE, invert = TRUE))
   if (length(noUnit) > 0) {
     warning("These variables have no units: ", paste(noUnit, collapse = ", "))
   }

--- a/R/getMapping.R
+++ b/R/getMapping.R
@@ -30,7 +30,7 @@ getMapping <- function(project = NULL) {
   filename <- if (project %in% names(mappings)) mappings[project] else project
   if (file.exists(filename)) {
     data <- read.csv2(filename, header = TRUE, sep = ";", na.strings = list(""),
-                      strip.white = TRUE, quote = "", comment.char = "#")
+                      strip.white = TRUE, quote = "", comment.char = "#", dec = ".")
 
     # check if more than one column is found
     if (length(data) == 1) {

--- a/tests/testthat/test-getMapping.R
+++ b/tests/testthat/test-getMapping.R
@@ -90,6 +90,19 @@ for (mapping in names(mappingNames())) {
     }
     expect_true(length(factorWithoutVar) == 0)
 
+    # check whether piam_factor column has , as decimal separator
+    factorWithComma <- mappingData %>%
+      filter(grepl(",", .data$piam_factor)) %>%
+      pull("variable")
+    if (length(factorWithComma) > 0) {
+      warning("These variables in mapping ", mapping, " have a piam_factor using a ',' as decimal. Please use '.':\n",
+              paste(factorWithComma, collapse = "\n"),
+              "\nYou can run: devtools::load_all(); write.csv2(getMapping('", mapping,
+              "') %>% mutate(piam_factor = gsub(',', '.', .data$piam_factor)), mappingNames('", mapping,
+              "'), na = '', row.names = FALSE, quote = FALSE)")
+    }
+    expect_true(length(factorWithComma) == 0)
+
     # checks only if source is supplied
     if ("source" %in% colnames(mappingData)) {
       # check for empty piam_variable with source


### PR DESCRIPTION
## Purpose of this PR

- avoid that Excel or Open Office replaces `.` with `,`
- improve readability and documentation of areUnitsIdentical
