### PR TITLE
fix plotIntercomparison + ELEVATE mapping bugs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7202520'
+ValidationKey: '7225054'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.36.0
-date-released: '2024-10-11'
+version: 0.36.1
+date-released: '2024-10-18'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.36.0
-Date: 2024-10-11
+Version: 0.36.1
+Date: 2024-10-18
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/plotIntercomparison.R
+++ b/R/plotIntercomparison.R
@@ -57,6 +57,8 @@ plotIntercomparison <- function(mifFile, outputDirectory = "output", summationsF
   if (isTRUE(summationsFile == "extractVariableGroups")) {
     summationList <- extractVariableGroups(levels(data$variable), keepOrigNames = FALSE, sorted = TRUE)
     summationList <- lapply(summationList, removePlus)
+    summationGroups <- bind_rows(lapply(names(summationList),
+                                        function(x) data.frame(parent = x, child = summationList[[x]], factor = 1)))
     data <- removePlus(data)
   } else if (! is.null(summationsFile)) {
     data <- removePlus(data)
@@ -94,6 +96,7 @@ plotIntercomparison <- function(mifFile, outputDirectory = "output", summationsF
   levels(data$model) <- newModelNames
 
   combineVariables <- function(vars) {
+    if (length(vars) == 0 || isFALSE(vars)) return(NULL)
     mappingfiles <- vars[vars %in% names(mappingNames()) | file.exists(vars)]
     tmpVars <- setdiff(vars, mappingfiles)
     for (mapping in mappingfiles) {
@@ -196,20 +199,16 @@ makepdf <- function(pdfFilename, plotdata, lineplotVariables, areaplotVariables,
   plotvariables <- plotvariables[removeNo(plotvariables) %in% plotdata$variable]
   for (p in plotvariables) {
     message(which(p == plotvariables), "/", length(plotvariables), ": Add plot for ", p)
-    areaworked <- FALSE
     # area plot
     if (p %in% names(areaplotVariables)) {
       childs <- intersect(areaplotVariables[[p]], unique(plotdata$variable))
       message("Childs: ", paste(gsub(p, "", childs, fixed = TRUE), collapse = ", "))
-      if (length(getModels(droplevels(filter(plotdata, .data$variable %in% childs)))) > 1 ||
-          length(getScenarios(droplevels(filter(plotdata, .data$variable %in% childs)))) > 1) {
-        e <- try(showAreaAndBarPlots(plotdata, if (length(childs) > 0) childs else removeNo(p), tot = removeNo(p),
-                                     mainReg = mainReg, scales = "fixed",
-                                     yearsBarPlot = intersect(yearsBarPlot, unique(plotdata$period))))
-        if (! inherits(e, "try-error")) areaworked <- TRUE
-      }
-      if (isFALSE(areaworked)) {
-        lineplotVariables <- c(lineplotVariables, removeNo(p)) # if no area plot possible, do lineplot
+      e <- try(showAreaAndBarPlots(plotdata, if (length(childs) > 0) childs else removeNo(p), tot = removeNo(p),
+                                   mainReg = mainReg, scales = "fixed",
+                                   yearsBarPlot = intersect(yearsBarPlot, unique(plotdata$period))))
+      if (inherits(e, "try-error")) {
+        message("areaplot failed for ", p, ", do lineplot.")
+        lineplotVariables <- c(lineplotVariables, removeNo(p)) # if area plot fails, do lineplot
       }
     }
     # line plot

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.36.0**
+R package **piamInterfaces**, version **0.36.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces)  [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -120,7 +120,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.36.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2024). _piamInterfaces: Project specific interfaces to REMIND / MAgPIE_. R package version 0.36.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -129,7 +129,7 @@ A BibTeX entry for LaTeX users is
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
   year = {2024},
-  note = {R package version 0.36.0},
+  note = {R package version 0.36.1},
   url = {https://github.com/pik-piam/piamInterfaces},
 }
 ```

--- a/inst/mappings/mapping_ELEVATE.csv
+++ b/inst/mappings/mapping_ELEVATE.csv
@@ -1,37 +1,16 @@
-idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
-1;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-1;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
-1;Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
-2;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-2;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
-2;Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
-3;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
-3;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
-3;Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
-4;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
-4;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
-4;Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
-5;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-5;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
-5;Gross Emissions|CO2|Energy|Supply;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
-6;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.2;;;;;Rx
-6;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.2;;;;;Rx
-6;Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.2;;;;;Rx
-7;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Gross|Energy|+|Waste;Mt CO2/yr;0.8;;;;;Rx
-7;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Feedstocks unknown fate;Mt CO2/yr;-0.8;;;;;Rx
-7;Gross Emissions|CO2|Energy|Supply|Other;Mt CO2/yr;Emi|CO2|Energy|Waste|Plastics Incineration;Mt CO2/yr;-0.8;;;;;Rx
-8;Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2017/t CO2;0.9096;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
-9;Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2017/yr;0.9096;;;;government revenue from import taxes;R
-10;Resource|Extraction|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R
-11;Resource|Extraction|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;R
-12;Resource|Extraction|Oil;EJ/yr;Res|Extraction|Oil;EJ/yr;1;;;;Extracted oil;R
-13;Extracted|Primary Energy|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R
-14;Extracted|Primary Energy|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;R
-15;Extracted|Primary Energy|Oil;EJ/yr;Res|Extraction|Oil;EJ/yr;1;;;;Extracted oil;R
-16;Sales|Transport|LDV|BEV;million vehicles/yr;Sales|Transport|Pass|Road|LDV|BEV;million veh;1;;;;;T
-17;Stock|Transport|LDV|BEV;million vehicles/yr;Stock|Transport|Pass|Road|LDV|BEV;million veh;1;;;;;T
-18;Sales|Transport|Truck|Electric;million vehicles/yr;Sales|Transport|Freight|Road|BEV;million veh;1;;;;;T
-19;Stock|Transport|Truck|Electric;million vehicles/yr;Stock|Transport|Freight|Road|BEV;million veh;1;;;;;T
-20;Sales|Transport|Bus|Electric;million vehicles/yr;Sales|Transport|Pass|Road|Bus|BEV;million veh;1;;;;;T
-21;Stock|Transport|Bus|Electric;million vehicles/yr;Stock|Transport|Pass|Road|Bus|BEV;million veh;1;;;;;T
-22;Final Energy|Residential and Commercial|Space Heating|Electricity|Heat Pumps;EJ/yr;FE|Buildings|Heating|Electricity|Heat pump;EJ/yr;1;;;;;R
+variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2017/t CO2;0.9096;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
+Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2017/yr;0.9096;;;;government revenue from import taxes;R
+Resource|Extraction|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R
+Resource|Extraction|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;R
+Resource|Extraction|Oil;EJ/yr;Res|Extraction|Oil;EJ/yr;1;;;;Extracted oil;R
+Extracted|Primary Energy|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R
+Extracted|Primary Energy|Gas;EJ/yr;Res|Extraction|Gas;EJ/yr;1;;;;Extracted gas;R
+Extracted|Primary Energy|Oil;EJ/yr;Res|Extraction|Oil;EJ/yr;1;;;;Extracted oil;R
+Sales|Transport|LDV|BEV;million vehicles/yr;Sales|Transport|Pass|Road|LDV|BEV;million veh;1;;;;;T
+Stock|Transport|LDV|BEV;million vehicles/yr;Stock|Transport|Pass|Road|LDV|BEV;million veh;1;;;;;T
+Sales|Transport|Truck|Electric;million vehicles/yr;Sales|Transport|Freight|Road|BEV;million veh;1;;;;;T
+Stock|Transport|Truck|Electric;million vehicles/yr;Stock|Transport|Freight|Road|BEV;million veh;1;;;;;T
+Sales|Transport|Bus|Electric;million vehicles/yr;Sales|Transport|Pass|Road|Bus|BEV;million veh;1;;;;;T
+Stock|Transport|Bus|Electric;million vehicles/yr;Stock|Transport|Pass|Road|Bus|BEV;million veh;1;;;;;T
+Final Energy|Residential and Commercial|Space Heating|Electricity|Heat Pumps;EJ/yr;FE|Buildings|Heating|Electricity|Heat pump;EJ/yr;1;;;;;R

--- a/inst/renamed_piam_variables.csv
+++ b/inst/renamed_piam_variables.csv
@@ -25,7 +25,7 @@ Resources|Land Cover|Cropland|Croparea|Forage*          ;Resources|Land Cover|Cr
 # https://github.com/pik-piam/magpie4/commit/2847a13e5c171b9dc78dccdc7d6a085e8c8d74d3
 Prices|Index2020|Agriculture|Producer*                  ;Prices|Producer Price Index*
 
-# Changes from edgeT refactoring v2.0
+# Changes from edgeT refactoring v2.0, see also /p/projects/edget/Refactoring/remind/output/variableMappingOldNew.csv
 Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping;Emi|CO2|Transport|Freight|International Shipping|Demand
 Emi|CO2|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Emi|CO2|Transport|Pass|Aviation|International|Demand
 Emi|CO2|Energy|Demand|Transport|Freight|Domestic Shipping;Emi|CO2|Transport|Freight|Navigation|Demand
@@ -65,6 +65,9 @@ FE|Transport|Pass|Domestic Aviation|Liquids;FE|Transport|Pass|Aviation|Domestic|
 FE|Transport|Pass|Domestic Aviation|Liquids|Biomass;FE|Transport|Pass|Aviation|Domestic|Liquids|Biomass
 FE|Transport|Pass|Domestic Aviation|Liquids|Fossil;FE|Transport|Pass|Aviation|Domestic|Liquids|Fossil
 FE|Transport|Pass|Domestic Aviation|Liquids|Hydrogen;FE|Transport|Pass|Aviation|Domestic|Liquids|Hydrogen
+Sales|Transport|Freight|Road|BEV;Sales|Transport|Truck|Electric
+Sales|Transport|Pass|Road|Bus|BEV;Sales|Transport|Bus|Electric
+Sales|Transport|Pass|Road|LDV|BEV;Sales|Transport|LDV|BEV
 Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|BEV;Sales|Transport|LDV|Large Car and SUV|BEV
 Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|FCEV;Sales|Transport|LDV|Large Car and SUV|FCEV
 Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|Hybrid electric;Sales|Transport|LDV|Large Car and SUV|Hybrid Electric
@@ -82,8 +85,11 @@ Sales|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|FCEV;Sales|Tran
 Sales|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Hybrid electric;Sales|Transport|LDV|Subcompact Car|Hybrid Electric
 Sales|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|Liquids;Sales|Transport|LDV|Subcompact Car|Liquids
 Sales|Transport|Pass|Road|LDV|Hybrid electric;Sales|Transport|LDV|Hybrid Electric
+Stock|Transport|Freight|Road|BEV;Stock|Transport|Truck|Electric
 Stock|Transport|Pass|Road|Bus;Stock|Transport|Bus
+Stock|Transport|Pass|Road|Bus|BEV;Stock|Transport|Bus|Electric
 Stock|Transport|Pass|Road|LDV;Stock|Transport|LDV
+Stock|Transport|Pass|Road|LDV|BEV;Stock|Transport|LDV|BEV
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|BEV;Stock|Transport|LDV|Large Car and SUV|BEV
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|FCEV;Stock|Transport|LDV|Large Car and SUV|FCEV
 Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|Hybrid electric;Stock|Transport|LDV|Large Car and SUV|Hybrid Electric


### PR DESCRIPTION
## Purpose of this PR

- plotIntercomparison did not work with extractVariableGroups anymore
- single model or scenario did not plot areaplot, no idea why I implemented that, it works
- make sure you can plot no lineplots or areaplots by passing NULL or FALSE
- remove Waste temporary fix in ELEVATE template #383 
- add some renamed transport piam variable
