### PR TITLE
remove OM Costs from summation checks NAVIGATE

### DIFF
--- a/inst/summations/summation_groups_NAVIGATE.csv
+++ b/inst/summations/summation_groups_NAVIGATE.csv
@@ -1351,9 +1351,6 @@ Land Cover|Forest;Land Cover|Forest|Afforestation and Reforestation;1
 Land Cover|Forest;Land Cover|Forest|Managed;1
 Land Cover|Forest;Land Cover|Forest|Natural Forest;1
 
-OM Cost|Fixed|Electricity|Wind;OM Cost|Fixed|Electricity|Wind|Offshore;1
-OM Cost|Fixed|Electricity|Wind;OM Cost|Fixed|Electricity|Wind|Onshore;1
-
 Population;Population|Rural;1
 Population;Population|Urban;1
 


### PR DESCRIPTION
makes no sense as these are costs per KW

## Purpose of this PR



## Checklist:
- [ ] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
