### PR TITLE
avoid inexplicable test fails in case of multiple units per variable

### DIFF
--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -11,7 +11,7 @@ for (mapping in c(setdiff(names(mappingNames()), c("AR6", "NAVIGATE", "AR6_NGFS"
       filter(!is.na(.data$variable)) %>%
       mutate(model = "REMIND", scenario = "default", region = "GLO", value = 1) %>%
       mutate(variable = deletePlus(.data$variable)) %>%
-      distinct()
+      distinct(.data$variable, .keep_all = TRUE)
 
     data <- tidyr::crossing(data, year = seq(2005, 2020, 5))
 


### PR DESCRIPTION
## Purpose of this PR

`distinct()` is not good if two piam_variable with different piam_unit exist, and the error is completely incomprehensible then. And this fact raises more comprehensible errors later anyway.