### PR TITLE
improve fixOnRef messaging

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '91042218'
+ValidationKey: '91096080'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.45.18
-date-released: '2025-03-04'
+version: 0.45.20
+date-released: '2025-03-07'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.45.18
-Date: 2025-03-04
+Version: 0.45.20
+Date: 2025-03-07
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/renameOldVariables.R
+++ b/R/renameOldVariables.R
@@ -50,7 +50,7 @@ getExpandRenamedVariables <- function(variables) {
     # if both end with *, replace by options taken from 'variables'
     if (all(grepl("\\*$", c(csvdata$piam_variable[i], csvdata$old_name[i])))) {
       matchOld <- sub("\\*$", "", csvdata$old_name[i])
-      postfix <- gsub(matchOld, "", grep(matchOld, variables, fixed = TRUE, value = TRUE), fixed = TRUE)
+      postfix <- sub(matchOld, "", variables[startsWith(variables, matchOld)], fixed = TRUE)
       csvdataNew <- rbind(
         csvdataNew,
         data.frame(piam_variable = paste0(gsub("\\*$", "", csvdata$piam_variable[i]), postfix),

--- a/R/variableInfo.R
+++ b/R/variableInfo.R
@@ -115,12 +115,12 @@ variableInfo <- function(varname, mif = NULL, mapping = NULL) {   # nolint: cycl
   }
 
   match <- function(x) {
-    grepl(paste0("^", gsub("*", ".*", gsub("|", "\\|", x, fixed = TRUE), fixed = TRUE), "$"), varname)
+    startsWith(varname, sub("\\*$", "", deletePlus(x)))
   }
   csvdata <- system.file("renamed_piam_variables.csv", package = "piamInterfaces") %>%
     read.csv2(comment.char = "#", strip.white = TRUE) %>%
     as_tibble() %>%
-    filter(unlist(lapply(deletePlus(.data$piam_variable), match)) | unlist(lapply(deletePlus(.data$old_name), match)))
+    filter(unlist(lapply(.data$piam_variable, match)) | unlist(lapply(.data$old_name, match)))
   if (nrow(csvdata) > 0) {
     message("\n### Renaming found in renamed_piam_variables.csv:\n",
             paste0("- ", csvdata$old_name, " -> ", csvdata$piam_variable, collapse = "\n"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.45.18**
+R package **piamInterfaces**, version **0.45.20**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -162,7 +162,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.18, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.20, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -170,9 +170,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-03-04},
+  date = {2025-03-07},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.45.18},
+  note = {Version: 0.45.20},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

- group only if necessary for staying below max rows
- show variable number directly after group and also add a `*` behind the group name, so it is more obvious that this is not the actual variable name
- simplify matching using `startsWith`  to avoid that a match in the middle of the possible is possible

## Checklist:
- [ ] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
