### PR TITLE
fix one NAVIGATE summation error, improve matching of renamed variables in variableInfo

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '90936950'
+ValidationKey: '90957100'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.45.13
+version: 0.45.14
 date-released: '2025-03-03'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.45.13
+Version: 0.45.14
 Date: 2025-03-03
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/variableInfo.R
+++ b/R/variableInfo.R
@@ -114,10 +114,13 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL) {   # nolint: cycl
     message(paste0("- ", mifchilds, collapse = "\n"))
   }
 
+  match <- function(x) {
+    grepl(paste0("^", gsub("*", ".*", gsub("|", "\\|", x, fixed = TRUE), fixed = TRUE), "$"), varname)
+  }
   csvdata <- system.file("renamed_piam_variables.csv", package = "piamInterfaces") %>%
     read.csv2(comment.char = "#", strip.white = TRUE) %>%
     as_tibble() %>%
-    filter(.data$piam_variable %in% varname | .data$old_name %in% varname)
+    filter(unlist(lapply(deletePlus(.data$piam_variable), match)) | unlist(lapply(deletePlus(.data$old_name), match)))
   if (nrow(csvdata) > 0) {
     message("\n### Renaming found in renamed_piam_variables.csv:\n",
             paste0("- ", csvdata$old_name, " -> ", csvdata$piam_variable, collapse = "\n"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.45.13**
+R package **piamInterfaces**, version **0.45.14**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -162,7 +162,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.13, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.14, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -173,6 +173,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-03-03},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.45.13},
+  note = {Version: 0.45.14},
 }
 ```

--- a/inst/summations/summation_groups_NAVIGATE.csv
+++ b/inst/summations/summation_groups_NAVIGATE.csv
@@ -1341,9 +1341,10 @@ Land Cover;Land Cover|Other Natural Land;1
 
 Land Cover|Cropland;Land Cover|Cropland|Cereals;1
 Land Cover|Cropland;Land Cover|Cropland|Energy Crops;1
-Land Cover|Cropland;Land Cover|Cropland|Irrigated;1
 Land Cover|Cropland;Land Cover|Cropland|Double-cropped;1
-Land Cover|Cropland;Land Cover|Cropland|Rainfed;1
+
+Land Cover|Cropland 2;Land Cover|Cropland|Irrigated;1
+Land Cover|Cropland 2;Land Cover|Cropland|Rainfed;1
 
 Land Cover|Cropland|Energy Crops;Land Cover|Cropland|Energy Crops|Irrigated;1
 


### PR DESCRIPTION
## Purpose of this PR

- irrigated and rainfed is |++| in MAgPIE, so split the NAVIGATE summation group
- also match |* variables in variableInfo
