### PR TITLE
use lowercase column names and 'description', not 'Definition' in mappings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '8179072'
+ValidationKey: '8199984'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.40.7
-date-released: '2025-01-08'
+version: 0.40.8
+date-released: '2025-01-10'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.40.7
-Date: 2025-01-08
+Version: 0.40.8
+Date: 2025-01-10
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/variableInfo.R
+++ b/R/variableInfo.R
@@ -100,9 +100,9 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL) {   # nolint: cycl
       message("Units: ", str_pad(paste0(unique(mappingData$unit[no]), collapse = ", "), width, "right"),
               " Units: ", paste0(unique(mappingData[, "piam_unit"][no]), collapse = ", "))
       # print definitions if existing
-      if ("Definition" %in% colnames(mappingData) && ! is.na(mappingData$Definition[[no]])) {
-        message("\nDefinition of ", mappingData$variable[[no]], " (", mappingData$unit[[no]], "): ",
-                mappingData$Definition[[no]])
+      if ("description" %in% colnames(mappingData) && ! is.na(mappingData$description[[no]])) {
+        message("\ndescription of ", mappingData$variable[[no]], " (", mappingData$unit[[no]], "): ",
+                mappingData$description[[no]])
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.40.7**
+R package **piamInterfaces**, version **0.40.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -23,12 +23,12 @@ serve to map variables from the PIAM framework to variables needed for the submi
 The mappings are `;`-separated files, using `#` as comment character, with the following mandatory columns:
 
 - `variable`: name of the variable in the project template
-- `unit`: unit corresponding to `variable`. If the IIASA template has no unit, use `unitless`.
+- `unit`: unit corresponding to `variable`. If the IIASA template has no unit, use `unitless`: an empty cell will fail the tests to avoid unintentially forgetting units.
 - `piam_variable`: name of the variable in REMIND / MAgPIE / EDGE-T etc. reporting
 - `piam_unit`: unit corresponding to `piam_variable`
 - `piam_factor`: factor with which the `piam_variable` has to be multiplied for units to match
 
-Recommended column:
+Recommended columns:
 - `description`: description text defining the `variable`. Never use `"` and `;` in the text.
 - `source`: abbreviation of the PIAM part where the `piam_variable` comes from.
   Use `B` = Brick, `C` = MAGICC, `M` = MAgPIE, `R` = REMIND, `S` = SDP postprocessing, `T` = EDGE-Transport.
@@ -36,12 +36,12 @@ Recommended column:
   [remind2](https://github.com/pik-piam/remind2/blob/master/tests/testthat/test-convGDX2mif.R#L13-L26)
   and [coupling tests](https://github.com/remindmodel/remind/blob/develop/tests/testthat/test_20-coupled.R).
   If the variable is not normally reported, add a small `x` after the model abbreviation for it to be skipped.
-- `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
 
 Additionally, some mappings use those columns:
 - `idx`: serial number of `variable`
-- `Tier`: importance of variable. 1 means most important
-- `Comment`: place for comments
+- `tier`: importance of variable, with 1 being most important
+- `comment`: place for internal comments
+- `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
 - `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 To edit a mapping in `R`, use:
@@ -123,7 +123,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.40.7, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.40.8, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -131,9 +131,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-01-08},
+  date = {2025-01-10},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.40.7},
+  note = {Version: 0.40.8},
 }
 ```

--- a/inst/mappings/mapping_AR6.csv
+++ b/inst/mappings/mapping_AR6.csv
@@ -1,4 +1,4 @@
-idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;comment;description;source
 0;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Fertilizer;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure From Stubble Grazing;Mt Nr/yr;;;;;total nitrogen fertilizer use (organic + inorganic);M

--- a/inst/mappings/mapping_AR6_MAgPIE.csv
+++ b/inst/mappings/mapping_AR6_MAgPIE.csv
@@ -1,4 +1,4 @@
-idx;variable;unit;piam_variable;piam_unit;piam_factor;source;internal_comment;Comment;Definition
+idx;variable;unit;piam_variable;piam_unit;piam_factor;source;internal_comment;comment;description
 0;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Fertilizer;Mt Nr/yr;;M;;;total nitrogen fertilizer use (organic + inorganic)
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure Recycled from Confinements;Mt Nr/yr;;M;;;total nitrogen fertilizer use (organic + inorganic)
 ;Fertilizer Use|Nitrogen;Tg N/yr;Resources|Nitrogen|Cropland Budget|Inputs|+|Manure From Stubble Grazing;Mt Nr/yr;;M;;;total nitrogen fertilizer use (organic + inorganic)

--- a/inst/mappings/mapping_AR6_NGFS.csv
+++ b/inst/mappings/mapping_AR6_NGFS.csv
@@ -1,4 +1,4 @@
-variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;comment;description;source
 Emissions|Kyoto Gases|AFOLU;Mt CO2-equiv/yr;Emi|GHG|AFOLU;Mt CO2eq/yr;1;;;;;R
 Emissions|Kyoto Gases|Industry;Mt CO2-equiv/yr;Emi|GHG|Industry;Mt CO2eq/yr;1;;;;;R
 Emissions|Kyoto Gases|Transportation;Mt CO2-equiv/yr;Emi|GHG|Energy|Demand|+|Transport;Mt CO2eq/yr;1;;;;;R

--- a/inst/mappings/mapping_ARIADNE.csv
+++ b/inst/mappings/mapping_ARIADNE.csv
@@ -1,4 +1,4 @@
-Tier;Category;variable;unit;Definition;piam_variable;piam_unit;piam_factor;Comment;idx;internal_comment;source
+tier;category;variable;unit;description;piam_variable;piam_unit;piam_factor;comment;idx;internal_comment;source
 1;demography;Population;million;Total population;Population;million;1;;0;;R
 3;demography;Population|Rural;million;Total population living in rural areas;;;;;0;;
 3;demography;Population|Urban;million;Total population living in urban areas;;;;;0;;

--- a/inst/mappings/mapping_ECEMF.csv
+++ b/inst/mappings/mapping_ECEMF.csv
@@ -1,4 +1,4 @@
-variable;unit;piam_variable;piam_unit;piam_factor;Definition;Comment;internal_comment;source
+variable;unit;piam_variable;piam_unit;piam_factor;description;comment;internal_comment;source
 Carbon Capture;Mt CO2/yr;Carbon Management|Carbon Capture;Mt CO2/yr;1;;;;R
 Carbon Capture|Biomass;Mt CO2/yr;Carbon Management|Carbon Capture|+|Biomass|Pe2Se;Mt CO2/yr;1;;;;R
 Carbon Capture|Biomass;Mt CO2/yr;Carbon Management|Carbon Capture|Industry Energy|+|Biomass;Mt CO2/yr;1;;;;R

--- a/inst/mappings/mapping_ELEVATE.csv
+++ b/inst/mappings/mapping_ELEVATE.csv
@@ -1,4 +1,4 @@
-variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;comment;description;source
 Price|Imported Carbon;US$2010/t CO2;Price|Carbon|Imported;US$2017/t CO2;0.9096;;;;Tax on regional imported CO2 (for regional aggregrates the weighted price of carbon by subregion should be used);Rx
 Revenue|government|Import Tax;billion US$2010/yr;Net Taxes|Primary energy import;billion US$2017/yr;0.9096;;;;government revenue from import taxes;R
 Resource|Extraction|Coal;EJ/yr;Res|Extraction|Coal;EJ/yr;1;;;;Extracted coal;R

--- a/inst/mappings/mapping_ESABCC.csv
+++ b/inst/mappings/mapping_ESABCC.csv
@@ -1,4 +1,4 @@
-variable;unit;piam_variable;piam_unit;piam_factor;Definition;Comment;internal_comment;source
+variable;unit;piam_variable;piam_unit;piam_factor;description;comment;internal_comment;source
 Carbon Capture;Mt CO2/yr;Carbon Management|Carbon Capture;Mt CO2/yr;1;;;;R
 Carbon Capture|Biomass;Mt CO2/yr;Carbon Management|Carbon Capture|+|Biomass|Pe2Se;Mt CO2/yr;1;;;;R
 Carbon Capture|Biomass;Mt CO2/yr;Carbon Management|Carbon Capture|Industry Energy|+|Biomass;Mt CO2/yr;1;;;;R

--- a/inst/mappings/mapping_NAVIGATE.csv
+++ b/inst/mappings/mapping_NAVIGATE.csv
@@ -1,4 +1,4 @@
-idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;Comment;Definition;source
+idx;tier;category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;comment;description;source
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|++|Crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M
 2;1;agriculture;Agricultural Demand;million t DM/yr;Demand|++|Livestock products;Mt DM/yr;;;;total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);M

--- a/inst/mappings/mapping_NAVIGATE_coupled.csv
+++ b/inst/mappings/mapping_NAVIGATE_coupled.csv
@@ -1,4 +1,4 @@
-idx;Tier;Category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;Comment;Definition;source
+idx;tier;category;variable;unit;piam_variable;piam_unit;piam_factor;internal_comment;comment;description;source
 96;1;carbon management;Carbon Removal|Land Use;Mt CO2/yr;Emi|CO2|CDR|Land-Use Change;Mt CO2/yr;1;;;total carbon dioxide sequestered through land-based sinks (e.g., afforestation, soil carbon enhancement, biochar);R
 96;1;carbon management;Carbon Removal|Land Use;Mt CO2/yr;Emissions|CO2|Land|Land-use Change|Regrowth|CO2-price AR;Mt CO2/yr;-1;;;total carbon dioxide sequestered through land-based sinks (e.g., afforestation, soil carbon enhancement, biochar);M
 96;1;carbon management;Carbon Removal|Land Use;Mt CO2/yr;Emissions|CO2|Land|Land-use Change|Regrowth|NPI_NDC AR;Mt CO2/yr;-1;;;total carbon dioxide sequestered through land-based sinks (e.g., afforestation, soil carbon enhancement, biochar);M

--- a/inst/mappings/mapping_SHAPE.csv
+++ b/inst/mappings/mapping_SHAPE.csv
@@ -1,4 +1,4 @@
-idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;Comment;Definition;source
+idx;variable;unit;piam_variable;piam_unit;piam_factor;piam_spatial;internal_comment;comment;description;source
 1;Useful Energy|Transportation|Passenger;GJ/cap/yr;UE|per capita|Transport|Pass;GJ/cap/yr;;;;;Useful energy per capita for passenger transport.;T
 2;Disability-Adjusted Life Year|PM2_5;DALY/yr;Disability-Adjusted Life Year|PM2_5;DALY/yr;;;;;Disability adjusted life years lost per year from air pollution health impact;S
 3;Useful Energy|Industry;GJ/cap/yr;;;;;;;Useful energy per capita for industry.;

--- a/inst/mappings/mapping_ScenarioMIP.csv
+++ b/inst/mappings/mapping_ScenarioMIP.csv
@@ -1,4 +1,4 @@
-variable;unit;Tier;description;Comment;weight;piam_variable;piam_unit;piam_factor;internal_comment;source;interpolation
+variable;unit;tier;description;comment;weight;piam_variable;piam_unit;piam_factor;internal_comment;source;interpolation
 Agricultural Demand;million t DM/yr;1;Total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);;;Demand|++|Crops;Mt DM/yr;;mapping taken from NAVIGATE, NAVIGATE category: agriculture;M;
 Agricultural Demand;million t DM/yr;1;Total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);;;Demand|Bioenergy|+|Bioenergy crops;Mt DM/yr;;mapping taken from NAVIGATE, NAVIGATE category: agriculture;M;
 Agricultural Demand;million t DM/yr;1;Total demand for food, non-food and feed products (crops and livestock) and bioenergy crops (1st & 2nd generation);;;Demand|++|Livestock products;Mt DM/yr;;mapping taken from NAVIGATE, NAVIGATE category: agriculture;M;

--- a/tutorial.md
+++ b/tutorial.md
@@ -19,7 +19,7 @@ The mappings are `;`-separated files, using `#` as comment character, with the f
 - `piam_unit`: unit corresponding to `piam_variable`
 - `piam_factor`: factor with which the `piam_variable` has to be multiplied for units to match
 
-Recommended column:
+Recommended columns:
 - `description`: description text defining the `variable`. Never use `"` and `;` in the text.
 - `source`: abbreviation of the PIAM part where the `piam_variable` comes from.
   Use `B` = Brick, `C` = MAGICC, `M` = MAgPIE, `R` = REMIND, `S` = SDP postprocessing, `T` = EDGE-Transport.
@@ -27,12 +27,12 @@ Recommended column:
   [remind2](https://github.com/pik-piam/remind2/blob/master/tests/testthat/test-convGDX2mif.R#L13-L26)
   and [coupling tests](https://github.com/remindmodel/remind/blob/develop/tests/testthat/test_20-coupled.R).
   If the variable is not normally reported, add a small `x` after the model abbreviation for it to be skipped.
-- `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
 
 Additionally, some mappings use those columns:
 - `idx`: serial number of `variable`
-- `Tier`: importance of variable. 1 means most important
-- `Comment`: place for comments
+- `tier`: importance of variable, with 1 being most important
+- `comment`: place for internal comments
+- `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
 - `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 To edit a mapping in `R`, use:


### PR DESCRIPTION
## Purpose of this PR

- as discussed in ScenarioMIP mattermost channel to improve consistency
- let `variableinfo` find all description columns