### PR TITLE
only interpolate t from timesteps

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '91096080'
+ValidationKey: '91129797'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.45.20
-date-released: '2025-03-07'
+version: 0.45.21
+date-released: '2025-03-10'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.45.20
-Date: 2025-03-07
+Version: 0.45.21
+Date: 2025-03-10
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -79,7 +79,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
                                       paste0(gsub("\\.[a-zA-Z]+$", "_log.txt", outputFilename)),
                                     iiasatemplate = NULL,
                                     generatePlots = FALSE,
-                                    timesteps = c(seq(2005, 2060, 5), seq(2070, 2100, 10)),
+                                    timesteps = seq(2005, 2100, 1),
                                     checkSummation = TRUE,
                                     mappingFile = NULL,
                                     naAction = "na.omit") {
@@ -190,7 +190,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
   )
 
   if (any(mapData$interpolation == "linear", na.rm = TRUE)) {
-    submission <- .interpolate(submission, mapData)
+    submission <- .interpolate(submission, mapData, timesteps)
   }
 
   # apply corrections using IIASA template ----
@@ -340,7 +340,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
   )
 }
 
-.interpolate <- function(submission, mapData) {
+.interpolate <- function(submission, mapData, timesteps) {
 
   message("# Apply linear interpolation to submission data")
 
@@ -348,11 +348,10 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
     dplyr::pull("variable") %>%
     unique()
 
+  timesteps <- intersect(timesteps, seq(min(submission$period), max(submission$period), 1))
   tmp <- submission %>%
     filter(.data$variable %in% intVars) %>%
-    quitte::interpolate_missing_periods(method = "linear",
-                                        period = seq(min(submission$period),
-                                                     max(submission$period), 1))
+    quitte::interpolate_missing_periods(method = "linear", period = timesteps)
 
   return(rbind(filter(submission, !.data$variable %in% intVars), tmp))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.45.20**
+R package **piamInterfaces**, version **0.45.21**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -162,7 +162,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.20, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.21, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -170,9 +170,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-03-07},
+  date = {2025-03-10},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.45.20},
+  note = {Version: 0.45.21},
 }
 ```

--- a/man/generateIIASASubmission.Rd
+++ b/man/generateIIASASubmission.Rd
@@ -17,7 +17,7 @@ generateIIASASubmission(
     "_log.txt", outputFilename)),
   iiasatemplate = NULL,
   generatePlots = FALSE,
-  timesteps = c(seq(2005, 2060, 5), seq(2070, 2100, 10)),
+  timesteps = seq(2005, 2100, 1),
   checkSummation = TRUE,
   mappingFile = NULL,
   naAction = "na.omit"

--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -112,7 +112,8 @@ test_that("interpolation for ScenarioMIP works as expected", {
   result <- generateIIASASubmission(
     mifs = data,
     mapping = "ScenarioMIP",
-    outputFilename = NULL
+    outputFilename = NULL,
+    timesteps = seq(2005, 2020, 1)
   )
 
   expect_true(all(seq(2005, 2020, 1) %in% unique(result$period)))


### PR DESCRIPTION
## Purpose of this PR

- close #474 
- the change does not alter the default behavior for REMIND, I think, but you can at least kick out the intermediate steps by defining `timesteps` differently.

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
