### PR TITLE
remove World from mappings, but add mainReg to convertHistoricalData

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7041056'
+ValidationKey: '7061412'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.35.2
-date-released: '2024-10-07'
+version: 0.35.3
+date-released: '2024-10-08'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.35.2
-Date: 2024-10-07
+Version: 0.35.3
+Date: 2024-10-08
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/convertHistoricalData.R
+++ b/R/convertHistoricalData.R
@@ -10,6 +10,7 @@
 #'  One can be called 'REMIND' or 'CountryCode' and contains the regions in the data.
 #'  The second can be called 'project_region' or 'RegionCode', to which the first is mapped.
 #'  You can also specify the filename part before the .csv from inst/regionmapping
+#' @param mainReg if regionMapping is specified, additional main region that is kept as is
 #' @importFrom dplyr %>% mutate select right_join left_join
 #' @importFrom quitte read.quitte as.quitte
 #' @importFrom piamutils deletePlus
@@ -24,7 +25,7 @@
 #' )
 #' }
 #' @export
-convertHistoricalData <- function(mif, project, regionMapping = NULL) {
+convertHistoricalData <- function(mif, project, regionMapping = NULL, mainReg = "World") {
 
   hist <- suppressWarnings(as.quitte(mif, na.rm = TRUE)) %>%
     rename("hist_variable" = "variable", "hist_unit" = "unit")
@@ -73,7 +74,9 @@ convertHistoricalData <- function(mif, project, regionMapping = NULL) {
     if (length(from) == 0 || length(to) == 0) {
       stop("regionMapping must contain columns 'REMIND'/'project_region' or 'CountryCode'/'RegionCode'")
     }
-
+    if (length(mainReg) == 1 && ! mainReg %in% regmap[[to]]) {
+      rbind(select(regmap, all_of(to), all_of(from)), c(mainReg, mainReg))
+    }
     out <- left_join(out, regmap, by = c("region" = from)) %>%
       filter(!is.na(.data[[to]])) %>%
       select("model", "scenario", "region" = all_of(to), "variable", "unit", "period", "value")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.35.2**
+R package **piamInterfaces**, version **0.35.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -120,7 +120,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.35.2, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.35.3, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -129,7 +129,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.35.2},
+  note = {R package version 0.35.3},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/regionmapping/ISO_2_ISO.csv
+++ b/inst/regionmapping/ISO_2_ISO.csv
@@ -248,4 +248,3 @@ Yemen;YEM;YEM
 South Africa;ZAF;ZAF
 Zambia;ZMB;ZMB
 Zimbabwe;ZWE;ZWE
-World;World;World

--- a/inst/regionmapping/ISO_2_R10.csv
+++ b/inst/regionmapping/ISO_2_R10.csv
@@ -248,4 +248,3 @@ Yemen;YEM;Middle East (R10)
 South Africa;ZAF;Africa (R10)
 Zambia;ZMB;Africa (R10)
 Zimbabwe;ZWE;Africa (R10)
-World;World;World

--- a/inst/regionmapping/ISO_2_R5.csv
+++ b/inst/regionmapping/ISO_2_R5.csv
@@ -248,4 +248,3 @@ Yemen;YEM;Middle East & Africa (R5)
 South Africa;ZAF;Middle East & Africa (R5)
 Zambia;ZMB;Middle East & Africa (R5)
 Zimbabwe;ZWE;Middle East & Africa (R5)
-World;World;World

--- a/man/convertHistoricalData.Rd
+++ b/man/convertHistoricalData.Rd
@@ -5,7 +5,7 @@
 \title{Converts data in historical.mif to match project-specific variables and
 regions so that it can be used for comparison in an intermodel comparison project}
 \usage{
-convertHistoricalData(mif, project, regionMapping = NULL)
+convertHistoricalData(mif, project, regionMapping = NULL, mainReg = "World")
 }
 \arguments{
 \item{mif}{quitte object with historical data or path to historical.mif}
@@ -17,6 +17,8 @@ project regions, must contain two columns:
 One can be called 'REMIND' or 'CountryCode' and contains the regions in the data.
 The second can be called 'project_region' or 'RegionCode', to which the first is mapped.
 You can also specify the filename part before the .csv from inst/regionmapping}
+
+\item{mainReg}{if regionMapping is specified, additional main region that is kept as is}
 }
 \description{
 Converts data in historical.mif to match project-specific variables and


### PR DESCRIPTION
## Purpose of this PR

- running the madrat routine as described [here](https://github.com/remindmodel/remind/blob/develop/tutorials/13_Submit_to_IIASA_database.md#further-information) does not work if `World` is part of the mappings
- but for convertHistorical, you need it
- so remove it from mapping, but add option to keep the mainReg = "World" in convertHistoricalData