### PR TITLE
add Waste temporary fix to ELEVATE mapping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6597360'
+ValidationKey: '6617352'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.33.0
+version: 0.33.1
 date-released: '2024-09-26'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.33.0
+Version: 0.33.1
 Date: 2024-09-26
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -82,6 +82,9 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
   template$piam_factor[is.na(template$piam_factor)] <- 1
   success <- areUnitsIdentical(template$piam_unit, template$unit) & template$piam_factor %in% c(1, -1)
   success <- success | is.na(template$piam_variable)
+  ignore <-  c(paste0("Emi|CO2|Energy|Waste", c("", "|Feedstocks unknown fate", "|Plastics Incineration")),
+               "Emi|CO2|Gross|Energy|Waste")
+  success <- success | removePlus(as.character(template$piam_variable)) %in% ignore
 
   firsterror <- TRUE
   for (sc in scaleConversion) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.33.0**
+R package **piamInterfaces**, version **0.33.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -120,7 +120,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.33.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.33.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -129,7 +129,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.33.0},
+  note = {R package version 0.33.1},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_ELEVATE.csv
+++ b/inst/mappings/mapping_ELEVATE.csv
@@ -1,4 +1,27 @@
 idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+# temporary fix. Waste is now separated, but ELEVATE still runs on a REMIND version where this is not the case. Therefore, add Emi|CO2|Energy|Waste and subtract its elements that were introduced only when it was fixed. So it will not affect the new version;;;;;;;;; # https://github.com/remindmodel/development_issues/issues/261 https://github.com/pik-piam/remind2/pull/641
+;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
+;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
+;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
+;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
+;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
+;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
+;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
+;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
+# ;;;;;;;;;;
 ;Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2017/t CO2;0.9096;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
 ;Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2017/yr;0.9096;;;;government revenue from import taxes;R
 ;Resource|Extraction|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R


### PR DESCRIPTION
## Purpose of this PR

- fix until we have not updated to more recent REMIND...
- Gross emissions are not ideal, but better than nothing… Remove the fix as soon as possible.