### PR TITLE
Add extensive summation checks for ScenarioMIP

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '91179157'
+ValidationKey: '9274060'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.45.23
-date-released: '2025-03-12'
+version: 0.46.0
+date-released: '2025-03-14'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.45.23
-Date: 2025-03-12
+Version: 0.46.0
+Date: 2025-03-14
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.45.23**
+R package **piamInterfaces**, version **0.46.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -162,7 +162,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.45.23, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.46.0, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -170,9 +170,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-03-12},
+  date = {2025-03-14},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.45.23},
+  note = {Version: 0.46.0},
 }
 ```

--- a/inst/summations/summation_groups_ScenarioMIP.csv
+++ b/inst/summations/summation_groups_ScenarioMIP.csv
@@ -1,5 +1,1446 @@
 parent;child;factor
 #  Variables that need add up for the emissions harmonization process (see https://docs.google.com/spreadsheets/d/1HKfl21NX8wohPEHpHlmf5XithknPw8zjLpVe4MiOU9U/edit?gid=1877841403#gid=1877841403);;
+## Total BC;;
+Emissions|BC 2;Emissions|BC|Energy|Supply;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Industry;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Other Sector;1
+Emissions|BC 2;Emissions|BC|Industrial Processes;1
+Emissions|BC 2;Emissions|BC|Other;1
+Emissions|BC 2;Emissions|BC|Other Capture and Removal;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Transportation;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Bunkers|International Shipping;1
+Emissions|BC 2;Emissions|BC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|BC 2;Emissions|BC|Product Use;1
+Emissions|BC 2;Emissions|BC|AFOLU|Agriculture;1
+Emissions|BC 2;Emissions|BC|AFOLU|Agricultural Waste Burning;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Fires|Peat Burning;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Harvested Wood Products;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Other;1
+Emissions|BC 2;Emissions|BC|AFOLU|Land|Wetlands;1
+Emissions|BC 2;Emissions|BC|Waste;1
+;;
+## Total CH4;;
+Emissions|CH4 2;Emissions|CH4|Energy|Supply;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Industry;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Other Sector;1
+Emissions|CH4 2;Emissions|CH4|Industrial Processes;1
+Emissions|CH4 2;Emissions|CH4|Other;1
+Emissions|CH4 2;Emissions|CH4|Other Capture and Removal;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Bunkers|International Aviation;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Transportation;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Bunkers|International Shipping;1
+Emissions|CH4 2;Emissions|CH4|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|CH4 2;Emissions|CH4|Product Use;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Agriculture;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Agricultural Waste Burning;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Fires|Forest Burning;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Fires|Peat Burning;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Harvested Wood Products;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Other;1
+Emissions|CH4 2;Emissions|CH4|AFOLU|Land|Wetlands;1
+Emissions|CH4 2;Emissions|CH4|Waste;1
+;;
+## Total CO;;
+Emissions|CO 2;Emissions|CO|Energy|Supply;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Industry;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Other Sector;1
+Emissions|CO 2;Emissions|CO|Industrial Processes;1
+Emissions|CO 2;Emissions|CO|Other;1
+Emissions|CO 2;Emissions|CO|Other Capture and Removal;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Bunkers|International Aviation;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Transportation;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Bunkers|International Shipping;1
+Emissions|CO 2;Emissions|CO|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|CO 2;Emissions|CO|Product Use;1
+Emissions|CO 2;Emissions|CO|AFOLU|Agriculture;1
+Emissions|CO 2;Emissions|CO|AFOLU|Agricultural Waste Burning;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Fires|Forest Burning;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Fires|Peat Burning;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Harvested Wood Products;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Other;1
+Emissions|CO 2;Emissions|CO|AFOLU|Land|Wetlands;1
+Emissions|CO 2;Emissions|CO|Waste;1
+;;
+## Total NH3;;
+Emissions|NH3 2;Emissions|NH3|Energy|Supply;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Industry;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Other Sector;1
+Emissions|NH3 2;Emissions|NH3|Industrial Processes;1
+Emissions|NH3 2;Emissions|NH3|Other;1
+Emissions|NH3 2;Emissions|NH3|Other Capture and Removal;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Bunkers|International Aviation;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Transportation;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Bunkers|International Shipping;1
+Emissions|NH3 2;Emissions|NH3|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|NH3 2;Emissions|NH3|Product Use;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Agriculture;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Agricultural Waste Burning;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Fires|Forest Burning;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Fires|Peat Burning;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Harvested Wood Products;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Other;1
+Emissions|NH3 2;Emissions|NH3|AFOLU|Land|Wetlands;1
+Emissions|NH3 2;Emissions|NH3|Waste;1
+;;
+## Total N2O;;
+Emissions|N2O 2;Emissions|N2O|Energy|Supply;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Industry;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Other Sector;1
+Emissions|N2O 2;Emissions|N2O|Industrial Processes;1
+Emissions|N2O 2;Emissions|N2O|Other;1
+Emissions|N2O 2;Emissions|N2O|Other Capture and Removal;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Bunkers|International Aviation;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Transportation;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Bunkers|International Shipping;1
+Emissions|N2O 2;Emissions|N2O|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|N2O 2;Emissions|N2O|Product Use;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Agriculture;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Agricultural Waste Burning;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Fires|Forest Burning;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Fires|Peat Burning;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Harvested Wood Products;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Other;1
+Emissions|N2O 2;Emissions|N2O|AFOLU|Land|Wetlands;1
+Emissions|N2O 2;Emissions|N2O|Waste;1
+;;
+## Total NOx;;
+Emissions|NOx 2;Emissions|NOx|Energy|Supply;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Industry;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Other Sector;1
+Emissions|NOx 2;Emissions|NOx|Industrial Processes;1
+Emissions|NOx 2;Emissions|NOx|Other;1
+Emissions|NOx 2;Emissions|NOx|Other Capture and Removal;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Bunkers|International Aviation;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Transportation;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Bunkers|International Shipping;1
+Emissions|NOx 2;Emissions|NOx|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|NOx 2;Emissions|NOx|Product Use;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Agriculture;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Agricultural Waste Burning;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Fires|Forest Burning;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Fires|Peat Burning;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Harvested Wood Products;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Other;1
+Emissions|NOx 2;Emissions|NOx|AFOLU|Land|Wetlands;1
+Emissions|NOx 2;Emissions|NOx|Waste;1
+;;
+## Total OC;;
+Emissions|OC 2;Emissions|OC|Energy|Supply;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Industry;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Other Sector;1
+Emissions|OC 2;Emissions|OC|Industrial Processes;1
+Emissions|OC 2;Emissions|OC|Other;1
+Emissions|OC 2;Emissions|OC|Other Capture and Removal;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Transportation;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Bunkers|International Shipping;1
+Emissions|OC 2;Emissions|OC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|OC 2;Emissions|OC|Product Use;1
+Emissions|OC 2;Emissions|OC|AFOLU|Agriculture;1
+Emissions|OC 2;Emissions|OC|AFOLU|Agricultural Waste Burning;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Fires|Peat Burning;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Harvested Wood Products;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Other;1
+Emissions|OC 2;Emissions|OC|AFOLU|Land|Wetlands;1
+Emissions|OC 2;Emissions|OC|Waste;1
+;;
+## Total Sulfur;;
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Supply;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Industry;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Other Sector;1
+Emissions|Sulfur 2;Emissions|Sulfur|Industrial Processes;1
+Emissions|Sulfur 2;Emissions|Sulfur|Other;1
+Emissions|Sulfur 2;Emissions|Sulfur|Other Capture and Removal;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Bunkers|International Aviation;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Transportation;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Bunkers|International Shipping;1
+Emissions|Sulfur 2;Emissions|Sulfur|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|Sulfur 2;Emissions|Sulfur|Product Use;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Agriculture;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Agricultural Waste Burning;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Fires|Forest Burning;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Fires|Peat Burning;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Harvested Wood Products;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Other;1
+Emissions|Sulfur 2;Emissions|Sulfur|AFOLU|Land|Wetlands;1
+Emissions|Sulfur 2;Emissions|Sulfur|Waste;1
+;;
+## Total VOC;;
+Emissions|VOC 2;Emissions|VOC|Energy|Supply;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Industry;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Other Sector;1
+Emissions|VOC 2;Emissions|VOC|Industrial Processes;1
+Emissions|VOC 2;Emissions|VOC|Other;1
+Emissions|VOC 2;Emissions|VOC|Other Capture and Removal;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Transportation;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Bunkers|International Shipping;1
+Emissions|VOC 2;Emissions|VOC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|VOC 2;Emissions|VOC|Product Use;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Agriculture;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Agricultural Waste Burning;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Fires|Peat Burning;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Harvested Wood Products;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Other;1
+Emissions|VOC 2;Emissions|VOC|AFOLU|Land|Wetlands;1
+Emissions|VOC 2;Emissions|VOC|Waste;1
+;;
+# Extensive summation checks;;
+Agricultural Demand;Agricultural Demand|Crops;1
+Agricultural Demand;Agricultural Demand|Livestock;1
+Agricultural Demand;Agricultural Demand|Residues;1
+;;
+Agricultural Demand|Crops;Agricultural Demand|Crops|Bioenergy;1
+Agricultural Demand|Crops;Agricultural Demand|Crops|Feed;1
+Agricultural Demand|Crops;Agricultural Demand|Crops|Food;1
+Agricultural Demand|Crops;Agricultural Demand|Crops|Other;1
+;;
+Agricultural Demand|Crops|Bioenergy;Agricultural Demand|Crops|Bioenergy|1st Generation;1
+Agricultural Demand|Crops|Bioenergy;Agricultural Demand|Crops|Bioenergy|2nd generation;1
+;;
+Agricultural Demand|Crops|Feed;Agricultural Demand|Crops|Feed|Cereals;1
+Agricultural Demand|Crops|Feed;Agricultural Demand|Crops|Feed|Oil Crops;1
+Agricultural Demand|Crops|Feed;Agricultural Demand|Crops|Feed|Other Crops;1
+Agricultural Demand|Crops|Feed;Agricultural Demand|Crops|Feed|Sugar Crops;1
+;;
+Agricultural Demand|Crops|Food;Agricultural Demand|Crops|Food|Cereals;1
+Agricultural Demand|Crops|Food;Agricultural Demand|Crops|Food|Oil Crops;1
+Agricultural Demand|Crops|Food;Agricultural Demand|Crops|Food|Other Crops;1
+Agricultural Demand|Crops|Food;Agricultural Demand|Crops|Food|Sugar Crops;1
+;;
+Agricultural Demand|Livestock;Agricultural Demand|Livestock|Feed;1
+Agricultural Demand|Livestock;Agricultural Demand|Livestock|Food;1
+Agricultural Demand|Livestock;Agricultural Demand|Livestock|Other;1
+;;
+Agricultural Demand|Livestock|Food;Agricultural Demand|Livestock|Food|Non-Ruminant;1
+Agricultural Demand|Livestock|Food;Agricultural Demand|Livestock|Food|Ruminant;1
+;;
+Agricultural Demand|Livestock|Food|Non-Ruminant;Agricultural Demand|Livestock|Food|Non-Ruminant|Eggs;1
+Agricultural Demand|Livestock|Food|Non-Ruminant;Agricultural Demand|Livestock|Food|Non-Ruminant|Meat;1
+;;
+Agricultural Demand|Livestock|Food|Non-Ruminant|Meat;Agricultural Demand|Livestock|Food|Non-Ruminant|Meat|Pig;1
+Agricultural Demand|Livestock|Food|Non-Ruminant|Meat;Agricultural Demand|Livestock|Food|Non-Ruminant|Meat|Poultry;1
+;;
+Agricultural Demand|Livestock|Food|Ruminant;Agricultural Demand|Livestock|Food|Ruminant|Dairy;1
+Agricultural Demand|Livestock|Food|Ruminant;Agricultural Demand|Livestock|Food|Ruminant|Meat;1
+;;
+Agricultural Demand|Residues;Agricultural Demand|Residues|Bioenergy;1
+Agricultural Demand|Residues;Agricultural Demand|Residues|Feed;1
+Agricultural Demand|Residues;Agricultural Demand|Residues|Other;1
+;;
+Agricultural Production;Agricultural Production|Crops;1
+Agricultural Production;Agricultural Production|Livestock;1
+Agricultural Production;Agricultural Production|Residues;1
+;;
+Agricultural Production|Crops;Agricultural Production|Crops|Cereals;1
+Agricultural Production|Crops;Agricultural Production|Crops|Energy Crops;1
+Agricultural Production|Crops;Agricultural Production|Crops|Oil Crops;1
+Agricultural Production|Crops;Agricultural Production|Crops|Other Crops;1
+Agricultural Production|Crops;Agricultural Production|Crops|Sugar Crops;1
+;;
+Agricultural Production|Livestock;Agricultural Production|Livestock|Non-Ruminant;1
+Agricultural Production|Livestock;Agricultural Production|Livestock|Ruminant;1
+;;
+Agricultural Production|Livestock|Non-Ruminant;Agricultural Production|Livestock|Non-Ruminant|Eggs;1
+Agricultural Production|Livestock|Non-Ruminant;Agricultural Production|Livestock|Non-Ruminant|Meat;1
+;;
+Agricultural Production|Livestock|Non-Ruminant|Meat;Agricultural Production|Livestock|Non-Ruminant|Meat|Pig;1
+Agricultural Production|Livestock|Non-Ruminant|Meat;Agricultural Production|Livestock|Non-Ruminant|Meat|Poultry;1
+;;
+Agricultural Production|Livestock|Ruminant;Agricultural Production|Livestock|Ruminant|Dairy;1
+Agricultural Production|Livestock|Ruminant;Agricultural Production|Livestock|Ruminant|Meat;1
+;;
+Capacity Additions|Electricity;Capacity Additions|Electricity|Ammonia;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Biomass;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Coal;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Geothermal;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Hydro;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Hydrogen;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Gas;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Nuclear;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Ocean;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Oil;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Other;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Solar;1
+Capacity Additions|Electricity;Capacity Additions|Electricity|Wind;1
+;;
+Capacity Additions|Electricity|Fossil;Capacity Additions|Electricity|Coal;1
+Capacity Additions|Electricity|Fossil;Capacity Additions|Electricity|Gas;1
+Capacity Additions|Electricity|Fossil;Capacity Additions|Electricity|Oil;1
+;;
+Capacity Additions|Electricity|Non-Biomass Renewables;Capacity Additions|Electricity|Geothermal;1
+Capacity Additions|Electricity|Non-Biomass Renewables;Capacity Additions|Electricity|Hydro;1
+Capacity Additions|Electricity|Non-Biomass Renewables;Capacity Additions|Electricity|Ocean;1
+Capacity Additions|Electricity|Non-Biomass Renewables;Capacity Additions|Electricity|Solar;1
+Capacity Additions|Electricity|Non-Biomass Renewables;Capacity Additions|Electricity|Wind;1
+;;
+Capacity Additions|Electricity|Biomass;Capacity Additions|Electricity|Biomass|w/ CCS;1
+Capacity Additions|Electricity|Biomass;Capacity Additions|Electricity|Biomass|w/o CCS;1
+;;
+Capacity Additions|Electricity|Coal;Capacity Additions|Electricity|Coal|w/ CCS;1
+Capacity Additions|Electricity|Coal;Capacity Additions|Electricity|Coal|w/o CCS;1
+;;
+Capacity Additions|Electricity|Fossil;Capacity Additions|Electricity|Fossil|w/ CCS;1
+Capacity Additions|Electricity|Fossil;Capacity Additions|Electricity|Fossil|w/o CCS;1
+;;
+Capacity Additions|Electricity|Gas;Capacity Additions|Electricity|Gas|w/ CCS;1
+Capacity Additions|Electricity|Gas;Capacity Additions|Electricity|Gas|w/o CCS;1
+;;
+Capacity Additions|Electricity|Oil;Capacity Additions|Electricity|Oil|w/ CCS;1
+Capacity Additions|Electricity|Oil;Capacity Additions|Electricity|Oil|w/o CCS;1
+;;
+Capacity Additions|Electricity|Solar;Capacity Additions|Electricity|Solar|CSP;1
+Capacity Additions|Electricity|Solar;Capacity Additions|Electricity|Solar|PV;1
+;;
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Agri-PV;1
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Commercial;1
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Floating;1
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Open Land;1
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Other;1
+Capacity Additions|Electricity|Solar|PV;Capacity Additions|Electricity|Solar|PV|Residential;1
+;;
+Capacity Additions|Electricity|Wind;Capacity Additions|Electricity|Wind|Offshore;1
+Capacity Additions|Electricity|Wind;Capacity Additions|Electricity|Wind|Onshore;1
+;;
+Capacity Additions|Gases;Capacity Additions|Gases|Biomass;1
+Capacity Additions|Gases;Capacity Additions|Gases|Coal;1
+Capacity Additions|Gases;Capacity Additions|Gases|Electricity;1
+Capacity Additions|Gases;Capacity Additions|Gases|Gas;1
+Capacity Additions|Gases;Capacity Additions|Gases|Hydrogen;1
+Capacity Additions|Gases;Capacity Additions|Gases|Other;1
+;;
+Capacity Additions|Gases|Fossil;Capacity Additions|Gases|Coal;1
+Capacity Additions|Gases|Fossil;Capacity Additions|Gases|Gas;1
+;;
+Capacity Additions|Heat;Capacity Additions|Heat|Biomass;1
+Capacity Additions|Heat;Capacity Additions|Heat|Coal;1
+Capacity Additions|Heat;Capacity Additions|Heat|Electricity;1
+Capacity Additions|Heat;Capacity Additions|Heat|Gas;1
+Capacity Additions|Heat;Capacity Additions|Heat|Geothermal;1
+Capacity Additions|Heat;Capacity Additions|Heat|Hydrogen;1
+Capacity Additions|Heat;Capacity Additions|Heat|Nuclear;1
+Capacity Additions|Heat;Capacity Additions|Heat|Oil;1
+Capacity Additions|Heat;Capacity Additions|Heat|Other;1
+Capacity Additions|Heat;Capacity Additions|Heat|Solar;1
+;;
+Capacity Additions|Heat|Fossil;Capacity Additions|Heat|Coal;1
+Capacity Additions|Heat|Fossil;Capacity Additions|Heat|Gas;1
+Capacity Additions|Heat|Fossil;Capacity Additions|Heat|Oil;1
+;;
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Biomass;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Coal;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Electricity;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Gas;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Nuclear;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Oil;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Other;1
+Capacity Additions|Hydrogen;Capacity Additions|Hydrogen|Solar;1
+;;
+Capacity Additions|Hydrogen|Fossil;Capacity Additions|Hydrogen|Coal;1
+Capacity Additions|Hydrogen|Fossil;Capacity Additions|Hydrogen|Gas;1
+Capacity Additions|Hydrogen|Fossil;Capacity Additions|Hydrogen|Oil;1
+;;
+Capacity Additions|Liquids;Capacity Additions|Liquids|Biomass;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Coal;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Electricity;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Gas;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Hydrogen;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Oil;1
+Capacity Additions|Liquids;Capacity Additions|Liquids|Other;1
+;;
+Capacity Additions|Liquids|Fossil;Capacity Additions|Liquids|Coal;1
+Capacity Additions|Liquids|Fossil;Capacity Additions|Liquids|Gas;1
+Capacity Additions|Liquids|Fossil;Capacity Additions|Liquids|Oil;1
+;;
+Capacity Additions|Solids;Capacity Additions|Solids|Biomass;1
+Capacity Additions|Solids;Capacity Additions|Solids|Coal;1
+;;
+Capacity|Electricity;Capacity|Electricity|Ammonia;1
+Capacity|Electricity;Capacity|Electricity|Biomass;1
+Capacity|Electricity;Capacity|Electricity|Coal;1
+Capacity|Electricity;Capacity|Electricity|Gas;1
+Capacity|Electricity;Capacity|Electricity|Geothermal;1
+Capacity|Electricity;Capacity|Electricity|Hydro;1
+Capacity|Electricity;Capacity|Electricity|Hydrogen;1
+Capacity|Electricity;Capacity|Electricity|Nuclear;1
+Capacity|Electricity;Capacity|Electricity|Ocean;1
+Capacity|Electricity;Capacity|Electricity|Oil;1
+Capacity|Electricity;Capacity|Electricity|Other;1
+Capacity|Electricity;Capacity|Electricity|Solar;1
+Capacity|Electricity;Capacity|Electricity|Wind;1
+;;
+Capacity|Electricity|Fossil;Capacity|Electricity|Coal;1
+Capacity|Electricity|Fossil;Capacity|Electricity|Gas;1
+Capacity|Electricity|Fossil;Capacity|Electricity|Oil;1
+;;
+Capacity|Electricity|Non-Biomass Renewables;Capacity|Electricity|Geothermal;1
+Capacity|Electricity|Non-Biomass Renewables;Capacity|Electricity|Hydro;1
+Capacity|Electricity|Non-Biomass Renewables;Capacity|Electricity|Ocean;1
+Capacity|Electricity|Non-Biomass Renewables;Capacity|Electricity|Solar;1
+Capacity|Electricity|Non-Biomass Renewables;Capacity|Electricity|Wind;1
+;;
+Capacity|Electricity|Biomass;Capacity|Electricity|Biomass|w/ CCS;1
+Capacity|Electricity|Biomass;Capacity|Electricity|Biomass|w/o CCS;1
+;;
+Capacity|Electricity|Coal;Capacity|Electricity|Coal|w/ CCS;1
+Capacity|Electricity|Coal;Capacity|Electricity|Coal|w/o CCS;1
+;;
+Capacity|Electricity|Fossil;Capacity|Electricity|Fossil|w/ CCS;1
+Capacity|Electricity|Fossil;Capacity|Electricity|Fossil|w/o CCS;1
+;;
+Capacity|Electricity|Gas;Capacity|Electricity|Gas|w/ CCS;1
+Capacity|Electricity|Gas;Capacity|Electricity|Gas|w/o CCS;1
+;;
+Capacity|Electricity|Oil;Capacity|Electricity|Oil|w/ CCS;1
+Capacity|Electricity|Oil;Capacity|Electricity|Oil|w/o CCS;1
+;;
+Capacity|Electricity|Solar;Capacity|Electricity|Solar|CSP;1
+Capacity|Electricity|Solar;Capacity|Electricity|Solar|PV;1
+;;
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Agri-PV;1
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Commercial;1
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Floating;1
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Open Land;1
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Other;1
+Capacity|Electricity|Solar|PV;Capacity|Electricity|Solar|PV|Residential;1
+;;
+Capacity|Electricity|Wind;Capacity|Electricity|Wind|Offshore;1
+Capacity|Electricity|Wind;Capacity|Electricity|Wind|Onshore;1
+;;
+Capacity|Gases;Capacity|Gases|Biomass;1
+Capacity|Gases;Capacity|Gases|Coal;1
+Capacity|Gases;Capacity|Gases|Electricity;1
+Capacity|Gases;Capacity|Gases|Gas;1
+Capacity|Gases;Capacity|Gases|Hydrogen;1
+Capacity|Gases;Capacity|Gases|Other;1
+;;
+Capacity|Gases|Fossil;Capacity|Gases|Coal;1
+Capacity|Gases|Fossil;Capacity|Gases|Gas;1
+;;
+Capacity|Gases 2;Capacity|Gases|w/ CCS;1
+Capacity|Gases 2;Capacity|Gases|w/o CCS;1
+;;
+Capacity|Gases|Biomass;Capacity|Gases|Biomass|w/ CCS;1
+Capacity|Gases|Biomass;Capacity|Gases|Biomass|w/o CCS;1
+;;
+Capacity|Gases|Coal;Capacity|Gases|Coal|w/ CCS;1
+Capacity|Gases|Coal;Capacity|Gases|Coal|w/o CCS;1
+;;
+Capacity|Gases|Electricity;Capacity|Gases|Electricity|w/ CCS;1
+Capacity|Gases|Electricity;Capacity|Gases|Electricity|w/o CCS;1
+;;
+Capacity|Gases|Fossil;Capacity|Gases|Fossil|w/ CCS;1
+Capacity|Gases|Fossil;Capacity|Gases|Fossil|w/o CCS;1
+;;
+Capacity|Gases|Gas;Capacity|Gases|Gas|w/ CCS;1
+Capacity|Gases|Gas;Capacity|Gases|Gas|w/o CCS;1
+;;
+Capacity|Gases|Hydrogen;Capacity|Gases|Hydrogen|w/ CCS;1
+Capacity|Gases|Hydrogen;Capacity|Gases|Hydrogen|w/o CCS;1
+;;
+Capacity|Gases|Other;Capacity|Gases|Other|w/ CCS;1
+Capacity|Gases|Other;Capacity|Gases|Other|w/o CCS;1
+;;
+Capacity|Heat;Capacity|Heat|Biomass;1
+Capacity|Heat;Capacity|Heat|Coal;1
+Capacity|Heat;Capacity|Heat|Electricity;1
+Capacity|Heat;Capacity|Heat|Gas;1
+Capacity|Heat;Capacity|Heat|Geothermal;1
+Capacity|Heat;Capacity|Heat|Hydrogen;1
+Capacity|Heat;Capacity|Heat|Nuclear;1
+Capacity|Heat;Capacity|Heat|Oil;1
+Capacity|Heat;Capacity|Heat|Other;1
+Capacity|Heat;Capacity|Heat|Solar;1
+;;
+Capacity|Heat|Fossil;Capacity|Heat|Coal;1
+Capacity|Heat|Fossil;Capacity|Heat|Gas;1
+Capacity|Heat|Fossil;Capacity|Heat|Oil;1
+;;
+Capacity|Heat 2;Capacity|Heat|w/ CCS;1
+Capacity|Heat 2;Capacity|Heat|w/o CCS;1
+;;
+Capacity|Heat|Biomass;Capacity|Heat|Biomass|w/ CCS;1
+Capacity|Heat|Biomass;Capacity|Heat|Biomass|w/o CCS;1
+;;
+Capacity|Heat|Coal;Capacity|Heat|Coal|w/ CCS;1
+Capacity|Heat|Coal;Capacity|Heat|Coal|w/o CCS;1
+;;
+Capacity|Heat|Electricity;Capacity|Heat|Electricity|w/ CCS;1
+Capacity|Heat|Electricity;Capacity|Heat|Electricity|w/o CCS;1
+;;
+Capacity|Heat|Fossil;Capacity|Heat|Fossil|w/ CCS;1
+Capacity|Heat|Fossil;Capacity|Heat|Fossil|w/o CCS;1
+;;
+Capacity|Heat|Gas;Capacity|Heat|Gas|w/ CCS;1
+Capacity|Heat|Gas;Capacity|Heat|Gas|w/o CCS;1
+;;
+Capacity|Heat|Geothermal;Capacity|Heat|Geothermal|w/ CCS;1
+Capacity|Heat|Geothermal;Capacity|Heat|Geothermal|w/o CCS;1
+;;
+Capacity|Heat|Hydrogen;Capacity|Heat|Hydrogen|w/ CCS;1
+Capacity|Heat|Hydrogen;Capacity|Heat|Hydrogen|w/o CCS;1
+;;
+Capacity|Heat|Nuclear;Capacity|Heat|Nuclear|w/ CCS;1
+Capacity|Heat|Nuclear;Capacity|Heat|Nuclear|w/o CCS;1
+;;
+Capacity|Heat|Oil;Capacity|Heat|Oil|w/ CCS;1
+Capacity|Heat|Oil;Capacity|Heat|Oil|w/o CCS;1
+;;
+Capacity|Heat|Other;Capacity|Heat|Other|w/ CCS;1
+Capacity|Heat|Other;Capacity|Heat|Other|w/o CCS;1
+;;
+Capacity|Heat|Solar;Capacity|Heat|Solar|w/ CCS;1
+Capacity|Heat|Solar;Capacity|Heat|Solar|w/o CCS;1
+;;
+Capacity|Hydrogen;Capacity|Hydrogen|Biomass;1
+Capacity|Hydrogen;Capacity|Hydrogen|Coal;1
+Capacity|Hydrogen;Capacity|Hydrogen|Electricity;1
+Capacity|Hydrogen;Capacity|Hydrogen|Gas;1
+Capacity|Hydrogen;Capacity|Hydrogen|Nuclear;1
+Capacity|Hydrogen;Capacity|Hydrogen|Oil;1
+Capacity|Hydrogen;Capacity|Hydrogen|Other;1
+Capacity|Hydrogen;Capacity|Hydrogen|Solar;1
+;;
+Capacity|Hydrogen|Fossil;Capacity|Hydrogen|Coal;1
+Capacity|Hydrogen|Fossil;Capacity|Hydrogen|Gas;1
+Capacity|Hydrogen|Fossil;Capacity|Hydrogen|Oil;1
+;;
+Capacity|Hydrogen 2;Capacity|Hydrogen|w/ CCS;1
+Capacity|Hydrogen 2;Capacity|Hydrogen|w/o CCS;1
+;;
+Capacity|Hydrogen|Biomass;Capacity|Hydrogen|Biomass|w/ CCS;1
+Capacity|Hydrogen|Biomass;Capacity|Hydrogen|Biomass|w/o CCS;1
+;;
+Capacity|Hydrogen|Coal;Capacity|Hydrogen|Coal|w/ CCS;1
+Capacity|Hydrogen|Coal;Capacity|Hydrogen|Coal|w/o CCS;1
+;;
+Capacity|Hydrogen|Electricity;Capacity|Hydrogen|Electricity|w/ CCS;1
+Capacity|Hydrogen|Electricity;Capacity|Hydrogen|Electricity|w/o CCS;1
+;;
+Capacity|Hydrogen|Fossil;Capacity|Hydrogen|Fossil|w/ CCS;1
+Capacity|Hydrogen|Fossil;Capacity|Hydrogen|Fossil|w/o CCS;1
+;;
+Capacity|Hydrogen|Gas;Capacity|Hydrogen|Gas|w/ CCS;1
+Capacity|Hydrogen|Gas;Capacity|Hydrogen|Gas|w/o CCS;1
+;;
+Capacity|Hydrogen|Nuclear;Capacity|Hydrogen|Nuclear|w/ CCS;1
+Capacity|Hydrogen|Nuclear;Capacity|Hydrogen|Nuclear|w/o CCS;1
+;;
+Capacity|Hydrogen|Oil;Capacity|Hydrogen|Oil|w/ CCS;1
+Capacity|Hydrogen|Oil;Capacity|Hydrogen|Oil|w/o CCS;1
+;;
+Capacity|Hydrogen|Other;Capacity|Hydrogen|Other|w/ CCS;1
+Capacity|Hydrogen|Other;Capacity|Hydrogen|Other|w/o CCS;1
+;;
+Capacity|Hydrogen|Solar;Capacity|Hydrogen|Solar|w/ CCS;1
+Capacity|Hydrogen|Solar;Capacity|Hydrogen|Solar|w/o CCS;1
+;;
+Capacity|Liquids;Capacity|Liquids|Biomass;1
+Capacity|Liquids;Capacity|Liquids|Coal;1
+Capacity|Liquids;Capacity|Liquids|Electricity;1
+Capacity|Liquids;Capacity|Liquids|Gas;1
+Capacity|Liquids;Capacity|Liquids|Hydrogen;1
+Capacity|Liquids;Capacity|Liquids|Oil;1
+Capacity|Liquids;Capacity|Liquids|Other;1
+;;
+Capacity|Liquids 2;Capacity|Liquids|w/ CCS;1
+Capacity|Liquids 2;Capacity|Liquids|w/o CCS;1
+;;
+Capacity|Liquids|Fossil;Capacity|Liquids|Coal;1
+Capacity|Liquids|Fossil;Capacity|Liquids|Gas;1
+Capacity|Liquids|Fossil;Capacity|Liquids|Oil;1
+;;
+Capacity|Liquids|Biomass;Capacity|Liquids|Biomass|w/ CCS;1
+Capacity|Liquids|Biomass;Capacity|Liquids|Biomass|w/o CCS;1
+;;
+Capacity|Liquids|Coal;Capacity|Liquids|Coal|w/ CCS;1
+Capacity|Liquids|Coal;Capacity|Liquids|Coal|w/o CCS;1
+;;
+Capacity|Liquids|Electricity;Capacity|Liquids|Electricity|w/ CCS;1
+Capacity|Liquids|Electricity;Capacity|Liquids|Electricity|w/o CCS;1
+;;
+Capacity|Liquids|Fossil;Capacity|Liquids|Fossil|w/ CCS;1
+Capacity|Liquids|Fossil;Capacity|Liquids|Fossil|w/o CCS;1
+;;
+Capacity|Liquids|Gas;Capacity|Liquids|Gas|w/ CCS;1
+Capacity|Liquids|Gas;Capacity|Liquids|Gas|w/o CCS;1
+;;
+Capacity|Liquids|Hydrogen;Capacity|Liquids|Hydrogen|w/ CCS;1
+Capacity|Liquids|Hydrogen;Capacity|Liquids|Hydrogen|w/o CCS;1
+;;
+Capacity|Liquids|Oil;Capacity|Liquids|Oil|w/ CCS;1
+Capacity|Liquids|Oil;Capacity|Liquids|Oil|w/o CCS;1
+;;
+Capacity|Liquids|Other;Capacity|Liquids|Other|w/ CCS;1
+Capacity|Liquids|Other;Capacity|Liquids|Other|w/o CCS;1
+;;
+Capacity|Solids;Capacity|Solids|Biomass;1
+Capacity|Solids;Capacity|Solids|Coal;1
+;;
+Capacity|Solids 2;Capacity|Solids|w/ CCS;1
+Capacity|Solids 2;Capacity|Solids|w/o CCS;1
+;;
+Capacity|Solids|Biomass;Capacity|Solids|Biomass|w/ CCS;1
+Capacity|Solids|Biomass;Capacity|Solids|Biomass|w/o CCS;1
+;;
+Capacity|Solids|Coal;Capacity|Solids|Coal|w/ CCS;1
+Capacity|Solids|Coal;Capacity|Solids|Coal|w/o CCS;1
+;;
+Carbon Capture;Carbon Capture|Direct Air Capture;1
+Carbon Capture;Carbon Capture|Direct Ocean Capture;1
+Carbon Capture;Carbon Capture|Energy;1
+Carbon Capture;Carbon Capture|Industrial Processes;1
+Carbon Capture;Carbon Capture|Other Sources;1
+;;
+Carbon Capture 2;Carbon Capture|Geological Storage;1
+Carbon Capture 2;Carbon Capture|Leakage;1
+Carbon Capture 2;Carbon Capture|Other Storage;1
+Carbon Capture 2;Carbon Capture|Utilization;1
+;;
+Carbon Capture|Energy;Carbon Capture|Energy|Biomass;1
+Carbon Capture|Energy;Carbon Capture|Energy|Fossil;1
+Carbon Capture|Energy;Carbon Capture|Energy|Synthetic Fuels;1
+;;
+Carbon Capture|Energy 2;Carbon Capture|Energy|Demand;1
+Carbon Capture|Energy 2;Carbon Capture|Energy|Supply;1
+;;
+Carbon Capture|Energy|Demand;Carbon Capture|Energy|Demand|Biomass;1
+Carbon Capture|Energy|Demand;Carbon Capture|Energy|Demand|Fossil;1
+Carbon Capture|Energy|Demand;Carbon Capture|Energy|Demand|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Chemicals;1
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Iron and Steel;1
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals;1
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals;1
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Other Sector;1
+Carbon Capture|Energy|Demand|Industry;Carbon Capture|Energy|Demand|Industry|Pulp and Paper;1
+;;
+Carbon Capture|Energy|Demand|Industry 2;Carbon Capture|Energy|Demand|Industry|Biomass;1
+Carbon Capture|Energy|Demand|Industry 2;Carbon Capture|Energy|Demand|Industry|Fossil;1
+Carbon Capture|Energy|Demand|Industry 2;Carbon Capture|Energy|Demand|Industry|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Chemicals;Carbon Capture|Energy|Demand|Industry|Chemicals|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Chemicals;Carbon Capture|Energy|Demand|Industry|Chemicals|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Chemicals;Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Chemicals|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Iron and Steel;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Iron and Steel;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Iron and Steel;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Iron and Steel|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Ferrous Metals|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Non-Metallic Minerals|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Other Sector;Carbon Capture|Energy|Demand|Industry|Other Sector|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Other Sector;Carbon Capture|Energy|Demand|Industry|Other Sector|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Other Sector;Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Other Sector|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Biomass;1
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Pulp and Paper|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Industry|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Industry|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Industry|Synthetic Fuels;Carbon Capture|Energy|Demand|Industry|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Demand|Synthetic Fuels;Carbon Capture|Energy|Demand|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Demand|Synthetic Fuels;Carbon Capture|Energy|Demand|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Demand|Synthetic Fuels;Carbon Capture|Energy|Demand|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Electricity;1
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Gases;1
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Heat;1
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Hydrogen;1
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Liquids;1
+Carbon Capture|Energy|Supply;Carbon Capture|Energy|Supply|Solids;1
+;;
+Carbon Capture|Energy|Supply 2;Carbon Capture|Energy|Supply|Biomass;1
+Carbon Capture|Energy|Supply 2;Carbon Capture|Energy|Supply|Fossil;1
+Carbon Capture|Energy|Supply 2;Carbon Capture|Energy|Supply|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Electricity;Carbon Capture|Energy|Supply|Electricity|Biomass;1
+Carbon Capture|Energy|Supply|Electricity;Carbon Capture|Energy|Supply|Electricity|Fossil;1
+Carbon Capture|Energy|Supply|Electricity;Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels;Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels;Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels;Carbon Capture|Energy|Supply|Electricity|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Gases;Carbon Capture|Energy|Supply|Gases|Biomass;1
+Carbon Capture|Energy|Supply|Gases;Carbon Capture|Energy|Supply|Gases|Fossil;1
+Carbon Capture|Energy|Supply|Gases;Carbon Capture|Energy|Supply|Gases|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Gases|Synthetic Fuels;Carbon Capture|Energy|Supply|Gases|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Gases|Synthetic Fuels;Carbon Capture|Energy|Supply|Gases|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Gases|Synthetic Fuels;Carbon Capture|Energy|Supply|Gases|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Heat;Carbon Capture|Energy|Supply|Heat|Biomass;1
+Carbon Capture|Energy|Supply|Heat;Carbon Capture|Energy|Supply|Heat|Fossil;1
+Carbon Capture|Energy|Supply|Heat;Carbon Capture|Energy|Supply|Heat|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Heat|Synthetic Fuels;Carbon Capture|Energy|Supply|Heat|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Heat|Synthetic Fuels;Carbon Capture|Energy|Supply|Heat|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Heat|Synthetic Fuels;Carbon Capture|Energy|Supply|Heat|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Hydrogen;Carbon Capture|Energy|Supply|Hydrogen|Biomass;1
+Carbon Capture|Energy|Supply|Hydrogen;Carbon Capture|Energy|Supply|Hydrogen|Fossil;1
+Carbon Capture|Energy|Supply|Hydrogen;Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels;Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels;Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels;Carbon Capture|Energy|Supply|Hydrogen|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Liquids;Carbon Capture|Energy|Supply|Liquids|Biomass;1
+Carbon Capture|Energy|Supply|Liquids;Carbon Capture|Energy|Supply|Liquids|Fossil;1
+Carbon Capture|Energy|Supply|Liquids;Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels;Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels;Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels;Carbon Capture|Energy|Supply|Liquids|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Solids;Carbon Capture|Energy|Supply|Solids|Biomass;1
+Carbon Capture|Energy|Supply|Solids;Carbon Capture|Energy|Supply|Solids|Fossil;1
+Carbon Capture|Energy|Supply|Solids;Carbon Capture|Energy|Supply|Solids|Synthetic Fuels;1
+;;
+Carbon Capture|Energy|Supply|Solids|Synthetic Fuels;Carbon Capture|Energy|Supply|Solids|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Solids|Synthetic Fuels;Carbon Capture|Energy|Supply|Solids|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Solids|Synthetic Fuels;Carbon Capture|Energy|Supply|Solids|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Supply|Synthetic Fuels;Carbon Capture|Energy|Supply|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Supply|Synthetic Fuels;Carbon Capture|Energy|Supply|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Supply|Synthetic Fuels;Carbon Capture|Energy|Supply|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Energy|Synthetic Fuels;Carbon Capture|Energy|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Energy|Synthetic Fuels;Carbon Capture|Energy|Synthetic Fuels|Fossil;1
+Carbon Capture|Energy|Synthetic Fuels;Carbon Capture|Energy|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Biomass;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Direct Air Capture;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Direct Ocean Capture;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Fossil;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Industrial Processes;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Other Sources;1
+Carbon Capture|Geological Storage;Carbon Capture|Geological Storage|Synthetic Fuels;1
+;;
+Carbon Capture|Geological Storage|Synthetic Fuels;Carbon Capture|Geological Storage|Synthetic Fuels|Carbon-Neutral;1
+Carbon Capture|Geological Storage|Synthetic Fuels;Carbon Capture|Geological Storage|Synthetic Fuels|Fossil;1
+Carbon Capture|Geological Storage|Synthetic Fuels;Carbon Capture|Geological Storage|Synthetic Fuels|Industrial Processes;1
+;;
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Chemicals;1
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Iron and Steel;1
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Non-Ferrous Metals;1
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Non-Metallic Minerals;1
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Other Sector;1
+Carbon Capture|Industrial Processes;Carbon Capture|Industrial Processes|Pulp and Paper;1
+;;
+Carbon Capture|Utilization;Carbon Capture|Utilization|Gases;1
+Carbon Capture|Utilization;Carbon Capture|Utilization|Liquids;1
+Carbon Capture|Utilization;Carbon Capture|Utilization|Materials;1
+Carbon Capture|Utilization;Carbon Capture|Utilization|Other;1
+;;
+Carbon Capture|Utilization|Materials;Carbon Capture|Utilization|Materials|Long-Lived;1
+Carbon Capture|Utilization|Materials;Carbon Capture|Utilization|Materials|Short-Lived;1
+;;
+Carbon Removal;Carbon Removal|Enhanced Weathering;1
+Carbon Removal;Carbon Removal|Geological Storage;1
+Carbon Removal;Carbon Removal|Land Use;1
+Carbon Removal;Carbon Removal|Long-Lived Materials;1
+Carbon Removal;Carbon Removal|Ocean;1
+Carbon Removal;Carbon Removal|Other;1
+;;
+Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Biomass;1
+Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Direct Air Capture;1
+Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Other Sources;1
+Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Synthetic Fuels;1
+;;
+Carbon Removal|Land Use;Carbon Removal|Land Use|Agroforestry;1
+Carbon Removal|Land Use;Carbon Removal|Land Use|Biochar;1
+Carbon Removal|Land Use;Carbon Removal|Land Use|Forest Management;1
+Carbon Removal|Land Use;Carbon Removal|Land Use|Other;1
+Carbon Removal|Land Use;Carbon Removal|Land Use|Re/Afforestation;1
+Carbon Removal|Land Use;Carbon Removal|Land Use|Soil Carbon Management;1
+;;
+Carbon Removal|Land Use|Re/Afforestation;Carbon Removal|Land Use|Re/Afforestation|Natural Forest;1
+Carbon Removal|Land Use|Re/Afforestation;Carbon Removal|Land Use|Re/Afforestation|Plantation;1
+;;
+Carbon Removal|Land Use|Soil Carbon Management;Carbon Removal|Land Use|Soil Carbon Management|Cropland;1
+Carbon Removal|Land Use|Soil Carbon Management;Carbon Removal|Land Use|Soil Carbon Management|Grassland;1
+;;
+Carbon Removal|Long-Lived Materials;Carbon Removal|Long-Lived Materials|Other;1
+Carbon Removal|Long-Lived Materials;Carbon Removal|Long-Lived Materials|Plastics;1
+Carbon Removal|Long-Lived Materials;Carbon Removal|Long-Lived Materials|Timber;1
+;;
+Carbon Removal|Ocean;Carbon Removal|Ocean|Direct Ocean Capture;1
+Carbon Removal|Ocean;Carbon Removal|Ocean|Fertilization;1
+Carbon Removal|Ocean;Carbon Removal|Ocean|Ocean Alkalinity Enhancement;1
+Carbon Removal|Ocean;Carbon Removal|Ocean|Other;1
+;;
+Emissions|BC;Emissions|BC|AFOLU;1
+Emissions|BC;Emissions|BC|Energy and Industrial Processes;1
+Emissions|BC;Emissions|BC|Other;1
+Emissions|BC;Emissions|BC|Other Capture and Removal;1
+Emissions|BC;Emissions|BC|Product Use;1
+Emissions|BC;Emissions|BC|Waste;1
+;;
+Emissions|BC|Energy and Industrial Processes;Emissions|BC|Energy;1
+Emissions|BC|Energy and Industrial Processes;Emissions|BC|Industrial Processes;1
+;;
+Emissions|BC|AFOLU;Emissions|BC|AFOLU|Agricultural Waste Burning;1
+Emissions|BC|AFOLU;Emissions|BC|AFOLU|Agriculture;1
+Emissions|BC|AFOLU;Emissions|BC|AFOLU|Land;1
+;;
+Emissions|BC|AFOLU|Agriculture;Emissions|BC|AFOLU|Agriculture|Livestock;1
+Emissions|BC|AFOLU|Agriculture;Emissions|BC|AFOLU|Agriculture|Managed Soils;1
+Emissions|BC|AFOLU|Agriculture;Emissions|BC|AFOLU|Agriculture|Rice;1
+;;
+Emissions|BC|AFOLU|Agriculture|Livestock;Emissions|BC|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|BC|AFOLU|Agriculture|Livestock;Emissions|BC|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|BC|AFOLU|Land;Emissions|BC|AFOLU|Land|Fires;1
+Emissions|BC|AFOLU|Land;Emissions|BC|AFOLU|Land|Harvested Wood Products;1
+Emissions|BC|AFOLU|Land;Emissions|BC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|BC|AFOLU|Land;Emissions|BC|AFOLU|Land|Other;1
+Emissions|BC|AFOLU|Land;Emissions|BC|AFOLU|Land|Wetlands;1
+;;
+Emissions|BC|AFOLU|Land|Fires;Emissions|BC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|BC|AFOLU|Land|Fires;Emissions|BC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|BC|AFOLU|Land|Fires;Emissions|BC|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|BC|Energy;Emissions|BC|Energy|Demand;1
+Emissions|BC|Energy;Emissions|BC|Energy|Supply;1
+;;
+Emissions|BC|Energy|Demand;Emissions|BC|Energy|Demand|Bunkers;1
+Emissions|BC|Energy|Demand;Emissions|BC|Energy|Demand|Industry;1
+Emissions|BC|Energy|Demand;Emissions|BC|Energy|Demand|Other Sector;1
+Emissions|BC|Energy|Demand;Emissions|BC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|BC|Energy|Demand;Emissions|BC|Energy|Demand|Transportation;1
+;;
+Emissions|BC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|BC|Energy|Demand|AFOFI;1
+Emissions|BC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|BC|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|BC|Energy|Demand|Residential and Commercial;Emissions|BC|Energy|Demand|Commercial;1
+Emissions|BC|Energy|Demand|Residential and Commercial;Emissions|BC|Energy|Demand|Residential;1
+;;
+Emissions|BC|Energy|Demand|Bunkers;Emissions|BC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|BC|Energy|Demand|Bunkers;Emissions|BC|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Bus;1
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Rail;1
+Emissions|BC|Energy|Demand|Transportation;Emissions|BC|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|BC|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Combustion;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Electricity;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Fugitive;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Gases;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Heat;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Hydrogen;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Liquids;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Other;1
+Emissions|BC|Energy|Supply;Emissions|BC|Energy|Supply|Solids;1
+;;
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Biomass;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Coal;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Combustion;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Electricity;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Fugitive;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Gas;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Hydrogen;1
+Emissions|BC|Energy|Supply|Gases;Emissions|BC|Energy|Supply|Gases|Other;1
+;;
+Emissions|BC|Energy|Supply|Gases|Fossil;Emissions|BC|Energy|Supply|Gases|Gas;1
+Emissions|BC|Energy|Supply|Gases|Fossil;Emissions|BC|Energy|Supply|Gases|Coal;1
+;;
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Biomass;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Coal;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Combustion;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Electricity;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Fugitive;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Gas;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Geothermal;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Hydrogen;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Nuclear;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Oil;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Other;1
+Emissions|BC|Energy|Supply|Heat;Emissions|BC|Energy|Supply|Heat|Solar;1
+;;
+Emissions|BC|Energy|Supply|Heat|Fossil;Emissions|BC|Energy|Supply|Heat|Coal;1
+Emissions|BC|Energy|Supply|Heat|Fossil;Emissions|BC|Energy|Supply|Heat|Gas;1
+Emissions|BC|Energy|Supply|Heat|Fossil;Emissions|BC|Energy|Supply|Heat|Oil;1
+;;
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Biomass;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Coal;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Combustion;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Electricity;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Gas;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Oil;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Other;1
+Emissions|BC|Energy|Supply|Hydrogen;Emissions|BC|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|BC|Energy|Supply|Hydrogen|Fossil;Emissions|BC|Energy|Supply|Hydrogen|Coal;1
+Emissions|BC|Energy|Supply|Hydrogen|Fossil;Emissions|BC|Energy|Supply|Hydrogen|Gas;1
+Emissions|BC|Energy|Supply|Hydrogen|Fossil;Emissions|BC|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Biomass;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Coal;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Combustion;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Electricity;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Fugitive;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Gas;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Hydrogen;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Oil;1
+Emissions|BC|Energy|Supply|Liquids;Emissions|BC|Energy|Supply|Liquids|Other;1
+;;
+Emissions|BC|Energy|Supply|Liquids|Fossil;Emissions|BC|Energy|Supply|Liquids|Coal;1
+Emissions|BC|Energy|Supply|Liquids|Fossil;Emissions|BC|Energy|Supply|Liquids|Gas;1
+Emissions|BC|Energy|Supply|Liquids|Fossil;Emissions|BC|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|BC|Energy|Supply|Solids;Emissions|BC|Energy|Supply|Solids|Biomass;1
+Emissions|BC|Energy|Supply|Solids;Emissions|BC|Energy|Supply|Solids|Coal;1
+Emissions|BC|Energy|Supply|Solids;Emissions|BC|Energy|Supply|Solids|Combustion;1
+Emissions|BC|Energy|Supply|Solids;Emissions|BC|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Cement;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Chemicals;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Iron and Steel;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Non-Ferrous Metals;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Non-Metallic Minerals;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Other Sector;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Plastics;1
+Emissions|BC|Industrial Processes;Emissions|BC|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|BC|Industrial Processes|Chemicals;Emissions|BC|Industrial Processes|Chemicals|Ammonia;1
+Emissions|BC|Industrial Processes|Chemicals;Emissions|BC|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|BC|Industrial Processes|Chemicals;Emissions|BC|Industrial Processes|Chemicals|Methanol;1
+Emissions|BC|Industrial Processes|Chemicals;Emissions|BC|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|BC|Product Use;Emissions|BC|Product Use|Non-Energy Use;1
+Emissions|BC|Product Use;Emissions|BC|Product Use|ODS Substitutes;1
+Emissions|BC|Product Use;Emissions|BC|Product Use|Other;1
+Emissions|BC|Product Use;Emissions|BC|Product Use|Solvents;1
+;;
+Emissions|C2F6;Emissions|C2F6|AFOLU;1
+Emissions|C2F6;Emissions|C2F6|Energy and Industrial Processes;1
+Emissions|C2F6;Emissions|C2F6|Other;1
+Emissions|C2F6;Emissions|C2F6|Other Capture and Removal;1
+Emissions|C2F6;Emissions|C2F6|Product Use;1
+Emissions|C2F6;Emissions|C2F6|Waste;1
+;;
+Emissions|C2F6|Energy and Industrial Processes;Emissions|C2F6|Energy;1
+Emissions|C2F6|Energy and Industrial Processes;Emissions|C2F6|Industrial Processes;1
+;;
+Emissions|C2F6|AFOLU;Emissions|C2F6|AFOLU|Agricultural Waste Burning;1
+Emissions|C2F6|AFOLU;Emissions|C2F6|AFOLU|Agriculture;1
+Emissions|C2F6|AFOLU;Emissions|C2F6|AFOLU|Land;1
+;;
+Emissions|C2F6|AFOLU|Agriculture;Emissions|C2F6|AFOLU|Agriculture|Livestock;1
+Emissions|C2F6|AFOLU|Agriculture;Emissions|C2F6|AFOLU|Agriculture|Managed Soils;1
+Emissions|C2F6|AFOLU|Agriculture;Emissions|C2F6|AFOLU|Agriculture|Rice;1
+;;
+Emissions|C2F6|AFOLU|Agriculture|Livestock;Emissions|C2F6|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|C2F6|AFOLU|Agriculture|Livestock;Emissions|C2F6|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|C2F6|AFOLU|Land;Emissions|C2F6|AFOLU|Land|Fires;1
+Emissions|C2F6|AFOLU|Land;Emissions|C2F6|AFOLU|Land|Harvested Wood Products;1
+Emissions|C2F6|AFOLU|Land;Emissions|C2F6|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|C2F6|AFOLU|Land;Emissions|C2F6|AFOLU|Land|Other;1
+Emissions|C2F6|AFOLU|Land;Emissions|C2F6|AFOLU|Land|Wetlands;1
+;;
+Emissions|C2F6|AFOLU|Land|Fires;Emissions|C2F6|AFOLU|Land|Fires|Forest Burning;1
+Emissions|C2F6|AFOLU|Land|Fires;Emissions|C2F6|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|C2F6|AFOLU|Land|Fires;Emissions|C2F6|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|C2F6|Energy;Emissions|C2F6|Energy|Demand;1
+Emissions|C2F6|Energy;Emissions|C2F6|Energy|Supply;1
+;;
+Emissions|C2F6|Energy|Demand;Emissions|C2F6|Energy|Demand|Bunkers;1
+Emissions|C2F6|Energy|Demand;Emissions|C2F6|Energy|Demand|Industry;1
+Emissions|C2F6|Energy|Demand;Emissions|C2F6|Energy|Demand|Other Sector;1
+Emissions|C2F6|Energy|Demand;Emissions|C2F6|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|C2F6|Energy|Demand;Emissions|C2F6|Energy|Demand|Transportation;1
+;;
+Emissions|C2F6|Energy|Demand|Residential and Commercial and AFOFI;Emissions|C2F6|Energy|Demand|Residential and Commercial;1
+Emissions|C2F6|Energy|Demand|Residential and Commercial and AFOFI;Emissions|C2F6|Energy|Demand|AFOFI;1
+;;
+Emissions|C2F6|Energy|Demand|Residential and Commercial;Emissions|C2F6|Energy|Demand|Residential;1
+Emissions|C2F6|Energy|Demand|Residential and Commercial;Emissions|C2F6|Energy|Demand|Commercial;1
+;;
+Emissions|C2F6|Energy|Demand|Bunkers;Emissions|C2F6|Energy|Demand|Bunkers|International Aviation;1
+Emissions|C2F6|Energy|Demand|Bunkers;Emissions|C2F6|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Bus;1
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Rail;1
+Emissions|C2F6|Energy|Demand|Transportation;Emissions|C2F6|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|C2F6|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Combustion;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Electricity;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Fugitive;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Gases;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Heat;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Hydrogen;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Liquids;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Other;1
+Emissions|C2F6|Energy|Supply;Emissions|C2F6|Energy|Supply|Solids;1
+;;
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Biomass;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Coal;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Combustion;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Electricity;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Fugitive;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Gas;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Hydrogen;1
+Emissions|C2F6|Energy|Supply|Gases;Emissions|C2F6|Energy|Supply|Gases|Other;1
+;;
+Emissions|C2F6|Energy|Supply|Gases|Fossil;Emissions|C2F6|Energy|Supply|Gases|Coal;1
+Emissions|C2F6|Energy|Supply|Gases|Fossil;Emissions|C2F6|Energy|Supply|Gases|Gas;1
+;;
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Biomass;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Coal;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Combustion;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Electricity;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Fugitive;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Gas;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Geothermal;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Hydrogen;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Nuclear;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Oil;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Other;1
+Emissions|C2F6|Energy|Supply|Heat;Emissions|C2F6|Energy|Supply|Heat|Solar;1
+;;
+Emissions|C2F6|Energy|Supply|Heat|Fossil;Emissions|C2F6|Energy|Supply|Heat|Coal;1
+Emissions|C2F6|Energy|Supply|Heat|Fossil;Emissions|C2F6|Energy|Supply|Heat|Gas;1
+Emissions|C2F6|Energy|Supply|Heat|Fossil;Emissions|C2F6|Energy|Supply|Heat|Oil;1
+;;
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Biomass;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Coal;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Combustion;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Electricity;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Gas;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Oil;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Other;1
+Emissions|C2F6|Energy|Supply|Hydrogen;Emissions|C2F6|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|C2F6|Energy|Supply|Hydrogen|Fossil;Emissions|C2F6|Energy|Supply|Hydrogen|Coal;1
+Emissions|C2F6|Energy|Supply|Hydrogen|Fossil;Emissions|C2F6|Energy|Supply|Hydrogen|Gas;1
+Emissions|C2F6|Energy|Supply|Hydrogen|Fossil;Emissions|C2F6|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Biomass;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Coal;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Combustion;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Electricity;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Fugitive;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Gas;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Hydrogen;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Oil;1
+Emissions|C2F6|Energy|Supply|Liquids;Emissions|C2F6|Energy|Supply|Liquids|Other;1
+;;
+Emissions|C2F6|Energy|Supply|Liquids|Fossil;Emissions|C2F6|Energy|Supply|Liquids|Coal;1
+Emissions|C2F6|Energy|Supply|Liquids|Fossil;Emissions|C2F6|Energy|Supply|Liquids|Gas;1
+Emissions|C2F6|Energy|Supply|Liquids|Fossil;Emissions|C2F6|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|C2F6|Energy|Supply|Solids;Emissions|C2F6|Energy|Supply|Solids|Biomass;1
+Emissions|C2F6|Energy|Supply|Solids;Emissions|C2F6|Energy|Supply|Solids|Coal;1
+Emissions|C2F6|Energy|Supply|Solids;Emissions|C2F6|Energy|Supply|Solids|Combustion;1
+Emissions|C2F6|Energy|Supply|Solids;Emissions|C2F6|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Cement;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Chemicals;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Iron and Steel;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Non-Ferrous Metals;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Non-Metallic Minerals;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Other Sector;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Plastics;1
+Emissions|C2F6|Industrial Processes;Emissions|C2F6|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|C2F6|Industrial Processes|Chemicals;Emissions|C2F6|Industrial Processes|Chemicals|Ammonia;1
+Emissions|C2F6|Industrial Processes|Chemicals;Emissions|C2F6|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|C2F6|Industrial Processes|Chemicals;Emissions|C2F6|Industrial Processes|Chemicals|Methanol;1
+Emissions|C2F6|Industrial Processes|Chemicals;Emissions|C2F6|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|C2F6|Product Use;Emissions|C2F6|Product Use|Non-Energy Use;1
+Emissions|C2F6|Product Use;Emissions|C2F6|Product Use|ODS Substitutes;1
+Emissions|C2F6|Product Use;Emissions|C2F6|Product Use|Other;1
+Emissions|C2F6|Product Use;Emissions|C2F6|Product Use|Solvents;1
+;;
+Emissions|CH4;Emissions|CH4|AFOLU;1
+Emissions|CH4;Emissions|CH4|Energy and Industrial Processes;1
+Emissions|CH4;Emissions|CH4|Other;1
+Emissions|CH4;Emissions|CH4|Other Capture and Removal;1
+Emissions|CH4;Emissions|CH4|Product Use;1
+Emissions|CH4;Emissions|CH4|Waste;1
+;;
+Emissions|CH4|Energy and Industrial Processes;Emissions|CH4|Energy;1
+Emissions|CH4|Energy and Industrial Processes;Emissions|CH4|Industrial Processes;1
+;;
+Emissions|CH4|AFOLU;Emissions|CH4|AFOLU|Agricultural Waste Burning;1
+Emissions|CH4|AFOLU;Emissions|CH4|AFOLU|Agriculture;1
+Emissions|CH4|AFOLU;Emissions|CH4|AFOLU|Land;1
+;;
+Emissions|CH4|AFOLU|Agriculture;Emissions|CH4|AFOLU|Agriculture|Livestock;1
+Emissions|CH4|AFOLU|Agriculture;Emissions|CH4|AFOLU|Agriculture|Managed Soils;1
+Emissions|CH4|AFOLU|Agriculture;Emissions|CH4|AFOLU|Agriculture|Rice;1
+;;
+Emissions|CH4|AFOLU|Agriculture|Livestock;Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|CH4|AFOLU|Agriculture|Livestock;Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|CH4|AFOLU|Land;Emissions|CH4|AFOLU|Land|Fires;1
+Emissions|CH4|AFOLU|Land;Emissions|CH4|AFOLU|Land|Harvested Wood Products;1
+Emissions|CH4|AFOLU|Land;Emissions|CH4|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|CH4|AFOLU|Land;Emissions|CH4|AFOLU|Land|Other;1
+Emissions|CH4|AFOLU|Land;Emissions|CH4|AFOLU|Land|Wetlands;1
+;;
+Emissions|CH4|AFOLU|Land|Fires;Emissions|CH4|AFOLU|Land|Fires|Forest Burning;1
+Emissions|CH4|AFOLU|Land|Fires;Emissions|CH4|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|CH4|AFOLU|Land|Fires;Emissions|CH4|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|CH4|Energy;Emissions|CH4|Energy|Demand;1
+Emissions|CH4|Energy;Emissions|CH4|Energy|Supply;1
+;;
+Emissions|CH4|Energy|Demand;Emissions|CH4|Energy|Demand|Bunkers;1
+Emissions|CH4|Energy|Demand;Emissions|CH4|Energy|Demand|Industry;1
+Emissions|CH4|Energy|Demand;Emissions|CH4|Energy|Demand|Other Sector;1
+Emissions|CH4|Energy|Demand;Emissions|CH4|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|CH4|Energy|Demand;Emissions|CH4|Energy|Demand|Transportation;1
+;;
+Emissions|CH4|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CH4|Energy|Demand|AFOFI;1
+Emissions|CH4|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CH4|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|CH4|Energy|Demand|Residential and Commercial;Emissions|CH4|Energy|Demand|Commercial;1
+Emissions|CH4|Energy|Demand|Residential and Commercial;Emissions|CH4|Energy|Demand|Residential;1
+;;
+Emissions|CH4|Energy|Demand|Bunkers;Emissions|CH4|Energy|Demand|Bunkers|International Aviation;1
+Emissions|CH4|Energy|Demand|Bunkers;Emissions|CH4|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Bus;1
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Rail;1
+Emissions|CH4|Energy|Demand|Transportation;Emissions|CH4|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CH4|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Combustion;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Electricity;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Fugitive;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Gases;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Heat;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Hydrogen;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Liquids;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Other;1
+Emissions|CH4|Energy|Supply;Emissions|CH4|Energy|Supply|Solids;1
+;;
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Biomass;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Coal;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Combustion;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Electricity;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Fugitive;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Gas;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Hydrogen;1
+Emissions|CH4|Energy|Supply|Gases;Emissions|CH4|Energy|Supply|Gases|Other;1
+;;
+Emissions|CH4|Energy|Supply|Gases|Fossil;Emissions|CH4|Energy|Supply|Gases|Coal;1
+Emissions|CH4|Energy|Supply|Gases|Fossil;Emissions|CH4|Energy|Supply|Gases|Gas;1
+;;
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Biomass;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Coal;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Combustion;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Electricity;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Fugitive;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Gas;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Geothermal;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Hydrogen;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Nuclear;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Oil;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Other;1
+Emissions|CH4|Energy|Supply|Heat;Emissions|CH4|Energy|Supply|Heat|Solar;1
+;;
+Emissions|CH4|Energy|Supply|Heat|Fossil;Emissions|CH4|Energy|Supply|Heat|Coal;1
+Emissions|CH4|Energy|Supply|Heat|Fossil;Emissions|CH4|Energy|Supply|Heat|Gas;1
+Emissions|CH4|Energy|Supply|Heat|Fossil;Emissions|CH4|Energy|Supply|Heat|Oil;1
+;;
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Biomass;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Coal;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Combustion;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Electricity;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Gas;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Oil;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Other;1
+Emissions|CH4|Energy|Supply|Hydrogen;Emissions|CH4|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|CH4|Energy|Supply|Hydrogen|Fossil;Emissions|CH4|Energy|Supply|Hydrogen|Coal;1
+Emissions|CH4|Energy|Supply|Hydrogen|Fossil;Emissions|CH4|Energy|Supply|Hydrogen|Gas;1
+Emissions|CH4|Energy|Supply|Hydrogen|Fossil;Emissions|CH4|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Biomass;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Coal;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Combustion;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Electricity;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Fugitive;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Gas;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Hydrogen;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Oil;1
+Emissions|CH4|Energy|Supply|Liquids;Emissions|CH4|Energy|Supply|Liquids|Other;1
+;;
+Emissions|CH4|Energy|Supply|Liquids|Fossil;Emissions|CH4|Energy|Supply|Liquids|Coal;1
+Emissions|CH4|Energy|Supply|Liquids|Fossil;Emissions|CH4|Energy|Supply|Liquids|Gas;1
+Emissions|CH4|Energy|Supply|Liquids|Fossil;Emissions|CH4|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|CH4|Energy|Supply|Solids;Emissions|CH4|Energy|Supply|Solids|Biomass;1
+Emissions|CH4|Energy|Supply|Solids;Emissions|CH4|Energy|Supply|Solids|Coal;1
+Emissions|CH4|Energy|Supply|Solids;Emissions|CH4|Energy|Supply|Solids|Combustion;1
+Emissions|CH4|Energy|Supply|Solids;Emissions|CH4|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Cement;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Chemicals;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Iron and Steel;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Non-Ferrous Metals;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Non-Metallic Minerals;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Other Sector;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Plastics;1
+Emissions|CH4|Industrial Processes;Emissions|CH4|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|CH4|Industrial Processes|Chemicals;Emissions|CH4|Industrial Processes|Chemicals|Ammonia;1
+Emissions|CH4|Industrial Processes|Chemicals;Emissions|CH4|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|CH4|Industrial Processes|Chemicals;Emissions|CH4|Industrial Processes|Chemicals|Methanol;1
+Emissions|CH4|Industrial Processes|Chemicals;Emissions|CH4|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|CH4|Product Use;Emissions|CH4|Product Use|Non-Energy Use;1
+Emissions|CH4|Product Use;Emissions|CH4|Product Use|ODS Substitutes;1
+Emissions|CH4|Product Use;Emissions|CH4|Product Use|Other;1
+Emissions|CH4|Product Use;Emissions|CH4|Product Use|Solvents;1
+;;
+Emissions|CO;Emissions|CO|AFOLU;1
+Emissions|CO;Emissions|CO|Energy and Industrial Processes;1
+Emissions|CO;Emissions|CO|Other;1
+Emissions|CO;Emissions|CO|Other Capture and Removal;1
+Emissions|CO;Emissions|CO|Product Use;1
+Emissions|CO;Emissions|CO|Waste;1
+;;
+Emissions|CO|Energy and Industrial Processes;Emissions|CO|Energy;1
+Emissions|CO|Energy and Industrial Processes;Emissions|CO|Industrial Processes;1
+;;
+Emissions|CO|AFOLU;Emissions|CO|AFOLU|Agricultural Waste Burning;1
+Emissions|CO|AFOLU;Emissions|CO|AFOLU|Agriculture;1
+Emissions|CO|AFOLU;Emissions|CO|AFOLU|Land;1
+;;
+Emissions|CO|AFOLU|Agriculture;Emissions|CO|AFOLU|Agriculture|Livestock;1
+Emissions|CO|AFOLU|Agriculture;Emissions|CO|AFOLU|Agriculture|Managed Soils;1
+Emissions|CO|AFOLU|Agriculture;Emissions|CO|AFOLU|Agriculture|Rice;1
+;;
+Emissions|CO|AFOLU|Agriculture|Livestock;Emissions|CO|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|CO|AFOLU|Agriculture|Livestock;Emissions|CO|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|CO|AFOLU|Land;Emissions|CO|AFOLU|Land|Fires;1
+Emissions|CO|AFOLU|Land;Emissions|CO|AFOLU|Land|Harvested Wood Products;1
+Emissions|CO|AFOLU|Land;Emissions|CO|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|CO|AFOLU|Land;Emissions|CO|AFOLU|Land|Other;1
+Emissions|CO|AFOLU|Land;Emissions|CO|AFOLU|Land|Wetlands;1
+;;
+Emissions|CO|AFOLU|Land|Fires;Emissions|CO|AFOLU|Land|Fires|Forest Burning;1
+Emissions|CO|AFOLU|Land|Fires;Emissions|CO|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|CO|AFOLU|Land|Fires;Emissions|CO|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|CO|Energy;Emissions|CO|Energy|Demand;1
+Emissions|CO|Energy;Emissions|CO|Energy|Supply;1
+;;
+Emissions|CO|Energy|Demand;Emissions|CO|Energy|Demand|Bunkers;1
+Emissions|CO|Energy|Demand;Emissions|CO|Energy|Demand|Industry;1
+Emissions|CO|Energy|Demand;Emissions|CO|Energy|Demand|Other Sector;1
+Emissions|CO|Energy|Demand;Emissions|CO|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|CO|Energy|Demand;Emissions|CO|Energy|Demand|Transportation;1
+;;
+Emissions|CO|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CO|Energy|Demand|AFOFI;1
+Emissions|CO|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CO|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|CO|Energy|Demand|Residential and Commercial;Emissions|CO|Energy|Demand|Commercial;1
+Emissions|CO|Energy|Demand|Residential and Commercial;Emissions|CO|Energy|Demand|Residential;1
+;;
+Emissions|CO|Energy|Demand|Bunkers;Emissions|CO|Energy|Demand|Bunkers|International Aviation;1
+Emissions|CO|Energy|Demand|Bunkers;Emissions|CO|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Bus;1
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Rail;1
+Emissions|CO|Energy|Demand|Transportation;Emissions|CO|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Combustion;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Electricity;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Fugitive;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Gases;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Heat;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Hydrogen;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Liquids;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Other;1
+Emissions|CO|Energy|Supply;Emissions|CO|Energy|Supply|Solids;1
+;;
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Biomass;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Coal;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Combustion;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Electricity;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Fugitive;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Gas;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Hydrogen;1
+Emissions|CO|Energy|Supply|Gases;Emissions|CO|Energy|Supply|Gases|Other;1
+;;
+Emissions|CO|Energy|Supply|Gases|Fossil;Emissions|CO|Energy|Supply|Gases|Coal;1
+Emissions|CO|Energy|Supply|Gases|Fossil;Emissions|CO|Energy|Supply|Gases|Gas;1
+;;
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Biomass;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Coal;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Combustion;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Electricity;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Fugitive;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Gas;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Geothermal;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Hydrogen;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Nuclear;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Oil;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Other;1
+Emissions|CO|Energy|Supply|Heat;Emissions|CO|Energy|Supply|Heat|Solar;1
+;;
+Emissions|CO|Energy|Supply|Heat|Fossil;Emissions|CO|Energy|Supply|Heat|Coal;1
+Emissions|CO|Energy|Supply|Heat|Fossil;Emissions|CO|Energy|Supply|Heat|Gas;1
+Emissions|CO|Energy|Supply|Heat|Fossil;Emissions|CO|Energy|Supply|Heat|Oil;1
+;;
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Biomass;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Coal;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Combustion;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Electricity;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Gas;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Oil;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Other;1
+Emissions|CO|Energy|Supply|Hydrogen;Emissions|CO|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|CO|Energy|Supply|Hydrogen|Fossil;Emissions|CO|Energy|Supply|Hydrogen|Coal;1
+Emissions|CO|Energy|Supply|Hydrogen|Fossil;Emissions|CO|Energy|Supply|Hydrogen|Gas;1
+Emissions|CO|Energy|Supply|Hydrogen|Fossil;Emissions|CO|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Biomass;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Coal;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Combustion;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Electricity;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Fugitive;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Gas;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Hydrogen;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Oil;1
+Emissions|CO|Energy|Supply|Liquids;Emissions|CO|Energy|Supply|Liquids|Other;1
+;;
+Emissions|CO|Energy|Supply|Liquids|Fossil;Emissions|CO|Energy|Supply|Liquids|Coal;1
+Emissions|CO|Energy|Supply|Liquids|Fossil;Emissions|CO|Energy|Supply|Liquids|Gas;1
+Emissions|CO|Energy|Supply|Liquids|Fossil;Emissions|CO|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|CO|Energy|Supply|Solids;Emissions|CO|Energy|Supply|Solids|Biomass;1
+Emissions|CO|Energy|Supply|Solids;Emissions|CO|Energy|Supply|Solids|Coal;1
+Emissions|CO|Energy|Supply|Solids;Emissions|CO|Energy|Supply|Solids|Combustion;1
+Emissions|CO|Energy|Supply|Solids;Emissions|CO|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Cement;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Chemicals;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Iron and Steel;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Non-Ferrous Metals;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Non-Metallic Minerals;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Other Sector;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Plastics;1
+Emissions|CO|Industrial Processes;Emissions|CO|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|CO|Industrial Processes|Chemicals;Emissions|CO|Industrial Processes|Chemicals|Ammonia;1
+Emissions|CO|Industrial Processes|Chemicals;Emissions|CO|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|CO|Industrial Processes|Chemicals;Emissions|CO|Industrial Processes|Chemicals|Methanol;1
+Emissions|CO|Industrial Processes|Chemicals;Emissions|CO|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|CO|Product Use;Emissions|CO|Product Use|Non-Energy Use;1
+Emissions|CO|Product Use;Emissions|CO|Product Use|ODS Substitutes;1
+Emissions|CO|Product Use;Emissions|CO|Product Use|Other;1
+Emissions|CO|Product Use;Emissions|CO|Product Use|Solvents;1
+;;
 ## Total CO2 - Note that for AFOLU we only report the total net variable;;
 Emissions|CO2;Emissions|CO2|AFOLU;1
 Emissions|CO2;Emissions|CO2|Energy and Industrial Processes;1
@@ -8,38 +1449,80 @@ Emissions|CO2;Emissions|CO2|Other Capture and Removal;1
 Emissions|CO2;Emissions|CO2|Product Use;1
 Emissions|CO2;Emissions|CO2|Waste;1
 ;;
+Emissions|CO2 2;Gross Emissions|CO2;1
+Emissions|CO2 2;Gross Removals|CO2;1
+;;
+Emissions|CO2|Energy and Industrial Processes;Emissions|CO2|Energy;1
+Emissions|CO2|Energy and Industrial Processes;Emissions|CO2|Industrial Processes;1
+;;
 ## AFOLU CO2: In ScenarioMIP, the variable Emissions|CO2|AFOLU is taken from the REMIND reporting, but the variable Emissions|CO2|AFOLU|Land is taken from the MAgPIE reporting. This check ensures consistency;;
 Emissions|CO2|AFOLU;Emissions|CO2|AFOLU|Agricultural Waste Burning;1
 Emissions|CO2|AFOLU;Emissions|CO2|AFOLU|Agriculture;1
 Emissions|CO2|AFOLU;Emissions|CO2|AFOLU|Land;1
 ;;
-## AFOLU|Land CO2;;
+Emissions|CO2|AFOLU 2;Gross Emissions|CO2|AFOLU;1
+Emissions|CO2|AFOLU 2;Gross Removals|CO2|AFOLU;1
+;;
+Emissions|CO2|AFOLU|Agriculture;Emissions|CO2|AFOLU|Agriculture|Livestock;1
+Emissions|CO2|AFOLU|Agriculture;Emissions|CO2|AFOLU|Agriculture|Managed Soils;1
+Emissions|CO2|AFOLU|Agriculture;Emissions|CO2|AFOLU|Agriculture|Rice;1
+;;
+Emissions|CO2|AFOLU|Agriculture|Livestock;Emissions|CO2|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|CO2|AFOLU|Agriculture|Livestock;Emissions|CO2|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
 Emissions|CO2|AFOLU|Land;Emissions|CO2|AFOLU|Land|Fires;1
 Emissions|CO2|AFOLU|Land;Emissions|CO2|AFOLU|Land|Harvested Wood Products;1
 Emissions|CO2|AFOLU|Land;Emissions|CO2|AFOLU|Land|Land Use and Land-Use Change;1
 Emissions|CO2|AFOLU|Land;Emissions|CO2|AFOLU|Land|Other;1
 Emissions|CO2|AFOLU|Land;Emissions|CO2|AFOLU|Land|Wetlands;1
 ;;
-# Energy and Industrial Processes CO2;;
-Emissions|CO2|Energy and Industrial Processes;Emissions|CO2|Energy;1
-Emissions|CO2|Energy and Industrial Processes;Emissions|CO2|Industrial Processes;1
+Emissions|CO2|AFOLU|Land|Fires;Emissions|CO2|AFOLU|Land|Fires|Forest Burning;1
+Emissions|CO2|AFOLU|Land|Fires;Emissions|CO2|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|CO2|AFOLU|Land|Fires;Emissions|CO2|AFOLU|Land|Fires|Peat Burning;1
 ;;
-## Energy CO2;;
-Emissions|CO2|Energy;Emissions|CO2|Energy|Supply;1
 Emissions|CO2|Energy;Emissions|CO2|Energy|Demand;1
+Emissions|CO2|Energy;Emissions|CO2|Energy|Supply;1
 ;;
-## Energy Demand CO2;;
+Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Bunkers;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Industry;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Other Sector;1
-Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Bunkers;1
-Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Transportation;1
 Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|CO2|Energy|Demand;Emissions|CO2|Energy|Demand|Transportation;1
 ;;
-## Energy Demand Bunkers CO2;;
+Emissions|CO2|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CO2|Energy|Demand|AFOFI;1
+Emissions|CO2|Energy|Demand|Residential and Commercial and AFOFI;Emissions|CO2|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|CO2|Energy|Demand|Residential and Commercial;Emissions|CO2|Energy|Demand|Commercial;1
+Emissions|CO2|Energy|Demand|Residential and Commercial;Emissions|CO2|Energy|Demand|Residential;1
+;;
 Emissions|CO2|Energy|Demand|Bunkers;Emissions|CO2|Energy|Demand|Bunkers|International Aviation;1
 Emissions|CO2|Energy|Demand|Bunkers;Emissions|CO2|Energy|Demand|Bunkers|International Shipping;1
 ;;
-## Energy Supply CO2;;
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Chemicals;1
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Iron and Steel;1
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Non-Ferrous Metals;1
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Non-Metallic Minerals;1
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Other Sector;1
+Emissions|CO2|Energy|Demand|Industry;Emissions|CO2|Energy|Demand|Industry|Plastics;1
+;;
+Emissions|CO2|Energy|Demand|Industry|Chemicals;Emissions|CO2|Energy|Demand|Industry|Chemicals|Ammonia;1
+Emissions|CO2|Energy|Demand|Industry|Chemicals;Emissions|CO2|Energy|Demand|Industry|Chemicals|High-Value Chemicals;1
+Emissions|CO2|Energy|Demand|Industry|Chemicals;Emissions|CO2|Energy|Demand|Industry|Chemicals|Methanol;1
+Emissions|CO2|Energy|Demand|Industry|Chemicals;Emissions|CO2|Energy|Demand|Industry|Chemicals|Other Sector;1
+;;
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Bus;1
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Rail;1
+Emissions|CO2|Energy|Demand|Transportation;Emissions|CO2|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|CO2|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
 Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Autoproduction;1
 Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Combustion;1
 Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Electricity;1
@@ -51,6 +1534,83 @@ Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Liquids;1
 Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Other;1
 Emissions|CO2|Energy|Supply;Emissions|CO2|Energy|Supply|Solids;1
 ;;
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Biomass;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Coal;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Combustion;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Electricity;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Fugitive;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Gas;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Hydrogen;1
+Emissions|CO2|Energy|Supply|Gases;Emissions|CO2|Energy|Supply|Gases|Other;1
+;;
+Emissions|CO2|Energy|Supply|Gases|Fossil;Emissions|CO2|Energy|Supply|Gases|Coal;1
+Emissions|CO2|Energy|Supply|Gases|Fossil;Emissions|CO2|Energy|Supply|Gases|Gas;1
+;;
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Biomass;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Coal;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Combustion;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Electricity;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Fugitive;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Gas;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Geothermal;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Hydrogen;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Nuclear;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Oil;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Other;1
+Emissions|CO2|Energy|Supply|Heat;Emissions|CO2|Energy|Supply|Heat|Solar;1
+;;
+Emissions|CO2|Energy|Supply|Heat|Fossil;Emissions|CO2|Energy|Supply|Heat|Coal;1
+Emissions|CO2|Energy|Supply|Heat|Fossil;Emissions|CO2|Energy|Supply|Heat|Gas;1
+Emissions|CO2|Energy|Supply|Heat|Fossil;Emissions|CO2|Energy|Supply|Heat|Oil;1
+;;
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Biomass;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Coal;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Combustion;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Electricity;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Gas;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Oil;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Other;1
+Emissions|CO2|Energy|Supply|Hydrogen;Emissions|CO2|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|CO2|Energy|Supply|Hydrogen|Fossil;Emissions|CO2|Energy|Supply|Hydrogen|Coal;1
+Emissions|CO2|Energy|Supply|Hydrogen|Fossil;Emissions|CO2|Energy|Supply|Hydrogen|Gas;1
+Emissions|CO2|Energy|Supply|Hydrogen|Fossil;Emissions|CO2|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Biomass;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Coal;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Combustion;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Electricity;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Fugitive;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Gas;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Hydrogen;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Oil;1
+Emissions|CO2|Energy|Supply|Liquids;Emissions|CO2|Energy|Supply|Liquids|Other;1
+;;
+Emissions|CO2|Energy|Supply|Liquids|Fossil;Emissions|CO2|Energy|Supply|Liquids|Coal;1
+Emissions|CO2|Energy|Supply|Liquids|Fossil;Emissions|CO2|Energy|Supply|Liquids|Gas;1
+Emissions|CO2|Energy|Supply|Liquids|Fossil;Emissions|CO2|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|CO2|Energy|Supply|Solids;Emissions|CO2|Energy|Supply|Solids|Biomass;1
+Emissions|CO2|Energy|Supply|Solids;Emissions|CO2|Energy|Supply|Solids|Coal;1
+Emissions|CO2|Energy|Supply|Solids;Emissions|CO2|Energy|Supply|Solids|Combustion;1
+Emissions|CO2|Energy|Supply|Solids;Emissions|CO2|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Cement;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Chemicals;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Iron and Steel;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Non-Ferrous Metals;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Non-Metallic Minerals;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Other Sector;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Plastics;1
+Emissions|CO2|Industrial Processes;Emissions|CO2|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|CO2|Industrial Processes|Chemicals;Emissions|CO2|Industrial Processes|Chemicals|Ammonia;1
+Emissions|CO2|Industrial Processes|Chemicals;Emissions|CO2|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|CO2|Industrial Processes|Chemicals;Emissions|CO2|Industrial Processes|Chemicals|Methanol;1
+Emissions|CO2|Industrial Processes|Chemicals;Emissions|CO2|Industrial Processes|Chemicals|Other Sector;1
+;;
 ## Other Capture and Removal CO2: Carbon Removal|Long-Lived Materials|Timber is already part of Emissions|CO2|AFOLU;;
 Emissions|CO2|Other Capture and Removal;Carbon Removal|Enhanced Weathering;-1
 Emissions|CO2|Other Capture and Removal;Carbon Removal|Geological Storage|Direct Air Capture;-1
@@ -59,223 +1619,20 @@ Emissions|CO2|Other Capture and Removal;Carbon Removal|Long-Lived Materials;-1
 Emissions|CO2|Other Capture and Removal;Carbon Removal|Long-Lived Materials|Timber;1
 Emissions|CO2|Other Capture and Removal;Carbon Removal|Ocean;-1
 ;;
-## Total BC;;
-Emissions|BC;Emissions|BC|Energy|Supply;1
-Emissions|BC;Emissions|BC|Energy|Demand|Industry;1
-Emissions|BC;Emissions|BC|Energy|Demand|Other Sector;1
-Emissions|BC;Emissions|BC|Industrial Processes;1
-Emissions|BC;Emissions|BC|Other;1
-Emissions|BC;Emissions|BC|Other Capture and Removal;1
-Emissions|BC;Emissions|BC|Energy|Demand|Bunkers|International Aviation;1
-Emissions|BC;Emissions|BC|Energy|Demand|Transportation;1
-Emissions|BC;Emissions|BC|Energy|Demand|Bunkers|International Shipping;1
-Emissions|BC;Emissions|BC|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|BC;Emissions|BC|Product Use;1
-Emissions|BC;Emissions|BC|AFOLU|Agriculture;1
-Emissions|BC;Emissions|BC|AFOLU|Agricultural Waste Burning;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Fires|Forest Burning;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Fires|Peat Burning;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Harvested Wood Products;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Other;1
-Emissions|BC;Emissions|BC|AFOLU|Land|Wetlands;1
-Emissions|BC;Emissions|BC|Waste;1
+Emissions|CO2|Product Use;Emissions|CO2|Product Use|Non-Energy Use;1
+Emissions|CO2|Product Use;Emissions|CO2|Product Use|ODS Substitutes;1
+Emissions|CO2|Product Use;Emissions|CO2|Product Use|Other;1
+Emissions|CO2|Product Use;Emissions|CO2|Product Use|Solvents;1
 ;;
-## Total CH4;;
-Emissions|CH4;Emissions|CH4|Energy|Supply;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Industry;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Other Sector;1
-Emissions|CH4;Emissions|CH4|Industrial Processes;1
-Emissions|CH4;Emissions|CH4|Other;1
-Emissions|CH4;Emissions|CH4|Other Capture and Removal;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Bunkers|International Aviation;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Transportation;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Bunkers|International Shipping;1
-Emissions|CH4;Emissions|CH4|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|CH4;Emissions|CH4|Product Use;1
-Emissions|CH4;Emissions|CH4|AFOLU|Agriculture;1
-Emissions|CH4;Emissions|CH4|AFOLU|Agricultural Waste Burning;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Fires|Forest Burning;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Fires|Peat Burning;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Harvested Wood Products;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Other;1
-Emissions|CH4;Emissions|CH4|AFOLU|Land|Wetlands;1
-Emissions|CH4;Emissions|CH4|Waste;1
+Emissions|HFC;Emissions|HFC|HFC125;1
+Emissions|HFC;Emissions|HFC|HFC134a;1
+Emissions|HFC;Emissions|HFC|HFC143a;1
+Emissions|HFC;Emissions|HFC|HFC227ea;1
+Emissions|HFC;Emissions|HFC|HFC23;1
+Emissions|HFC;Emissions|HFC|HFC245fa;1
+Emissions|HFC;Emissions|HFC|HFC32;1
+Emissions|HFC;Emissions|HFC|HFC43-10;1
 ;;
-## Total CO;;
-Emissions|CO;Emissions|CO|Energy|Supply;1
-Emissions|CO;Emissions|CO|Energy|Demand|Industry;1
-Emissions|CO;Emissions|CO|Energy|Demand|Other Sector;1
-Emissions|CO;Emissions|CO|Industrial Processes;1
-Emissions|CO;Emissions|CO|Other;1
-Emissions|CO;Emissions|CO|Other Capture and Removal;1
-Emissions|CO;Emissions|CO|Energy|Demand|Bunkers|International Aviation;1
-Emissions|CO;Emissions|CO|Energy|Demand|Transportation;1
-Emissions|CO;Emissions|CO|Energy|Demand|Bunkers|International Shipping;1
-Emissions|CO;Emissions|CO|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|CO;Emissions|CO|Product Use;1
-Emissions|CO;Emissions|CO|AFOLU|Agriculture;1
-Emissions|CO;Emissions|CO|AFOLU|Agricultural Waste Burning;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Fires|Forest Burning;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Fires|Peat Burning;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Harvested Wood Products;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Other;1
-Emissions|CO;Emissions|CO|AFOLU|Land|Wetlands;1
-Emissions|CO;Emissions|CO|Waste;1
-;;
-## Total NH3;;
-Emissions|NH3;Emissions|NH3|Energy|Supply;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Industry;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Other Sector;1
-Emissions|NH3;Emissions|NH3|Industrial Processes;1
-Emissions|NH3;Emissions|NH3|Other;1
-Emissions|NH3;Emissions|NH3|Other Capture and Removal;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Bunkers|International Aviation;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Transportation;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Bunkers|International Shipping;1
-Emissions|NH3;Emissions|NH3|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|NH3;Emissions|NH3|Product Use;1
-Emissions|NH3;Emissions|NH3|AFOLU|Agriculture;1
-Emissions|NH3;Emissions|NH3|AFOLU|Agricultural Waste Burning;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Fires|Forest Burning;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Fires|Peat Burning;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Harvested Wood Products;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Other;1
-Emissions|NH3;Emissions|NH3|AFOLU|Land|Wetlands;1
-Emissions|NH3;Emissions|NH3|Waste;1
-;;
-## Total N2O;;
-Emissions|N2O;Emissions|N2O|Energy|Supply;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Industry;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Other Sector;1
-Emissions|N2O;Emissions|N2O|Industrial Processes;1
-Emissions|N2O;Emissions|N2O|Other;1
-Emissions|N2O;Emissions|N2O|Other Capture and Removal;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Bunkers|International Aviation;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Transportation;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Bunkers|International Shipping;1
-Emissions|N2O;Emissions|N2O|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|N2O;Emissions|N2O|Product Use;1
-Emissions|N2O;Emissions|N2O|AFOLU|Agriculture;1
-Emissions|N2O;Emissions|N2O|AFOLU|Agricultural Waste Burning;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Fires|Forest Burning;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Fires|Peat Burning;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Harvested Wood Products;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Other;1
-Emissions|N2O;Emissions|N2O|AFOLU|Land|Wetlands;1
-Emissions|N2O;Emissions|N2O|Waste;1
-;;
-## Total NOx;;
-Emissions|NOx;Emissions|NOx|Energy|Supply;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Industry;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Other Sector;1
-Emissions|NOx;Emissions|NOx|Industrial Processes;1
-Emissions|NOx;Emissions|NOx|Other;1
-Emissions|NOx;Emissions|NOx|Other Capture and Removal;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Bunkers|International Aviation;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Transportation;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Bunkers|International Shipping;1
-Emissions|NOx;Emissions|NOx|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|NOx;Emissions|NOx|Product Use;1
-Emissions|NOx;Emissions|NOx|AFOLU|Agriculture;1
-Emissions|NOx;Emissions|NOx|AFOLU|Agricultural Waste Burning;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Fires|Forest Burning;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Fires|Peat Burning;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Harvested Wood Products;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Other;1
-Emissions|NOx;Emissions|NOx|AFOLU|Land|Wetlands;1
-Emissions|NOx;Emissions|NOx|Waste;1
-;;
-## Total OC;;
-Emissions|OC;Emissions|OC|Energy|Supply;1
-Emissions|OC;Emissions|OC|Energy|Demand|Industry;1
-Emissions|OC;Emissions|OC|Energy|Demand|Other Sector;1
-Emissions|OC;Emissions|OC|Industrial Processes;1
-Emissions|OC;Emissions|OC|Other;1
-Emissions|OC;Emissions|OC|Other Capture and Removal;1
-Emissions|OC;Emissions|OC|Energy|Demand|Bunkers|International Aviation;1
-Emissions|OC;Emissions|OC|Energy|Demand|Transportation;1
-Emissions|OC;Emissions|OC|Energy|Demand|Bunkers|International Shipping;1
-Emissions|OC;Emissions|OC|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|OC;Emissions|OC|Product Use;1
-Emissions|OC;Emissions|OC|AFOLU|Agriculture;1
-Emissions|OC;Emissions|OC|AFOLU|Agricultural Waste Burning;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Fires|Forest Burning;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Fires|Peat Burning;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Harvested Wood Products;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Other;1
-Emissions|OC;Emissions|OC|AFOLU|Land|Wetlands;1
-Emissions|OC;Emissions|OC|Waste;1
-;;
-## Total Sulfur;;
-Emissions|Sulfur;Emissions|Sulfur|Energy|Supply;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Industry;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Other Sector;1
-Emissions|Sulfur;Emissions|Sulfur|Industrial Processes;1
-Emissions|Sulfur;Emissions|Sulfur|Other;1
-Emissions|Sulfur;Emissions|Sulfur|Other Capture and Removal;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Bunkers|International Aviation;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Transportation;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Bunkers|International Shipping;1
-Emissions|Sulfur;Emissions|Sulfur|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|Sulfur;Emissions|Sulfur|Product Use;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Agriculture;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Agricultural Waste Burning;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Fires|Forest Burning;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Fires|Peat Burning;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Harvested Wood Products;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Other;1
-Emissions|Sulfur;Emissions|Sulfur|AFOLU|Land|Wetlands;1
-Emissions|Sulfur;Emissions|Sulfur|Waste;1
-;;
-## Total VOC;;
-Emissions|VOC;Emissions|VOC|Energy|Supply;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Industry;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Other Sector;1
-Emissions|VOC;Emissions|VOC|Industrial Processes;1
-Emissions|VOC;Emissions|VOC|Other;1
-Emissions|VOC;Emissions|VOC|Other Capture and Removal;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Bunkers|International Aviation;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Transportation;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Bunkers|International Shipping;1
-Emissions|VOC;Emissions|VOC|Energy|Demand|Residential and Commercial and AFOFI;1
-Emissions|VOC;Emissions|VOC|Product Use;1
-Emissions|VOC;Emissions|VOC|AFOLU|Agriculture;1
-Emissions|VOC;Emissions|VOC|AFOLU|Agricultural Waste Burning;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Fires|Forest Burning;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Fires|Grassland Burning;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Fires|Peat Burning;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Harvested Wood Products;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Land Use and Land-Use Change;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Other;1
-Emissions|VOC;Emissions|VOC|AFOLU|Land|Wetlands;1
-Emissions|VOC;Emissions|VOC|Waste;1
-;;
-#  Additional summation checks for emission variables;;
-## Total CO2: net emissions = gross emissions plus gross removals;;
-Gross Emissions|CO2;Emissions|CO2;1
-Gross Emissions|CO2;Gross Removals|CO2;-1
-;;
-## AFOLU CO2: net emissions equal gross emissions plus gross removals;;
-Gross Emissions|CO2|AFOLU;Emissions|CO2|AFOLU;1
-Gross Emissions|CO2|AFOLU;Gross Removals|CO2|AFOLU;-1
-;;
-## Kyoto Gases;;
 Emissions|Kyoto Gases;Emissions|Kyoto Gases|AFOLU;1
 Emissions|Kyoto Gases;Emissions|Kyoto Gases|Energy and Industrial Processes;1
 Emissions|Kyoto Gases;Emissions|Kyoto Gases|Other;1
@@ -283,57 +1640,1095 @@ Emissions|Kyoto Gases;Emissions|Kyoto Gases|Other Capture and Removal;1
 Emissions|Kyoto Gases;Emissions|Kyoto Gases|Product Use;1
 Emissions|Kyoto Gases;Emissions|Kyoto Gases|Waste;1
 ;;
-## AFOLU Kyoto Gases;;
+Emissions|Kyoto Gases|Energy and Industrial Processes;Emissions|Kyoto Gases|Energy;1
+Emissions|Kyoto Gases|Energy and Industrial Processes;Emissions|Kyoto Gases|Industrial Processes;1
+;;
 Emissions|Kyoto Gases|AFOLU;Emissions|Kyoto Gases|AFOLU|Agricultural Waste Burning;1
 Emissions|Kyoto Gases|AFOLU;Emissions|Kyoto Gases|AFOLU|Agriculture;1
 Emissions|Kyoto Gases|AFOLU;Emissions|Kyoto Gases|AFOLU|Land;1
 ;;
-# Energy and Industrial Processes Kyoto Gases;;
-Emissions|Kyoto Gases|Energy and Industrial Processes;Emissions|Kyoto Gases|Energy;1
-Emissions|Kyoto Gases|Energy and Industrial Processes;Emissions|Kyoto Gases|Industrial Processes;1
+Emissions|Kyoto Gases|AFOLU|Agriculture;Emissions|Kyoto Gases|AFOLU|Agriculture|Livestock;1
+Emissions|Kyoto Gases|AFOLU|Agriculture;Emissions|Kyoto Gases|AFOLU|Agriculture|Managed Soils;1
+Emissions|Kyoto Gases|AFOLU|Agriculture;Emissions|Kyoto Gases|AFOLU|Agriculture|Rice;1
 ;;
-## Energy Kyoto Gases;;
-Emissions|Kyoto Gases|Energy;Emissions|Kyoto Gases|Energy|Supply;1
+Emissions|Kyoto Gases|AFOLU|Agriculture|Livestock;Emissions|Kyoto Gases|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|Kyoto Gases|AFOLU|Agriculture|Livestock;Emissions|Kyoto Gases|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|Kyoto Gases|AFOLU|Land;Emissions|Kyoto Gases|AFOLU|Land|Fires;1
+Emissions|Kyoto Gases|AFOLU|Land;Emissions|Kyoto Gases|AFOLU|Land|Harvested Wood Products;1
+Emissions|Kyoto Gases|AFOLU|Land;Emissions|Kyoto Gases|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|Kyoto Gases|AFOLU|Land;Emissions|Kyoto Gases|AFOLU|Land|Other;1
+Emissions|Kyoto Gases|AFOLU|Land;Emissions|Kyoto Gases|AFOLU|Land|Wetlands;1
+;;
+Emissions|Kyoto Gases|AFOLU|Land|Fires;Emissions|Kyoto Gases|AFOLU|Land|Fires|Forest Burning;1
+Emissions|Kyoto Gases|AFOLU|Land|Fires;Emissions|Kyoto Gases|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|Kyoto Gases|AFOLU|Land|Fires;Emissions|Kyoto Gases|AFOLU|Land|Fires|Peat Burning;1
+;;
 Emissions|Kyoto Gases|Energy;Emissions|Kyoto Gases|Energy|Demand;1
+Emissions|Kyoto Gases|Energy;Emissions|Kyoto Gases|Energy|Supply;1
 ;;
-## Energy Demand Kyoto Gases;;
+Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Bunkers;1
 Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Industry;1
 Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Other Sector;1
-Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Bunkers;1
-Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Transportation;1
 Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|Kyoto Gases|Energy|Demand;Emissions|Kyoto Gases|Energy|Demand|Transportation;1
 ;;
-#  Carbon Capture and Carbon Removal;;
-## Carbon Capture by Sink;;
-Carbon Capture|Utilization;Carbon Capture;1
-Carbon Capture|Utilization;Carbon Capture|Leakage;-1
-Carbon Capture|Utilization;Carbon Capture|Other Storage;-1
-Carbon Capture|Utilization;Carbon Capture|Geological Storage;-1
+Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial and AFOFI;Emissions|Kyoto Gases|Energy|Demand|AFOFI;1
+Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial and AFOFI;Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial;1
 ;;
-## Carbon Capture by Source;;
-Carbon Capture;Carbon Capture|Direct Air Capture;1
-Carbon Capture;Carbon Capture|Direct Ocean Capture;1
-Carbon Capture;Carbon Capture|Energy|Demand;1
-Carbon Capture;Carbon Capture|Energy|Supply;1
-Carbon Capture;Carbon Capture|Industrial Processes;1
-Carbon Capture;Carbon Capture|Other Sources;1
+Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial;Emissions|Kyoto Gases|Energy|Demand|Commercial;1
+Emissions|Kyoto Gases|Energy|Demand|Residential and Commercial;Emissions|Kyoto Gases|Energy|Demand|Residential;1
 ;;
-## Carbon Removal;;
-Carbon Removal;Carbon Removal|Enhanced Weathering;1
-Carbon Removal;Carbon Removal|Geological Storage;1
-Carbon Removal;Carbon Removal|Land Use;1
-Carbon Removal;Carbon Removal|Long-Lived Materials;1
-Carbon Removal;Carbon Removal|Ocean;1
-Carbon Removal;Carbon Removal|Other;1
+Emissions|Kyoto Gases|Energy|Demand|Bunkers;Emissions|Kyoto Gases|Energy|Demand|Bunkers|International Aviation;1
+Emissions|Kyoto Gases|Energy|Demand|Bunkers;Emissions|Kyoto Gases|Energy|Demand|Bunkers|International Shipping;1
 ;;
-## Carbon Removal Geological Storage;;
-Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Biomass;1
-Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Direct Air Capture;1
-Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Other Sources;1
-Carbon Removal|Geological Storage;Carbon Removal|Geological Storage|Synthetic Fuels;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Bus;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Rail;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation;Emissions|Kyoto Gases|Energy|Demand|Transportation|Truck;1
 ;;
-# Final Energy;;
-## Final Energy by Carrier;;
+Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Kyoto Gases|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Electricity;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Fugitive;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Gases;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Heat;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Hydrogen;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Liquids;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Other;1
+Emissions|Kyoto Gases|Energy|Supply;Emissions|Kyoto Gases|Energy|Supply|Solids;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Biomass;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Electricity;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Fugitive;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Hydrogen;1
+Emissions|Kyoto Gases|Energy|Supply|Gases;Emissions|Kyoto Gases|Energy|Supply|Gases|Other;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Gases|Fossil;Emissions|Kyoto Gases|Energy|Supply|Gases|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Gases|Fossil;Emissions|Kyoto Gases|Energy|Supply|Gases|Gas;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Biomass;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Electricity;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Fugitive;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Geothermal;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Hydrogen;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Nuclear;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Oil;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Other;1
+Emissions|Kyoto Gases|Energy|Supply|Heat;Emissions|Kyoto Gases|Energy|Supply|Heat|Solar;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Heat|Fossil;Emissions|Kyoto Gases|Energy|Supply|Heat|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Heat|Fossil;Emissions|Kyoto Gases|Energy|Supply|Heat|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Heat|Fossil;Emissions|Kyoto Gases|Energy|Supply|Heat|Oil;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Biomass;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Electricity;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Oil;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Other;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Fossil;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Fossil;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Fossil;Emissions|Kyoto Gases|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Biomass;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Electricity;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Fugitive;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Hydrogen;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Oil;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids;Emissions|Kyoto Gases|Energy|Supply|Liquids|Other;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Liquids|Fossil;Emissions|Kyoto Gases|Energy|Supply|Liquids|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids|Fossil;Emissions|Kyoto Gases|Energy|Supply|Liquids|Gas;1
+Emissions|Kyoto Gases|Energy|Supply|Liquids|Fossil;Emissions|Kyoto Gases|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|Kyoto Gases|Energy|Supply|Solids;Emissions|Kyoto Gases|Energy|Supply|Solids|Biomass;1
+Emissions|Kyoto Gases|Energy|Supply|Solids;Emissions|Kyoto Gases|Energy|Supply|Solids|Coal;1
+Emissions|Kyoto Gases|Energy|Supply|Solids;Emissions|Kyoto Gases|Energy|Supply|Solids|Combustion;1
+Emissions|Kyoto Gases|Energy|Supply|Solids;Emissions|Kyoto Gases|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Cement;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Chemicals;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Iron and Steel;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Non-Ferrous Metals;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Non-Metallic Minerals;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Other Sector;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Plastics;1
+Emissions|Kyoto Gases|Industrial Processes;Emissions|Kyoto Gases|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|Kyoto Gases|Industrial Processes|Chemicals;Emissions|Kyoto Gases|Industrial Processes|Chemicals|Ammonia;1
+Emissions|Kyoto Gases|Industrial Processes|Chemicals;Emissions|Kyoto Gases|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|Kyoto Gases|Industrial Processes|Chemicals;Emissions|Kyoto Gases|Industrial Processes|Chemicals|Methanol;1
+Emissions|Kyoto Gases|Industrial Processes|Chemicals;Emissions|Kyoto Gases|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|Kyoto Gases|Product Use;Emissions|Kyoto Gases|Product Use|Non-Energy Use;1
+Emissions|Kyoto Gases|Product Use;Emissions|Kyoto Gases|Product Use|ODS Substitutes;1
+Emissions|Kyoto Gases|Product Use;Emissions|Kyoto Gases|Product Use|Other;1
+Emissions|Kyoto Gases|Product Use;Emissions|Kyoto Gases|Product Use|Solvents;1
+;;
+Emissions|N2O;Emissions|N2O|AFOLU;1
+Emissions|N2O;Emissions|N2O|Energy and Industrial Processes;1
+Emissions|N2O;Emissions|N2O|Other;1
+Emissions|N2O;Emissions|N2O|Other Capture and Removal;1
+Emissions|N2O;Emissions|N2O|Product Use;1
+Emissions|N2O;Emissions|N2O|Waste;1
+;;
+Emissions|N2O|Energy and Industrial Processes;Emissions|N2O|Energy;1
+Emissions|N2O|Energy and Industrial Processes;Emissions|N2O|Industrial Processes;1
+;;
+Emissions|N2O|AFOLU;Emissions|N2O|AFOLU|Agricultural Waste Burning;1
+Emissions|N2O|AFOLU;Emissions|N2O|AFOLU|Agriculture;1
+Emissions|N2O|AFOLU;Emissions|N2O|AFOLU|Land;1
+;;
+Emissions|N2O|AFOLU|Agriculture;Emissions|N2O|AFOLU|Agriculture|Livestock;1
+Emissions|N2O|AFOLU|Agriculture;Emissions|N2O|AFOLU|Agriculture|Managed Soils;1
+Emissions|N2O|AFOLU|Agriculture;Emissions|N2O|AFOLU|Agriculture|Rice;1
+;;
+Emissions|N2O|AFOLU|Agriculture|Livestock;Emissions|N2O|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|N2O|AFOLU|Agriculture|Livestock;Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|N2O|AFOLU|Land;Emissions|N2O|AFOLU|Land|Fires;1
+Emissions|N2O|AFOLU|Land;Emissions|N2O|AFOLU|Land|Harvested Wood Products;1
+Emissions|N2O|AFOLU|Land;Emissions|N2O|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|N2O|AFOLU|Land;Emissions|N2O|AFOLU|Land|Other;1
+Emissions|N2O|AFOLU|Land;Emissions|N2O|AFOLU|Land|Wetlands;1
+;;
+Emissions|N2O|AFOLU|Land|Fires;Emissions|N2O|AFOLU|Land|Fires|Forest Burning;1
+Emissions|N2O|AFOLU|Land|Fires;Emissions|N2O|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|N2O|AFOLU|Land|Fires;Emissions|N2O|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|N2O|Energy;Emissions|N2O|Energy|Demand;1
+Emissions|N2O|Energy;Emissions|N2O|Energy|Supply;1
+;;
+Emissions|N2O|Energy|Demand;Emissions|N2O|Energy|Demand|Bunkers;1
+Emissions|N2O|Energy|Demand;Emissions|N2O|Energy|Demand|Industry;1
+Emissions|N2O|Energy|Demand;Emissions|N2O|Energy|Demand|Other Sector;1
+Emissions|N2O|Energy|Demand;Emissions|N2O|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|N2O|Energy|Demand;Emissions|N2O|Energy|Demand|Transportation;1
+;;
+Emissions|N2O|Energy|Demand|Residential and Commercial and AFOFI;Emissions|N2O|Energy|Demand|AFOFI;1
+Emissions|N2O|Energy|Demand|Residential and Commercial and AFOFI;Emissions|N2O|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|N2O|Energy|Demand|Residential and Commercial;Emissions|N2O|Energy|Demand|Commercial;1
+Emissions|N2O|Energy|Demand|Residential and Commercial;Emissions|N2O|Energy|Demand|Residential;1
+;;
+Emissions|N2O|Energy|Demand|Bunkers;Emissions|N2O|Energy|Demand|Bunkers|International Aviation;1
+Emissions|N2O|Energy|Demand|Bunkers;Emissions|N2O|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Bus;1
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Rail;1
+Emissions|N2O|Energy|Demand|Transportation;Emissions|N2O|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|N2O|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Combustion;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Electricity;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Fugitive;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Gases;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Heat;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Hydrogen;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Liquids;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Other;1
+Emissions|N2O|Energy|Supply;Emissions|N2O|Energy|Supply|Solids;1
+;;
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Biomass;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Coal;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Combustion;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Electricity;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Fugitive;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Gas;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Hydrogen;1
+Emissions|N2O|Energy|Supply|Gases;Emissions|N2O|Energy|Supply|Gases|Other;1
+;;
+Emissions|N2O|Energy|Supply|Gases|Fossil;Emissions|N2O|Energy|Supply|Gases|Coal;1
+Emissions|N2O|Energy|Supply|Gases|Fossil;Emissions|N2O|Energy|Supply|Gases|Gas;1
+;;
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Biomass;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Coal;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Combustion;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Electricity;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Fugitive;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Gas;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Geothermal;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Hydrogen;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Nuclear;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Oil;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Other;1
+Emissions|N2O|Energy|Supply|Heat;Emissions|N2O|Energy|Supply|Heat|Solar;1
+;;
+Emissions|N2O|Energy|Supply|Heat|Fossil;Emissions|N2O|Energy|Supply|Heat|Coal;1
+Emissions|N2O|Energy|Supply|Heat|Fossil;Emissions|N2O|Energy|Supply|Heat|Gas;1
+Emissions|N2O|Energy|Supply|Heat|Fossil;Emissions|N2O|Energy|Supply|Heat|Oil;1
+;;
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Biomass;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Coal;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Combustion;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Electricity;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Gas;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Oil;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Other;1
+Emissions|N2O|Energy|Supply|Hydrogen;Emissions|N2O|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|N2O|Energy|Supply|Hydrogen|Fossil;Emissions|N2O|Energy|Supply|Hydrogen|Coal;1
+Emissions|N2O|Energy|Supply|Hydrogen|Fossil;Emissions|N2O|Energy|Supply|Hydrogen|Gas;1
+Emissions|N2O|Energy|Supply|Hydrogen|Fossil;Emissions|N2O|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Biomass;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Coal;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Combustion;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Electricity;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Fugitive;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Gas;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Hydrogen;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Oil;1
+Emissions|N2O|Energy|Supply|Liquids;Emissions|N2O|Energy|Supply|Liquids|Other;1
+;;
+Emissions|N2O|Energy|Supply|Liquids|Fossil;Emissions|N2O|Energy|Supply|Liquids|Coal;1
+Emissions|N2O|Energy|Supply|Liquids|Fossil;Emissions|N2O|Energy|Supply|Liquids|Gas;1
+Emissions|N2O|Energy|Supply|Liquids|Fossil;Emissions|N2O|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|N2O|Energy|Supply|Solids;Emissions|N2O|Energy|Supply|Solids|Biomass;1
+Emissions|N2O|Energy|Supply|Solids;Emissions|N2O|Energy|Supply|Solids|Coal;1
+Emissions|N2O|Energy|Supply|Solids;Emissions|N2O|Energy|Supply|Solids|Combustion;1
+Emissions|N2O|Energy|Supply|Solids;Emissions|N2O|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Cement;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Chemicals;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Iron and Steel;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Non-Ferrous Metals;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Non-Metallic Minerals;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Other Sector;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Plastics;1
+Emissions|N2O|Industrial Processes;Emissions|N2O|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|N2O|Industrial Processes|Chemicals;Emissions|N2O|Industrial Processes|Chemicals|Ammonia;1
+Emissions|N2O|Industrial Processes|Chemicals;Emissions|N2O|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|N2O|Industrial Processes|Chemicals;Emissions|N2O|Industrial Processes|Chemicals|Methanol;1
+Emissions|N2O|Industrial Processes|Chemicals;Emissions|N2O|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|N2O|Product Use;Emissions|N2O|Product Use|Non-Energy Use;1
+Emissions|N2O|Product Use;Emissions|N2O|Product Use|ODS Substitutes;1
+Emissions|N2O|Product Use;Emissions|N2O|Product Use|Other;1
+Emissions|N2O|Product Use;Emissions|N2O|Product Use|Solvents;1
+;;
+Emissions|NH3;Emissions|NH3|AFOLU;1
+Emissions|NH3;Emissions|NH3|Energy and Industrial Processes;1
+Emissions|NH3;Emissions|NH3|Other;1
+Emissions|NH3;Emissions|NH3|Other Capture and Removal;1
+Emissions|NH3;Emissions|NH3|Product Use;1
+Emissions|NH3;Emissions|NH3|Waste;1
+;;
+Emissions|NH3|Energy and Industrial Processes;Emissions|NH3|Energy;1
+Emissions|NH3|Energy and Industrial Processes;Emissions|NH3|Industrial Processes;1
+;;
+Emissions|NH3|AFOLU;Emissions|NH3|AFOLU|Agricultural Waste Burning;1
+Emissions|NH3|AFOLU;Emissions|NH3|AFOLU|Agriculture;1
+Emissions|NH3|AFOLU;Emissions|NH3|AFOLU|Land;1
+;;
+Emissions|NH3|AFOLU|Agriculture;Emissions|NH3|AFOLU|Agriculture|Livestock;1
+Emissions|NH3|AFOLU|Agriculture;Emissions|NH3|AFOLU|Agriculture|Managed Soils;1
+Emissions|NH3|AFOLU|Agriculture;Emissions|NH3|AFOLU|Agriculture|Rice;1
+;;
+Emissions|NH3|AFOLU|Agriculture|Livestock;Emissions|NH3|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|NH3|AFOLU|Agriculture|Livestock;Emissions|NH3|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|NH3|AFOLU|Land;Emissions|NH3|AFOLU|Land|Fires;1
+Emissions|NH3|AFOLU|Land;Emissions|NH3|AFOLU|Land|Harvested Wood Products;1
+Emissions|NH3|AFOLU|Land;Emissions|NH3|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|NH3|AFOLU|Land;Emissions|NH3|AFOLU|Land|Other;1
+Emissions|NH3|AFOLU|Land;Emissions|NH3|AFOLU|Land|Wetlands;1
+;;
+Emissions|NH3|AFOLU|Land|Fires;Emissions|NH3|AFOLU|Land|Fires|Forest Burning;1
+Emissions|NH3|AFOLU|Land|Fires;Emissions|NH3|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|NH3|AFOLU|Land|Fires;Emissions|NH3|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|NH3|Energy;Emissions|NH3|Energy|Demand;1
+Emissions|NH3|Energy;Emissions|NH3|Energy|Supply;1
+;;
+Emissions|NH3|Energy|Demand;Emissions|NH3|Energy|Demand|Bunkers;1
+Emissions|NH3|Energy|Demand;Emissions|NH3|Energy|Demand|Industry;1
+Emissions|NH3|Energy|Demand;Emissions|NH3|Energy|Demand|Other Sector;1
+Emissions|NH3|Energy|Demand;Emissions|NH3|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|NH3|Energy|Demand;Emissions|NH3|Energy|Demand|Transportation;1
+;;
+Emissions|NH3|Energy|Demand|Residential and Commercial and AFOFI;Emissions|NH3|Energy|Demand|AFOFI;1
+Emissions|NH3|Energy|Demand|Residential and Commercial and AFOFI;Emissions|NH3|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|NH3|Energy|Demand|Residential and Commercial;Emissions|NH3|Energy|Demand|Commercial;1
+Emissions|NH3|Energy|Demand|Residential and Commercial;Emissions|NH3|Energy|Demand|Residential;1
+;;
+Emissions|NH3|Energy|Demand|Bunkers;Emissions|NH3|Energy|Demand|Bunkers|International Aviation;1
+Emissions|NH3|Energy|Demand|Bunkers;Emissions|NH3|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Bus;1
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Rail;1
+Emissions|NH3|Energy|Demand|Transportation;Emissions|NH3|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NH3|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Combustion;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Electricity;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Fugitive;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Gases;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Heat;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Hydrogen;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Liquids;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Other;1
+Emissions|NH3|Energy|Supply;Emissions|NH3|Energy|Supply|Solids;1
+;;
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Biomass;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Coal;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Combustion;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Electricity;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Fugitive;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Gas;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Hydrogen;1
+Emissions|NH3|Energy|Supply|Gases;Emissions|NH3|Energy|Supply|Gases|Other;1
+;;
+Emissions|NH3|Energy|Supply|Gases|Fossil;Emissions|NH3|Energy|Supply|Gases|Coal;1
+Emissions|NH3|Energy|Supply|Gases|Fossil;Emissions|NH3|Energy|Supply|Gases|Gas;1
+;;
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Biomass;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Coal;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Combustion;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Electricity;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Fugitive;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Gas;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Geothermal;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Hydrogen;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Nuclear;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Oil;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Other;1
+Emissions|NH3|Energy|Supply|Heat;Emissions|NH3|Energy|Supply|Heat|Solar;1
+;;
+Emissions|NH3|Energy|Supply|Heat|Fossil;Emissions|NH3|Energy|Supply|Heat|Coal;1
+Emissions|NH3|Energy|Supply|Heat|Fossil;Emissions|NH3|Energy|Supply|Heat|Gas;1
+Emissions|NH3|Energy|Supply|Heat|Fossil;Emissions|NH3|Energy|Supply|Heat|Oil;1
+;;
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Biomass;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Coal;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Combustion;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Electricity;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Gas;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Oil;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Other;1
+Emissions|NH3|Energy|Supply|Hydrogen;Emissions|NH3|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|NH3|Energy|Supply|Hydrogen|Fossil;Emissions|NH3|Energy|Supply|Hydrogen|Coal;1
+Emissions|NH3|Energy|Supply|Hydrogen|Fossil;Emissions|NH3|Energy|Supply|Hydrogen|Gas;1
+Emissions|NH3|Energy|Supply|Hydrogen|Fossil;Emissions|NH3|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Biomass;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Coal;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Combustion;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Electricity;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Fugitive;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Gas;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Hydrogen;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Oil;1
+Emissions|NH3|Energy|Supply|Liquids;Emissions|NH3|Energy|Supply|Liquids|Other;1
+;;
+Emissions|NH3|Energy|Supply|Liquids|Fossil;Emissions|NH3|Energy|Supply|Liquids|Coal;1
+Emissions|NH3|Energy|Supply|Liquids|Fossil;Emissions|NH3|Energy|Supply|Liquids|Gas;1
+Emissions|NH3|Energy|Supply|Liquids|Fossil;Emissions|NH3|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|NH3|Energy|Supply|Solids;Emissions|NH3|Energy|Supply|Solids|Biomass;1
+Emissions|NH3|Energy|Supply|Solids;Emissions|NH3|Energy|Supply|Solids|Coal;1
+Emissions|NH3|Energy|Supply|Solids;Emissions|NH3|Energy|Supply|Solids|Combustion;1
+Emissions|NH3|Energy|Supply|Solids;Emissions|NH3|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Cement;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Chemicals;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Iron and Steel;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Non-Ferrous Metals;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Non-Metallic Minerals;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Other Sector;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Plastics;1
+Emissions|NH3|Industrial Processes;Emissions|NH3|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|NH3|Industrial Processes|Chemicals;Emissions|NH3|Industrial Processes|Chemicals|Ammonia;1
+Emissions|NH3|Industrial Processes|Chemicals;Emissions|NH3|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|NH3|Industrial Processes|Chemicals;Emissions|NH3|Industrial Processes|Chemicals|Methanol;1
+Emissions|NH3|Industrial Processes|Chemicals;Emissions|NH3|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|NH3|Product Use;Emissions|NH3|Product Use|Non-Energy Use;1
+Emissions|NH3|Product Use;Emissions|NH3|Product Use|ODS Substitutes;1
+Emissions|NH3|Product Use;Emissions|NH3|Product Use|Other;1
+Emissions|NH3|Product Use;Emissions|NH3|Product Use|Solvents;1
+;;
+Emissions|NOx;Emissions|NOx|AFOLU;1
+Emissions|NOx;Emissions|NOx|Energy and Industrial Processes;1
+Emissions|NOx;Emissions|NOx|Other;1
+Emissions|NOx;Emissions|NOx|Other Capture and Removal;1
+Emissions|NOx;Emissions|NOx|Product Use;1
+Emissions|NOx;Emissions|NOx|Waste;1
+;;
+Emissions|NOx|Energy and Industrial Processes;Emissions|NOx|Energy;1
+Emissions|NOx|Energy and Industrial Processes;Emissions|NOx|Industrial Processes;1
+;;
+Emissions|NOx|AFOLU;Emissions|NOx|AFOLU|Agricultural Waste Burning;1
+Emissions|NOx|AFOLU;Emissions|NOx|AFOLU|Agriculture;1
+Emissions|NOx|AFOLU;Emissions|NOx|AFOLU|Land;1
+;;
+Emissions|NOx|AFOLU|Agriculture;Emissions|NOx|AFOLU|Agriculture|Livestock;1
+Emissions|NOx|AFOLU|Agriculture;Emissions|NOx|AFOLU|Agriculture|Managed Soils;1
+Emissions|NOx|AFOLU|Agriculture;Emissions|NOx|AFOLU|Agriculture|Rice;1
+;;
+Emissions|NOx|AFOLU|Agriculture|Livestock;Emissions|NOx|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|NOx|AFOLU|Agriculture|Livestock;Emissions|NOx|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|NOx|AFOLU|Land;Emissions|NOx|AFOLU|Land|Fires;1
+Emissions|NOx|AFOLU|Land;Emissions|NOx|AFOLU|Land|Harvested Wood Products;1
+Emissions|NOx|AFOLU|Land;Emissions|NOx|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|NOx|AFOLU|Land;Emissions|NOx|AFOLU|Land|Other;1
+Emissions|NOx|AFOLU|Land;Emissions|NOx|AFOLU|Land|Wetlands;1
+;;
+Emissions|NOx|AFOLU|Land|Fires;Emissions|NOx|AFOLU|Land|Fires|Forest Burning;1
+Emissions|NOx|AFOLU|Land|Fires;Emissions|NOx|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|NOx|AFOLU|Land|Fires;Emissions|NOx|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|NOx|Energy;Emissions|NOx|Energy|Demand;1
+Emissions|NOx|Energy;Emissions|NOx|Energy|Supply;1
+;;
+Emissions|NOx|Energy|Demand;Emissions|NOx|Energy|Demand|Bunkers;1
+Emissions|NOx|Energy|Demand;Emissions|NOx|Energy|Demand|Industry;1
+Emissions|NOx|Energy|Demand;Emissions|NOx|Energy|Demand|Other Sector;1
+Emissions|NOx|Energy|Demand;Emissions|NOx|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|NOx|Energy|Demand;Emissions|NOx|Energy|Demand|Transportation;1
+;;
+Emissions|NOx|Energy|Demand|Residential and Commercial and AFOFI;Emissions|NOx|Energy|Demand|AFOFI;1
+Emissions|NOx|Energy|Demand|Residential and Commercial and AFOFI;Emissions|NOx|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|NOx|Energy|Demand|Residential and Commercial;Emissions|NOx|Energy|Demand|Commercial;1
+Emissions|NOx|Energy|Demand|Residential and Commercial;Emissions|NOx|Energy|Demand|Residential;1
+;;
+Emissions|NOx|Energy|Demand|Bunkers;Emissions|NOx|Energy|Demand|Bunkers|International Aviation;1
+Emissions|NOx|Energy|Demand|Bunkers;Emissions|NOx|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Bus;1
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Rail;1
+Emissions|NOx|Energy|Demand|Transportation;Emissions|NOx|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|NOx|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Combustion;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Electricity;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Fugitive;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Gases;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Heat;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Hydrogen;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Liquids;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Other;1
+Emissions|NOx|Energy|Supply;Emissions|NOx|Energy|Supply|Solids;1
+;;
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Biomass;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Coal;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Combustion;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Electricity;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Fugitive;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Gas;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Hydrogen;1
+Emissions|NOx|Energy|Supply|Gases;Emissions|NOx|Energy|Supply|Gases|Other;1
+;;
+Emissions|NOx|Energy|Supply|Gases|Fossil;Emissions|NOx|Energy|Supply|Gases|Coal;1
+Emissions|NOx|Energy|Supply|Gases|Fossil;Emissions|NOx|Energy|Supply|Gases|Gas;1
+;;
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Biomass;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Coal;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Combustion;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Electricity;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Fugitive;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Gas;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Geothermal;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Hydrogen;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Nuclear;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Oil;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Other;1
+Emissions|NOx|Energy|Supply|Heat;Emissions|NOx|Energy|Supply|Heat|Solar;1
+;;
+Emissions|NOx|Energy|Supply|Heat|Fossil;Emissions|NOx|Energy|Supply|Heat|Coal;1
+Emissions|NOx|Energy|Supply|Heat|Fossil;Emissions|NOx|Energy|Supply|Heat|Gas;1
+Emissions|NOx|Energy|Supply|Heat|Fossil;Emissions|NOx|Energy|Supply|Heat|Oil;1
+;;
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Biomass;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Coal;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Combustion;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Electricity;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Gas;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Oil;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Other;1
+Emissions|NOx|Energy|Supply|Hydrogen;Emissions|NOx|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|NOx|Energy|Supply|Hydrogen|Fossil;Emissions|NOx|Energy|Supply|Hydrogen|Coal;1
+Emissions|NOx|Energy|Supply|Hydrogen|Fossil;Emissions|NOx|Energy|Supply|Hydrogen|Gas;1
+Emissions|NOx|Energy|Supply|Hydrogen|Fossil;Emissions|NOx|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Biomass;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Coal;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Combustion;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Electricity;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Fugitive;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Gas;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Hydrogen;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Oil;1
+Emissions|NOx|Energy|Supply|Liquids;Emissions|NOx|Energy|Supply|Liquids|Other;1
+;;
+Emissions|NOx|Energy|Supply|Liquids|Fossil;Emissions|NOx|Energy|Supply|Liquids|Coal;1
+Emissions|NOx|Energy|Supply|Liquids|Fossil;Emissions|NOx|Energy|Supply|Liquids|Gas;1
+Emissions|NOx|Energy|Supply|Liquids|Fossil;Emissions|NOx|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|NOx|Energy|Supply|Solids;Emissions|NOx|Energy|Supply|Solids|Biomass;1
+Emissions|NOx|Energy|Supply|Solids;Emissions|NOx|Energy|Supply|Solids|Coal;1
+Emissions|NOx|Energy|Supply|Solids;Emissions|NOx|Energy|Supply|Solids|Combustion;1
+Emissions|NOx|Energy|Supply|Solids;Emissions|NOx|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Cement;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Chemicals;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Iron and Steel;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Non-Ferrous Metals;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Non-Metallic Minerals;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Other Sector;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Plastics;1
+Emissions|NOx|Industrial Processes;Emissions|NOx|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|NOx|Industrial Processes|Chemicals;Emissions|NOx|Industrial Processes|Chemicals|Ammonia;1
+Emissions|NOx|Industrial Processes|Chemicals;Emissions|NOx|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|NOx|Industrial Processes|Chemicals;Emissions|NOx|Industrial Processes|Chemicals|Methanol;1
+Emissions|NOx|Industrial Processes|Chemicals;Emissions|NOx|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|NOx|Product Use;Emissions|NOx|Product Use|Non-Energy Use;1
+Emissions|NOx|Product Use;Emissions|NOx|Product Use|ODS Substitutes;1
+Emissions|NOx|Product Use;Emissions|NOx|Product Use|Other;1
+Emissions|NOx|Product Use;Emissions|NOx|Product Use|Solvents;1
+;;
+Emissions|OC;Emissions|OC|AFOLU;1
+Emissions|OC;Emissions|OC|Energy and Industrial Processes;1
+Emissions|OC;Emissions|OC|Other;1
+Emissions|OC;Emissions|OC|Other Capture and Removal;1
+Emissions|OC;Emissions|OC|Product Use;1
+Emissions|OC;Emissions|OC|Waste;1
+;;
+Emissions|OC|Energy and Industrial Processes;Emissions|OC|Energy;1
+Emissions|OC|Energy and Industrial Processes;Emissions|OC|Industrial Processes;1
+;;
+Emissions|OC|AFOLU;Emissions|OC|AFOLU|Agricultural Waste Burning;1
+Emissions|OC|AFOLU;Emissions|OC|AFOLU|Agriculture;1
+Emissions|OC|AFOLU;Emissions|OC|AFOLU|Land;1
+;;
+Emissions|OC|AFOLU|Agriculture;Emissions|OC|AFOLU|Agriculture|Livestock;1
+Emissions|OC|AFOLU|Agriculture;Emissions|OC|AFOLU|Agriculture|Managed Soils;1
+Emissions|OC|AFOLU|Agriculture;Emissions|OC|AFOLU|Agriculture|Rice;1
+;;
+Emissions|OC|AFOLU|Agriculture|Livestock;Emissions|OC|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|OC|AFOLU|Agriculture|Livestock;Emissions|OC|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|OC|AFOLU|Land;Emissions|OC|AFOLU|Land|Fires;1
+Emissions|OC|AFOLU|Land;Emissions|OC|AFOLU|Land|Harvested Wood Products;1
+Emissions|OC|AFOLU|Land;Emissions|OC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|OC|AFOLU|Land;Emissions|OC|AFOLU|Land|Other;1
+Emissions|OC|AFOLU|Land;Emissions|OC|AFOLU|Land|Wetlands;1
+;;
+Emissions|OC|AFOLU|Land|Fires;Emissions|OC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|OC|AFOLU|Land|Fires;Emissions|OC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|OC|AFOLU|Land|Fires;Emissions|OC|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|OC|Energy;Emissions|OC|Energy|Demand;1
+Emissions|OC|Energy;Emissions|OC|Energy|Supply;1
+;;
+Emissions|OC|Energy|Demand;Emissions|OC|Energy|Demand|Bunkers;1
+Emissions|OC|Energy|Demand;Emissions|OC|Energy|Demand|Industry;1
+Emissions|OC|Energy|Demand;Emissions|OC|Energy|Demand|Other Sector;1
+Emissions|OC|Energy|Demand;Emissions|OC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|OC|Energy|Demand;Emissions|OC|Energy|Demand|Transportation;1
+;;
+Emissions|OC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|OC|Energy|Demand|AFOFI;1
+Emissions|OC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|OC|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|OC|Energy|Demand|Residential and Commercial;Emissions|OC|Energy|Demand|Commercial;1
+Emissions|OC|Energy|Demand|Residential and Commercial;Emissions|OC|Energy|Demand|Residential;1
+;;
+Emissions|OC|Energy|Demand|Bunkers;Emissions|OC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|OC|Energy|Demand|Bunkers;Emissions|OC|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Bus;1
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Rail;1
+Emissions|OC|Energy|Demand|Transportation;Emissions|OC|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|OC|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Combustion;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Electricity;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Fugitive;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Gases;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Heat;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Hydrogen;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Liquids;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Other;1
+Emissions|OC|Energy|Supply;Emissions|OC|Energy|Supply|Solids;1
+;;
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Biomass;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Coal;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Combustion;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Electricity;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Fugitive;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Gas;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Hydrogen;1
+Emissions|OC|Energy|Supply|Gases;Emissions|OC|Energy|Supply|Gases|Other;1
+;;
+Emissions|OC|Energy|Supply|Gases|Fossil;Emissions|OC|Energy|Supply|Gases|Coal;1
+Emissions|OC|Energy|Supply|Gases|Fossil;Emissions|OC|Energy|Supply|Gases|Gas;1
+;;
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Biomass;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Coal;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Combustion;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Electricity;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Fugitive;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Gas;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Geothermal;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Hydrogen;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Nuclear;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Oil;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Other;1
+Emissions|OC|Energy|Supply|Heat;Emissions|OC|Energy|Supply|Heat|Solar;1
+;;
+Emissions|OC|Energy|Supply|Heat|Fossil;Emissions|OC|Energy|Supply|Heat|Coal;1
+Emissions|OC|Energy|Supply|Heat|Fossil;Emissions|OC|Energy|Supply|Heat|Gas;1
+Emissions|OC|Energy|Supply|Heat|Fossil;Emissions|OC|Energy|Supply|Heat|Oil;1
+;;
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Biomass;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Coal;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Combustion;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Electricity;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Gas;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Oil;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Other;1
+Emissions|OC|Energy|Supply|Hydrogen;Emissions|OC|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|OC|Energy|Supply|Hydrogen|Fossil;Emissions|OC|Energy|Supply|Hydrogen|Coal;1
+Emissions|OC|Energy|Supply|Hydrogen|Fossil;Emissions|OC|Energy|Supply|Hydrogen|Gas;1
+Emissions|OC|Energy|Supply|Hydrogen|Fossil;Emissions|OC|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Biomass;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Coal;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Combustion;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Electricity;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Fugitive;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Gas;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Hydrogen;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Oil;1
+Emissions|OC|Energy|Supply|Liquids;Emissions|OC|Energy|Supply|Liquids|Other;1
+;;
+Emissions|OC|Energy|Supply|Liquids|Fossil;Emissions|OC|Energy|Supply|Liquids|Coal;1
+Emissions|OC|Energy|Supply|Liquids|Fossil;Emissions|OC|Energy|Supply|Liquids|Gas;1
+Emissions|OC|Energy|Supply|Liquids|Fossil;Emissions|OC|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|OC|Energy|Supply|Solids;Emissions|OC|Energy|Supply|Solids|Biomass;1
+Emissions|OC|Energy|Supply|Solids;Emissions|OC|Energy|Supply|Solids|Coal;1
+Emissions|OC|Energy|Supply|Solids;Emissions|OC|Energy|Supply|Solids|Combustion;1
+Emissions|OC|Energy|Supply|Solids;Emissions|OC|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Cement;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Chemicals;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Iron and Steel;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Non-Ferrous Metals;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Non-Metallic Minerals;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Other Sector;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Plastics;1
+Emissions|OC|Industrial Processes;Emissions|OC|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|OC|Industrial Processes|Chemicals;Emissions|OC|Industrial Processes|Chemicals|Ammonia;1
+Emissions|OC|Industrial Processes|Chemicals;Emissions|OC|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|OC|Industrial Processes|Chemicals;Emissions|OC|Industrial Processes|Chemicals|Methanol;1
+Emissions|OC|Industrial Processes|Chemicals;Emissions|OC|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|OC|Product Use;Emissions|OC|Product Use|Non-Energy Use;1
+Emissions|OC|Product Use;Emissions|OC|Product Use|ODS Substitutes;1
+Emissions|OC|Product Use;Emissions|OC|Product Use|Other;1
+Emissions|OC|Product Use;Emissions|OC|Product Use|Solvents;1
+;;
+Emissions|Sulfur;Emissions|Sulfur|AFOLU;1
+Emissions|Sulfur;Emissions|Sulfur|Energy and Industrial Processes;1
+Emissions|Sulfur;Emissions|Sulfur|Other;1
+Emissions|Sulfur;Emissions|Sulfur|Other Capture and Removal;1
+Emissions|Sulfur;Emissions|Sulfur|Product Use;1
+Emissions|Sulfur;Emissions|Sulfur|Waste;1
+;;
+Emissions|Sulfur|Energy and Industrial Processes;Emissions|Sulfur|Energy;1
+Emissions|Sulfur|Energy and Industrial Processes;Emissions|Sulfur|Industrial Processes;1
+;;
+Emissions|Sulfur|AFOLU;Emissions|Sulfur|AFOLU|Agricultural Waste Burning;1
+Emissions|Sulfur|AFOLU;Emissions|Sulfur|AFOLU|Agriculture;1
+Emissions|Sulfur|AFOLU;Emissions|Sulfur|AFOLU|Land;1
+;;
+Emissions|Sulfur|AFOLU|Agriculture;Emissions|Sulfur|AFOLU|Agriculture|Livestock;1
+Emissions|Sulfur|AFOLU|Agriculture;Emissions|Sulfur|AFOLU|Agriculture|Managed Soils;1
+Emissions|Sulfur|AFOLU|Agriculture;Emissions|Sulfur|AFOLU|Agriculture|Rice;1
+;;
+Emissions|Sulfur|AFOLU|Agriculture|Livestock;Emissions|Sulfur|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|Sulfur|AFOLU|Agriculture|Livestock;Emissions|Sulfur|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|Sulfur|AFOLU|Land;Emissions|Sulfur|AFOLU|Land|Fires;1
+Emissions|Sulfur|AFOLU|Land;Emissions|Sulfur|AFOLU|Land|Harvested Wood Products;1
+Emissions|Sulfur|AFOLU|Land;Emissions|Sulfur|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|Sulfur|AFOLU|Land;Emissions|Sulfur|AFOLU|Land|Other;1
+Emissions|Sulfur|AFOLU|Land;Emissions|Sulfur|AFOLU|Land|Wetlands;1
+;;
+Emissions|Sulfur|AFOLU|Land|Fires;Emissions|Sulfur|AFOLU|Land|Fires|Forest Burning;1
+Emissions|Sulfur|AFOLU|Land|Fires;Emissions|Sulfur|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|Sulfur|AFOLU|Land|Fires;Emissions|Sulfur|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|Sulfur|Energy;Emissions|Sulfur|Energy|Demand;1
+Emissions|Sulfur|Energy;Emissions|Sulfur|Energy|Supply;1
+;;
+Emissions|Sulfur|Energy|Demand;Emissions|Sulfur|Energy|Demand|Bunkers;1
+Emissions|Sulfur|Energy|Demand;Emissions|Sulfur|Energy|Demand|Industry;1
+Emissions|Sulfur|Energy|Demand;Emissions|Sulfur|Energy|Demand|Other Sector;1
+Emissions|Sulfur|Energy|Demand;Emissions|Sulfur|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|Sulfur|Energy|Demand;Emissions|Sulfur|Energy|Demand|Transportation;1
+;;
+Emissions|Sulfur|Energy|Demand|Residential and Commercial and AFOFI;Emissions|Sulfur|Energy|Demand|AFOFI;1
+Emissions|Sulfur|Energy|Demand|Residential and Commercial and AFOFI;Emissions|Sulfur|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|Sulfur|Energy|Demand|Residential and Commercial;Emissions|Sulfur|Energy|Demand|Commercial;1
+Emissions|Sulfur|Energy|Demand|Residential and Commercial;Emissions|Sulfur|Energy|Demand|Residential;1
+;;
+Emissions|Sulfur|Energy|Demand|Bunkers;Emissions|Sulfur|Energy|Demand|Bunkers|International Aviation;1
+Emissions|Sulfur|Energy|Demand|Bunkers;Emissions|Sulfur|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Bus;1
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Rail;1
+Emissions|Sulfur|Energy|Demand|Transportation;Emissions|Sulfur|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|Sulfur|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Combustion;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Electricity;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Fugitive;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Gases;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Heat;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Hydrogen;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Liquids;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Other;1
+Emissions|Sulfur|Energy|Supply;Emissions|Sulfur|Energy|Supply|Solids;1
+;;
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Biomass;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Coal;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Combustion;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Electricity;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Fugitive;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Gas;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Hydrogen;1
+Emissions|Sulfur|Energy|Supply|Gases;Emissions|Sulfur|Energy|Supply|Gases|Other;1
+;;
+Emissions|Sulfur|Energy|Supply|Gases|Fossil;Emissions|Sulfur|Energy|Supply|Gases|Coal;1
+Emissions|Sulfur|Energy|Supply|Gases|Fossil;Emissions|Sulfur|Energy|Supply|Gases|Gas;1
+;;
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Biomass;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Coal;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Combustion;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Electricity;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Fugitive;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Gas;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Geothermal;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Hydrogen;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Nuclear;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Oil;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Other;1
+Emissions|Sulfur|Energy|Supply|Heat;Emissions|Sulfur|Energy|Supply|Heat|Solar;1
+;;
+Emissions|Sulfur|Energy|Supply|Heat|Fossil;Emissions|Sulfur|Energy|Supply|Heat|Coal;1
+Emissions|Sulfur|Energy|Supply|Heat|Fossil;Emissions|Sulfur|Energy|Supply|Heat|Gas;1
+Emissions|Sulfur|Energy|Supply|Heat|Fossil;Emissions|Sulfur|Energy|Supply|Heat|Oil;1
+;;
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Biomass;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Coal;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Combustion;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Electricity;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Gas;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Oil;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Other;1
+Emissions|Sulfur|Energy|Supply|Hydrogen;Emissions|Sulfur|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|Sulfur|Energy|Supply|Hydrogen|Fossil;Emissions|Sulfur|Energy|Supply|Hydrogen|Coal;1
+Emissions|Sulfur|Energy|Supply|Hydrogen|Fossil;Emissions|Sulfur|Energy|Supply|Hydrogen|Gas;1
+Emissions|Sulfur|Energy|Supply|Hydrogen|Fossil;Emissions|Sulfur|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Biomass;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Coal;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Combustion;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Electricity;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Fugitive;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Gas;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Hydrogen;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Oil;1
+Emissions|Sulfur|Energy|Supply|Liquids;Emissions|Sulfur|Energy|Supply|Liquids|Other;1
+;;
+Emissions|Sulfur|Energy|Supply|Liquids|Fossil;Emissions|Sulfur|Energy|Supply|Liquids|Coal;1
+Emissions|Sulfur|Energy|Supply|Liquids|Fossil;Emissions|Sulfur|Energy|Supply|Liquids|Gas;1
+Emissions|Sulfur|Energy|Supply|Liquids|Fossil;Emissions|Sulfur|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|Sulfur|Energy|Supply|Solids;Emissions|Sulfur|Energy|Supply|Solids|Biomass;1
+Emissions|Sulfur|Energy|Supply|Solids;Emissions|Sulfur|Energy|Supply|Solids|Coal;1
+Emissions|Sulfur|Energy|Supply|Solids;Emissions|Sulfur|Energy|Supply|Solids|Combustion;1
+Emissions|Sulfur|Energy|Supply|Solids;Emissions|Sulfur|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Cement;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Chemicals;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Iron and Steel;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Non-Ferrous Metals;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Non-Metallic Minerals;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Other Sector;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Plastics;1
+Emissions|Sulfur|Industrial Processes;Emissions|Sulfur|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|Sulfur|Industrial Processes|Chemicals;Emissions|Sulfur|Industrial Processes|Chemicals|Ammonia;1
+Emissions|Sulfur|Industrial Processes|Chemicals;Emissions|Sulfur|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|Sulfur|Industrial Processes|Chemicals;Emissions|Sulfur|Industrial Processes|Chemicals|Methanol;1
+Emissions|Sulfur|Industrial Processes|Chemicals;Emissions|Sulfur|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|Sulfur|Product Use;Emissions|Sulfur|Product Use|Non-Energy Use;1
+Emissions|Sulfur|Product Use;Emissions|Sulfur|Product Use|ODS Substitutes;1
+Emissions|Sulfur|Product Use;Emissions|Sulfur|Product Use|Other;1
+Emissions|Sulfur|Product Use;Emissions|Sulfur|Product Use|Solvents;1
+;;
+Emissions|VOC;Emissions|VOC|AFOLU;1
+Emissions|VOC;Emissions|VOC|Energy and Industrial Processes;1
+Emissions|VOC;Emissions|VOC|Other;1
+Emissions|VOC;Emissions|VOC|Other Capture and Removal;1
+Emissions|VOC;Emissions|VOC|Product Use;1
+Emissions|VOC;Emissions|VOC|Waste;1
+;;
+Emissions|VOC|Energy and Industrial Processes;Emissions|VOC|Energy;1
+Emissions|VOC|Energy and Industrial Processes;Emissions|VOC|Industrial Processes;1
+;;
+Emissions|VOC|AFOLU;Emissions|VOC|AFOLU|Agricultural Waste Burning;1
+Emissions|VOC|AFOLU;Emissions|VOC|AFOLU|Agriculture;1
+Emissions|VOC|AFOLU;Emissions|VOC|AFOLU|Land;1
+;;
+Emissions|VOC|AFOLU|Agriculture;Emissions|VOC|AFOLU|Agriculture|Livestock;1
+Emissions|VOC|AFOLU|Agriculture;Emissions|VOC|AFOLU|Agriculture|Managed Soils;1
+Emissions|VOC|AFOLU|Agriculture;Emissions|VOC|AFOLU|Agriculture|Rice;1
+;;
+Emissions|VOC|AFOLU|Agriculture|Livestock;Emissions|VOC|AFOLU|Agriculture|Livestock|Enteric Fermentation;1
+Emissions|VOC|AFOLU|Agriculture|Livestock;Emissions|VOC|AFOLU|Agriculture|Livestock|Manure Management;1
+;;
+Emissions|VOC|AFOLU|Land;Emissions|VOC|AFOLU|Land|Fires;1
+Emissions|VOC|AFOLU|Land;Emissions|VOC|AFOLU|Land|Harvested Wood Products;1
+Emissions|VOC|AFOLU|Land;Emissions|VOC|AFOLU|Land|Land Use and Land-Use Change;1
+Emissions|VOC|AFOLU|Land;Emissions|VOC|AFOLU|Land|Other;1
+Emissions|VOC|AFOLU|Land;Emissions|VOC|AFOLU|Land|Wetlands;1
+;;
+Emissions|VOC|AFOLU|Land|Fires;Emissions|VOC|AFOLU|Land|Fires|Forest Burning;1
+Emissions|VOC|AFOLU|Land|Fires;Emissions|VOC|AFOLU|Land|Fires|Grassland Burning;1
+Emissions|VOC|AFOLU|Land|Fires;Emissions|VOC|AFOLU|Land|Fires|Peat Burning;1
+;;
+Emissions|VOC|Energy;Emissions|VOC|Energy|Demand;1
+Emissions|VOC|Energy;Emissions|VOC|Energy|Supply;1
+;;
+Emissions|VOC|Energy|Demand;Emissions|VOC|Energy|Demand|Bunkers;1
+Emissions|VOC|Energy|Demand;Emissions|VOC|Energy|Demand|Industry;1
+Emissions|VOC|Energy|Demand;Emissions|VOC|Energy|Demand|Other Sector;1
+Emissions|VOC|Energy|Demand;Emissions|VOC|Energy|Demand|Residential and Commercial and AFOFI;1
+Emissions|VOC|Energy|Demand;Emissions|VOC|Energy|Demand|Transportation;1
+;;
+Emissions|VOC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|VOC|Energy|Demand|AFOFI;1
+Emissions|VOC|Energy|Demand|Residential and Commercial and AFOFI;Emissions|VOC|Energy|Demand|Residential and Commercial;1
+;;
+Emissions|VOC|Energy|Demand|Residential and Commercial;Emissions|VOC|Energy|Demand|Commercial;1
+Emissions|VOC|Energy|Demand|Residential and Commercial;Emissions|VOC|Energy|Demand|Residential;1
+;;
+Emissions|VOC|Energy|Demand|Bunkers;Emissions|VOC|Energy|Demand|Bunkers|International Aviation;1
+Emissions|VOC|Energy|Demand|Bunkers;Emissions|VOC|Energy|Demand|Bunkers|International Shipping;1
+;;
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Bus;1
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Domestic Aviation;1
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Domestic Shipping;1
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;1
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Rail;1
+Emissions|VOC|Energy|Demand|Transportation;Emissions|VOC|Energy|Demand|Transportation|Truck;1
+;;
+Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle|Compact Car;1
+Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle|Midsize Car;1
+Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle;Emissions|VOC|Energy|Demand|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Combustion;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Electricity;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Fugitive;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Gases;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Heat;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Hydrogen;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Liquids;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Other;1
+Emissions|VOC|Energy|Supply;Emissions|VOC|Energy|Supply|Solids;1
+;;
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Biomass;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Coal;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Combustion;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Electricity;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Fugitive;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Gas;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Hydrogen;1
+Emissions|VOC|Energy|Supply|Gases;Emissions|VOC|Energy|Supply|Gases|Other;1
+;;
+Emissions|VOC|Energy|Supply|Gases|Fossil;Emissions|VOC|Energy|Supply|Gases|Coal;1
+Emissions|VOC|Energy|Supply|Gases|Fossil;Emissions|VOC|Energy|Supply|Gases|Gas;1
+;;
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Biomass;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Coal;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Combustion;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Electricity;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Fugitive;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Gas;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Geothermal;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Hydrogen;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Nuclear;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Oil;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Other;1
+Emissions|VOC|Energy|Supply|Heat;Emissions|VOC|Energy|Supply|Heat|Solar;1
+;;
+Emissions|VOC|Energy|Supply|Heat|Fossil;Emissions|VOC|Energy|Supply|Heat|Coal;1
+Emissions|VOC|Energy|Supply|Heat|Fossil;Emissions|VOC|Energy|Supply|Heat|Gas;1
+Emissions|VOC|Energy|Supply|Heat|Fossil;Emissions|VOC|Energy|Supply|Heat|Oil;1
+;;
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Biomass;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Coal;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Combustion;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Electricity;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Fugitive;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Gas;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Nuclear;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Oil;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Other;1
+Emissions|VOC|Energy|Supply|Hydrogen;Emissions|VOC|Energy|Supply|Hydrogen|Solar;1
+;;
+Emissions|VOC|Energy|Supply|Hydrogen|Fossil;Emissions|VOC|Energy|Supply|Hydrogen|Coal;1
+Emissions|VOC|Energy|Supply|Hydrogen|Fossil;Emissions|VOC|Energy|Supply|Hydrogen|Gas;1
+Emissions|VOC|Energy|Supply|Hydrogen|Fossil;Emissions|VOC|Energy|Supply|Hydrogen|Oil;1
+;;
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Biomass;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Coal;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Combustion;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Electricity;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Fugitive;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Gas;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Hydrogen;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Oil;1
+Emissions|VOC|Energy|Supply|Liquids;Emissions|VOC|Energy|Supply|Liquids|Other;1
+;;
+Emissions|VOC|Energy|Supply|Liquids|Fossil;Emissions|VOC|Energy|Supply|Liquids|Coal;1
+Emissions|VOC|Energy|Supply|Liquids|Fossil;Emissions|VOC|Energy|Supply|Liquids|Gas;1
+Emissions|VOC|Energy|Supply|Liquids|Fossil;Emissions|VOC|Energy|Supply|Liquids|Oil;1
+;;
+Emissions|VOC|Energy|Supply|Solids;Emissions|VOC|Energy|Supply|Solids|Biomass;1
+Emissions|VOC|Energy|Supply|Solids;Emissions|VOC|Energy|Supply|Solids|Coal;1
+Emissions|VOC|Energy|Supply|Solids;Emissions|VOC|Energy|Supply|Solids|Combustion;1
+Emissions|VOC|Energy|Supply|Solids;Emissions|VOC|Energy|Supply|Solids|Fugitive;1
+;;
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Cement;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Chemicals;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Iron and Steel;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Non-Ferrous Metals;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Non-Metallic Minerals;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Other Sector;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Plastics;1
+Emissions|VOC|Industrial Processes;Emissions|VOC|Industrial Processes|Pulp and Paper;1
+;;
+Emissions|VOC|Industrial Processes|Chemicals;Emissions|VOC|Industrial Processes|Chemicals|Ammonia;1
+Emissions|VOC|Industrial Processes|Chemicals;Emissions|VOC|Industrial Processes|Chemicals|High-Value Chemicals;1
+Emissions|VOC|Industrial Processes|Chemicals;Emissions|VOC|Industrial Processes|Chemicals|Methanol;1
+Emissions|VOC|Industrial Processes|Chemicals;Emissions|VOC|Industrial Processes|Chemicals|Other Sector;1
+;;
+Emissions|VOC|Product Use;Emissions|VOC|Product Use|Non-Energy Use;1
+Emissions|VOC|Product Use;Emissions|VOC|Product Use|ODS Substitutes;1
+Emissions|VOC|Product Use;Emissions|VOC|Product Use|Other;1
+Emissions|VOC|Product Use;Emissions|VOC|Product Use|Solvents;1
+;;
+Energy Service|Transportation|Freight;Energy Service|Transportation|Freight|Truck;1
+;;
+Energy Service|Transportation|Freight|Truck;Energy Service|Transportation|Freight|Truck|Battery-Electric;1
+Energy Service|Transportation|Freight|Truck;Energy Service|Transportation|Freight|Truck|Fuel-Cell-Electric;1
+Energy Service|Transportation|Freight|Truck;Energy Service|Transportation|Freight|Truck|Internal Combustion;1
+Energy Service|Transportation|Freight|Truck;Energy Service|Transportation|Freight|Truck|Plug-in Hybrid;1
+;;
+Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle;Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle|Battery-Electric;1
+Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle;Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle|Fuel-Cell-Electric;1
+Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle;Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle|Internal Combustion;1
+Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle;Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle|Plug-in Hybrid;1
+;;
+Fertilizer Use|Nitrogen;Fertilizer Use|Nitrogen|Organic;1
+Fertilizer Use|Nitrogen;Fertilizer Use|Nitrogen|Synthetic;1
+;;
+Fertilizer Use|Phosphorus;Fertilizer Use|Phosphorus|Organic;1
+Fertilizer Use|Phosphorus;Fertilizer Use|Phosphorus|Synthetic;1
+;;
 Final Energy;Final Energy|Electricity;1
 Final Energy;Final Energy|Gases;1
 Final Energy;Final Energy|Geothermal;1
@@ -345,24 +2740,3129 @@ Final Energy;Final Energy|Solar;1
 Final Energy;Final Energy|Solids;1
 Final Energy;Final Energy|Waste;1
 ;;
-## Final Energy by Sector without bunkers;;
-Final Energy (w/o bunkers);Final Energy|Agriculture;1
-Final Energy (w/o bunkers);Final Energy|Industry;1
-Final Energy (w/o bunkers);Final Energy|Non-Energy Use;1
-Final Energy (w/o bunkers);Final Energy|Other Sector;1
-Final Energy (w/o bunkers);Final Energy|Residential and Commercial;1
-Final Energy (w/o bunkers);Final Energy|Transportation;1
+Final Energy 2;Final Energy|Agriculture;1
+Final Energy 2;Final Energy|Bunkers;1
+Final Energy 2;Final Energy|Industry;1
+Final Energy 2;Final Energy|Non-Energy Use;1
+Final Energy 2;Final Energy|Other Sector;1
+Final Energy 2;Final Energy|Residential and Commercial;1
+Final Energy 2;Final Energy|Transportation;1
 ;;
-## Final Energy Bunkers;;
-Final Energy|Bunkers;Final Energy;1
-Final Energy|Bunkers;Final Energy (w/o bunkers);-1
+Final Energy 3;Final Energy|Bunkers;1
+Final Energy 3;Final Energy (w/o bunkers);1
 ;;
-## Final Energy Transportation with and without bunkers;;
-Final Energy|Transportation;Final Energy|Transportation (w/ bunkers);1
-Final Energy|Transportation;Final Energy|Bunkers;-1
+Final Energy|Transportation (w/ bunkers);Final Energy|Bunkers;1
+Final Energy|Transportation (w/ bunkers);Final Energy|Transportation;1
 ;;
-# Primary Energy;;
-## Primary Energy by Carrier;;
+Final Energy|Residential and Commercial;Final Energy|Commercial;1
+Final Energy|Residential and Commercial;Final Energy|Residential;1
+;;
+Final Energy|Agriculture;Final Energy|Agriculture|Electricity;1
+Final Energy|Agriculture;Final Energy|Agriculture|Gases;1
+Final Energy|Agriculture;Final Energy|Agriculture|Heat;1
+Final Energy|Agriculture;Final Energy|Agriculture|Hydrogen;1
+Final Energy|Agriculture;Final Energy|Agriculture|Liquids;1
+Final Energy|Agriculture;Final Energy|Agriculture|Other;1
+Final Energy|Agriculture;Final Energy|Agriculture|Solids;1
+;;
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Biomass;1
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Coal;1
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Electricity;1
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Gas;1
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Hydrogen;1
+Final Energy|Agriculture|Gases;Final Energy|Agriculture|Gases|Other;1
+;;
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Biomass;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Coal;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Electricity;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Gas;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Geothermal;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Hydrogen;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Nuclear;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Oil;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Other;1
+Final Energy|Agriculture|Heat;Final Energy|Agriculture|Heat|Solar;1
+;;
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Biomass;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Coal;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Electricity;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Gas;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Nuclear;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Oil;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Other;1
+Final Energy|Agriculture|Hydrogen;Final Energy|Agriculture|Hydrogen|Solar;1
+;;
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Biomass;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Coal;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Electricity;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Gas;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Hydrogen;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Oil;1
+Final Energy|Agriculture|Liquids;Final Energy|Agriculture|Liquids|Other;1
+;;
+Final Energy|Agriculture|Solids;Final Energy|Agriculture|Solids|Biomass;1
+Final Energy|Agriculture|Solids;Final Energy|Agriculture|Solids|Coal;1
+;;
+Final Energy|Bunkers;Final Energy|Bunkers|Electricity;1
+Final Energy|Bunkers;Final Energy|Bunkers|Gases;1
+Final Energy|Bunkers;Final Energy|Bunkers|Heat;1
+Final Energy|Bunkers;Final Energy|Bunkers|Hydrogen;1
+Final Energy|Bunkers;Final Energy|Bunkers|Liquids;1
+Final Energy|Bunkers;Final Energy|Bunkers|Other;1
+Final Energy|Bunkers;Final Energy|Bunkers|Solids;1
+;;
+Final Energy|Bunkers 2;Final Energy|Bunkers|Freight;1
+Final Energy|Bunkers 2;Final Energy|Bunkers|Passenger;1
+;;
+Final Energy|Bunkers 3;Final Energy|Bunkers|International Aviation;1
+Final Energy|Bunkers 3;Final Energy|Bunkers|International Shipping;1
+;;
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Biomass;1
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Coal;1
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Electricity;1
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Gas;1
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Hydrogen;1
+Final Energy|Bunkers|Gases;Final Energy|Bunkers|Gases|Other;1
+;;
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Biomass;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Coal;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Electricity;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Gas;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Geothermal;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Hydrogen;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Nuclear;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Oil;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Other;1
+Final Energy|Bunkers|Heat;Final Energy|Bunkers|Heat|Solar;1
+;;
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Biomass;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Coal;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Electricity;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Gas;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Nuclear;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Oil;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Other;1
+Final Energy|Bunkers|Hydrogen;Final Energy|Bunkers|Hydrogen|Solar;1
+;;
+Final Energy|Bunkers|International Aviation;Final Energy|Bunkers|International Aviation|Freight;1
+Final Energy|Bunkers|International Aviation;Final Energy|Bunkers|International Aviation|Passenger;1
+;;
+Final Energy|Bunkers|International Shipping;Final Energy|Bunkers|International Shipping|Freight;1
+Final Energy|Bunkers|International Shipping;Final Energy|Bunkers|International Shipping|Passenger;1
+;;
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Biomass;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Coal;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Electricity;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Gas;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Hydrogen;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Oil;1
+Final Energy|Bunkers|Liquids;Final Energy|Bunkers|Liquids|Other;1
+;;
+Final Energy|Bunkers|Solids;Final Energy|Bunkers|Solids|Biomass;1
+Final Energy|Bunkers|Solids;Final Energy|Bunkers|Solids|Coal;1
+;;
+Final Energy|Carbon Management;Final Energy|Carbon Management|Biochar;1
+Final Energy|Carbon Management;Final Energy|Carbon Management|Carbon Capture and Storage;1
+Final Energy|Carbon Management;Final Energy|Carbon Management|Direct Air Capture;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Direct Ocean Capture;1
+Final Energy|Carbon Management;Final Energy|Carbon Management|Enhanced Weathering;1
+Final Energy|Carbon Management;Final Energy|Carbon Management|Hydrogen;1
+Final Energy|Carbon Management;Final Energy|Carbon Management|Ocean Alkalinity Enhancement;1
+;;
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Electricity;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Gases;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Heat;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Liquids;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Other;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Solids;1
+;;
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Electricity;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Gases;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Heat;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Hydrogen;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Liquids;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Other;1
+Final Energy|Carbon Management|Biochar;Final Energy|Carbon Management|Biochar|Solids;1
+;;
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Biomass;1
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Coal;1
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Electricity;1
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Gas;1
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Hydrogen;1
+Final Energy|Carbon Management|Biochar|Gases;Final Energy|Carbon Management|Biochar|Gases|Other;1
+;;
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Biomass;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Coal;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Electricity;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Gas;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Geothermal;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Hydrogen;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Nuclear;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Oil;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Other;1
+Final Energy|Carbon Management|Biochar|Heat;Final Energy|Carbon Management|Biochar|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Coal;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Gas;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Oil;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Other;1
+Final Energy|Carbon Management|Biochar|Hydrogen;Final Energy|Carbon Management|Biochar|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Biomass;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Coal;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Electricity;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Gas;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Oil;1
+Final Energy|Carbon Management|Biochar|Liquids;Final Energy|Carbon Management|Biochar|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Biochar|Solids;Final Energy|Carbon Management|Biochar|Solids|Biomass;1
+Final Energy|Carbon Management|Biochar|Solids;Final Energy|Carbon Management|Biochar|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Electricity;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Gases;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Heat;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Other;1
+Final Energy|Carbon Management|Carbon Capture and Storage;Final Energy|Carbon Management|Carbon Capture and Storage|Solids;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Biomass;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Coal;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Electricity;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Gas;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Hydrogen;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Gases;Final Energy|Carbon Management|Carbon Capture and Storage|Gases|Other;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Biomass;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Coal;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Electricity;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Gas;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Geothermal;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Hydrogen;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Nuclear;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Oil;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Other;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Heat;Final Energy|Carbon Management|Carbon Capture and Storage|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Coal;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Gas;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Oil;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Other;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen;Final Energy|Carbon Management|Carbon Capture and Storage|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Biomass;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Coal;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Electricity;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Gas;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Oil;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Liquids;Final Energy|Carbon Management|Carbon Capture and Storage|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Carbon Capture and Storage|Solids;Final Energy|Carbon Management|Carbon Capture and Storage|Solids|Biomass;1
+Final Energy|Carbon Management|Carbon Capture and Storage|Solids;Final Energy|Carbon Management|Carbon Capture and Storage|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Electricity;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Gases;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Heat;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Hydrogen;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Liquids;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Other;1
+Final Energy|Carbon Management|Direct Air Capture;Final Energy|Carbon Management|Direct Air Capture|Solids;1
+;;
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Biomass;1
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Coal;1
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Electricity;1
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Gas;1
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Hydrogen;1
+Final Energy|Carbon Management|Direct Air Capture|Gases;Final Energy|Carbon Management|Direct Air Capture|Gases|Other;1
+;;
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Biomass;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Coal;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Electricity;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Gas;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Geothermal;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Hydrogen;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Nuclear;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Oil;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Other;1
+Final Energy|Carbon Management|Direct Air Capture|Heat;Final Energy|Carbon Management|Direct Air Capture|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Coal;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Gas;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Oil;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Other;1
+Final Energy|Carbon Management|Direct Air Capture|Hydrogen;Final Energy|Carbon Management|Direct Air Capture|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Biomass;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Coal;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Electricity;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Gas;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Oil;1
+Final Energy|Carbon Management|Direct Air Capture|Liquids;Final Energy|Carbon Management|Direct Air Capture|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Direct Air Capture|Solids;Final Energy|Carbon Management|Direct Air Capture|Solids|Biomass;1
+Final Energy|Carbon Management|Direct Air Capture|Solids;Final Energy|Carbon Management|Direct Air Capture|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Electricity;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Gases;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Heat;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Liquids;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Other;1
+Final Energy|Carbon Management|Direct Ocean Capture;Final Energy|Carbon Management|Direct Ocean Capture|Solids;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Biomass;1
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Coal;1
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Electricity;1
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Gas;1
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Hydrogen;1
+Final Energy|Carbon Management|Direct Ocean Capture|Gases;Final Energy|Carbon Management|Direct Ocean Capture|Gases|Other;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Biomass;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Coal;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Electricity;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Gas;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Geothermal;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Hydrogen;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Nuclear;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Oil;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Other;1
+Final Energy|Carbon Management|Direct Ocean Capture|Heat;Final Energy|Carbon Management|Direct Ocean Capture|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Coal;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Gas;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Oil;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Other;1
+Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen;Final Energy|Carbon Management|Direct Ocean Capture|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Biomass;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Coal;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Electricity;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Gas;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Oil;1
+Final Energy|Carbon Management|Direct Ocean Capture|Liquids;Final Energy|Carbon Management|Direct Ocean Capture|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Direct Ocean Capture|Solids;Final Energy|Carbon Management|Direct Ocean Capture|Solids|Biomass;1
+Final Energy|Carbon Management|Direct Ocean Capture|Solids;Final Energy|Carbon Management|Direct Ocean Capture|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Electricity;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Gases;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Heat;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Liquids;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Other;1
+Final Energy|Carbon Management|Enhanced Weathering;Final Energy|Carbon Management|Enhanced Weathering|Solids;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Biomass;1
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Coal;1
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Electricity;1
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Gas;1
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Hydrogen;1
+Final Energy|Carbon Management|Enhanced Weathering|Gases;Final Energy|Carbon Management|Enhanced Weathering|Gases|Other;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Biomass;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Coal;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Electricity;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Gas;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Geothermal;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Hydrogen;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Nuclear;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Oil;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Other;1
+Final Energy|Carbon Management|Enhanced Weathering|Heat;Final Energy|Carbon Management|Enhanced Weathering|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Coal;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Gas;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Oil;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Other;1
+Final Energy|Carbon Management|Enhanced Weathering|Hydrogen;Final Energy|Carbon Management|Enhanced Weathering|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Biomass;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Coal;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Electricity;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Gas;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Oil;1
+Final Energy|Carbon Management|Enhanced Weathering|Liquids;Final Energy|Carbon Management|Enhanced Weathering|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Enhanced Weathering|Solids;Final Energy|Carbon Management|Enhanced Weathering|Solids|Biomass;1
+Final Energy|Carbon Management|Enhanced Weathering|Solids;Final Energy|Carbon Management|Enhanced Weathering|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Biomass;1
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Coal;1
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Electricity;1
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Gas;1
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Hydrogen;1
+Final Energy|Carbon Management|Gases;Final Energy|Carbon Management|Gases|Other;1
+;;
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Biomass;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Coal;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Electricity;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Gas;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Geothermal;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Hydrogen;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Nuclear;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Oil;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Other;1
+Final Energy|Carbon Management|Heat;Final Energy|Carbon Management|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Coal;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Gas;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Oil;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Other;1
+Final Energy|Carbon Management|Hydrogen;Final Energy|Carbon Management|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Biomass;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Coal;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Electricity;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Gas;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Oil;1
+Final Energy|Carbon Management|Liquids;Final Energy|Carbon Management|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Electricity;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Other;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Solids;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Biomass;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Coal;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Electricity;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Gas;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Hydrogen;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Gases|Other;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Biomass;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Coal;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Electricity;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Gas;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Geothermal;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Hydrogen;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Nuclear;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Oil;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Other;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Heat|Solar;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Biomass;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Coal;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Electricity;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Gas;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Nuclear;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Oil;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Other;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Hydrogen|Solar;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Biomass;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Coal;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Electricity;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Gas;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Hydrogen;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Oil;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Liquids|Other;1
+;;
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Solids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Solids|Biomass;1
+Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Solids;Final Energy|Carbon Management|Ocean Alkalinity Enhancement|Solids|Coal;1
+;;
+Final Energy|Carbon Management|Solids;Final Energy|Carbon Management|Solids|Biomass;1
+Final Energy|Carbon Management|Solids;Final Energy|Carbon Management|Solids|Coal;1
+;;
+Final Energy|Commercial;Final Energy|Commercial|Electricity;1
+Final Energy|Commercial;Final Energy|Commercial|Gases;1
+Final Energy|Commercial;Final Energy|Commercial|Heat;1
+Final Energy|Commercial;Final Energy|Commercial|Hydrogen;1
+Final Energy|Commercial;Final Energy|Commercial|Liquids;1
+Final Energy|Commercial;Final Energy|Commercial|Other;1
+Final Energy|Commercial;Final Energy|Commercial|Solids;1
+Final Energy|Commercial;Final Energy|Commercial|Water;1
+;;
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Biomass;1
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Coal;1
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Electricity;1
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Gas;1
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Hydrogen;1
+Final Energy|Commercial|Gases;Final Energy|Commercial|Gases|Other;1
+;;
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Biomass;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Coal;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Electricity;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Gas;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Geothermal;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Hydrogen;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Nuclear;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Oil;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Other;1
+Final Energy|Commercial|Heat;Final Energy|Commercial|Heat|Solar;1
+;;
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Biomass;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Coal;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Electricity;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Gas;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Nuclear;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Oil;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Other;1
+Final Energy|Commercial|Hydrogen;Final Energy|Commercial|Hydrogen|Solar;1
+;;
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Biomass;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Coal;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Electricity;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Gas;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Hydrogen;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Oil;1
+Final Energy|Commercial|Liquids;Final Energy|Commercial|Liquids|Other;1
+;;
+Final Energy|Commercial|Solids;Final Energy|Commercial|Solids|Biomass;1
+Final Energy|Commercial|Solids;Final Energy|Commercial|Solids|Coal;1
+;;
+Final Energy|Commercial|Water;Final Energy|Commercial|Water|Desalination;1
+Final Energy|Commercial|Water;Final Energy|Commercial|Water|Groundwater Extraction;1
+Final Energy|Commercial|Water;Final Energy|Commercial|Water|Surface Water Extraction;1
+Final Energy|Commercial|Water;Final Energy|Commercial|Water|Transfer;1
+;;
+Final Energy|Gases;Final Energy|Gases|Biomass;1
+Final Energy|Gases;Final Energy|Gases|Coal;1
+Final Energy|Gases;Final Energy|Gases|Electricity;1
+Final Energy|Gases;Final Energy|Gases|Gas;1
+Final Energy|Gases;Final Energy|Gases|Hydrogen;1
+Final Energy|Gases;Final Energy|Gases|Other;1
+;;
+Final Energy|Heat;Final Energy|Heat|Biomass;1
+Final Energy|Heat;Final Energy|Heat|Coal;1
+Final Energy|Heat;Final Energy|Heat|Electricity;1
+Final Energy|Heat;Final Energy|Heat|Gas;1
+Final Energy|Heat;Final Energy|Heat|Geothermal;1
+Final Energy|Heat;Final Energy|Heat|Hydrogen;1
+Final Energy|Heat;Final Energy|Heat|Nuclear;1
+Final Energy|Heat;Final Energy|Heat|Oil;1
+Final Energy|Heat;Final Energy|Heat|Other;1
+Final Energy|Heat;Final Energy|Heat|Solar;1
+;;
+Final Energy|Hydrogen;Final Energy|Hydrogen|Biomass;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Coal;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Electricity;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Gas;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Nuclear;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Oil;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Other;1
+Final Energy|Hydrogen;Final Energy|Hydrogen|Solar;1
+;;
+Final Energy|Industry;Final Energy|Industry|Electricity;1
+Final Energy|Industry;Final Energy|Industry|Gases;1
+Final Energy|Industry;Final Energy|Industry|Geothermal;1
+Final Energy|Industry;Final Energy|Industry|Heat;1
+Final Energy|Industry;Final Energy|Industry|Hydrogen;1
+Final Energy|Industry;Final Energy|Industry|Liquids;1
+Final Energy|Industry;Final Energy|Industry|Other;1
+Final Energy|Industry;Final Energy|Industry|Solar;1
+Final Energy|Industry;Final Energy|Industry|Solids;1
+Final Energy|Industry;Final Energy|Industry|Waste;1
+;;
+Final Energy|Industry 2;Final Energy|Industry|Chemicals;1
+Final Energy|Industry 2;Final Energy|Industry|Iron and Steel;1
+Final Energy|Industry 2;Final Energy|Industry|Non-Ferrous Metals;1
+Final Energy|Industry 2;Final Energy|Industry|Non-Metallic Minerals;1
+Final Energy|Industry 2;Final Energy|Industry|Other Sector;1
+Final Energy|Industry 2;Final Energy|Industry|Plastics;1
+Final Energy|Industry 2;Final Energy|Industry|Pulp and Paper;1
+;;
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Electricity;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Gases;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Heat;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Hydrogen;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Liquids;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Other;1
+Final Energy|Industry|Chemicals;Final Energy|Industry|Chemicals|Solids;1
+;;
+Final Energy|Industry|Chemicals 2;Final Energy|Industry|Chemicals|Ammonia;1
+Final Energy|Industry|Chemicals 2;Final Energy|Industry|Chemicals|High-Value Chemicals;1
+Final Energy|Industry|Chemicals 2;Final Energy|Industry|Chemicals|Methanol;1
+Final Energy|Industry|Chemicals 2;Final Energy|Industry|Chemicals|Other Sector;1
+;;
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Electricity;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Gases;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Heat;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Hydrogen;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Liquids;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Other;1
+Final Energy|Industry|Chemicals|Ammonia;Final Energy|Industry|Chemicals|Ammonia|Solids;1
+;;
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Biomass;1
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Coal;1
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Electricity;1
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Gas;1
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Hydrogen;1
+Final Energy|Industry|Chemicals|Ammonia|Gases;Final Energy|Industry|Chemicals|Ammonia|Gases|Other;1
+;;
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Biomass;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Coal;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Electricity;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Gas;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Geothermal;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Hydrogen;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Nuclear;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Oil;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Other;1
+Final Energy|Industry|Chemicals|Ammonia|Heat;Final Energy|Industry|Chemicals|Ammonia|Heat|Solar;1
+;;
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Biomass;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Coal;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Electricity;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Gas;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Nuclear;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Oil;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Other;1
+Final Energy|Industry|Chemicals|Ammonia|Hydrogen;Final Energy|Industry|Chemicals|Ammonia|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Biomass;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Coal;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Electricity;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Gas;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Hydrogen;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Oil;1
+Final Energy|Industry|Chemicals|Ammonia|Liquids;Final Energy|Industry|Chemicals|Ammonia|Liquids|Other;1
+;;
+Final Energy|Industry|Chemicals|Ammonia|Solids;Final Energy|Industry|Chemicals|Ammonia|Solids|Biomass;1
+Final Energy|Industry|Chemicals|Ammonia|Solids;Final Energy|Industry|Chemicals|Ammonia|Solids|Coal;1
+;;
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Biomass;1
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Coal;1
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Electricity;1
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Gas;1
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Hydrogen;1
+Final Energy|Industry|Chemicals|Gases;Final Energy|Industry|Chemicals|Gases|Other;1
+;;
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Biomass;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Coal;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Electricity;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Gas;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Geothermal;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Hydrogen;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Nuclear;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Oil;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Other;1
+Final Energy|Industry|Chemicals|Heat;Final Energy|Industry|Chemicals|Heat|Solar;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Electricity;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Other;1
+Final Energy|Industry|Chemicals|High-Value Chemicals;Final Energy|Industry|Chemicals|High-Value Chemicals|Solids;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Biomass;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Coal;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Electricity;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Gas;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Hydrogen;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Gases;Final Energy|Industry|Chemicals|High-Value Chemicals|Gases|Other;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Biomass;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Coal;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Electricity;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Gas;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Geothermal;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Hydrogen;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Nuclear;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Oil;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Other;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Heat;Final Energy|Industry|Chemicals|High-Value Chemicals|Heat|Solar;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Biomass;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Coal;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Electricity;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Gas;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Nuclear;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Oil;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Other;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Industry|Chemicals|High-Value Chemicals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Biomass;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Coal;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Electricity;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Gas;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Hydrogen;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Oil;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids;Final Energy|Industry|Chemicals|High-Value Chemicals|Liquids|Other;1
+;;
+Final Energy|Industry|Chemicals|High-Value Chemicals|Solids;Final Energy|Industry|Chemicals|High-Value Chemicals|Solids|Biomass;1
+Final Energy|Industry|Chemicals|High-Value Chemicals|Solids;Final Energy|Industry|Chemicals|High-Value Chemicals|Solids|Coal;1
+;;
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Biomass;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Coal;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Electricity;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Gas;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Nuclear;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Oil;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Other;1
+Final Energy|Industry|Chemicals|Hydrogen;Final Energy|Industry|Chemicals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Biomass;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Coal;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Electricity;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Gas;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Hydrogen;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Oil;1
+Final Energy|Industry|Chemicals|Liquids;Final Energy|Industry|Chemicals|Liquids|Other;1
+;;
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Electricity;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Gases;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Heat;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Hydrogen;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Liquids;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Other;1
+Final Energy|Industry|Chemicals|Methanol;Final Energy|Industry|Chemicals|Methanol|Solids;1
+;;
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Biomass;1
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Coal;1
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Electricity;1
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Gas;1
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Hydrogen;1
+Final Energy|Industry|Chemicals|Methanol|Gases;Final Energy|Industry|Chemicals|Methanol|Gases|Other;1
+;;
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Biomass;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Coal;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Electricity;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Gas;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Geothermal;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Hydrogen;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Nuclear;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Oil;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Other;1
+Final Energy|Industry|Chemicals|Methanol|Heat;Final Energy|Industry|Chemicals|Methanol|Heat|Solar;1
+;;
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Biomass;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Coal;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Electricity;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Gas;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Nuclear;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Oil;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Other;1
+Final Energy|Industry|Chemicals|Methanol|Hydrogen;Final Energy|Industry|Chemicals|Methanol|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Biomass;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Coal;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Electricity;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Gas;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Hydrogen;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Oil;1
+Final Energy|Industry|Chemicals|Methanol|Liquids;Final Energy|Industry|Chemicals|Methanol|Liquids|Other;1
+;;
+Final Energy|Industry|Chemicals|Methanol|Solids;Final Energy|Industry|Chemicals|Methanol|Solids|Biomass;1
+Final Energy|Industry|Chemicals|Methanol|Solids;Final Energy|Industry|Chemicals|Methanol|Solids|Coal;1
+;;
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Electricity;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Gases;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Heat;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Hydrogen;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Liquids;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Other;1
+Final Energy|Industry|Chemicals|Other Sector;Final Energy|Industry|Chemicals|Other Sector|Solids;1
+;;
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Biomass;1
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Coal;1
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Electricity;1
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Gas;1
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Hydrogen;1
+Final Energy|Industry|Chemicals|Other Sector|Gases;Final Energy|Industry|Chemicals|Other Sector|Gases|Other;1
+;;
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Biomass;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Coal;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Electricity;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Gas;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Geothermal;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Hydrogen;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Nuclear;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Oil;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Other;1
+Final Energy|Industry|Chemicals|Other Sector|Heat;Final Energy|Industry|Chemicals|Other Sector|Heat|Solar;1
+;;
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Biomass;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Coal;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Electricity;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Gas;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Nuclear;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Oil;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Other;1
+Final Energy|Industry|Chemicals|Other Sector|Hydrogen;Final Energy|Industry|Chemicals|Other Sector|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Biomass;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Coal;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Electricity;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Gas;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Hydrogen;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Oil;1
+Final Energy|Industry|Chemicals|Other Sector|Liquids;Final Energy|Industry|Chemicals|Other Sector|Liquids|Other;1
+;;
+Final Energy|Industry|Chemicals|Other Sector|Solids;Final Energy|Industry|Chemicals|Other Sector|Solids|Biomass;1
+Final Energy|Industry|Chemicals|Other Sector|Solids;Final Energy|Industry|Chemicals|Other Sector|Solids|Coal;1
+;;
+Final Energy|Industry|Chemicals|Solids;Final Energy|Industry|Chemicals|Solids|Biomass;1
+Final Energy|Industry|Chemicals|Solids;Final Energy|Industry|Chemicals|Solids|Coal;1
+;;
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Biomass;1
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Coal;1
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Electricity;1
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Gas;1
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Hydrogen;1
+Final Energy|Industry|Gases;Final Energy|Industry|Gases|Other;1
+;;
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Biomass;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Coal;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Electricity;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Gas;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Geothermal;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Hydrogen;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Nuclear;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Oil;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Other;1
+Final Energy|Industry|Heat;Final Energy|Industry|Heat|Solar;1
+;;
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Biomass;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Coal;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Electricity;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Gas;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Nuclear;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Oil;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Other;1
+Final Energy|Industry|Hydrogen;Final Energy|Industry|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Electricity;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Gases;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Heat;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Hydrogen;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Liquids;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Other;1
+Final Energy|Industry|Iron and Steel;Final Energy|Industry|Iron and Steel|Solids;1
+;;
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Biomass;1
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Coal;1
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Electricity;1
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Gas;1
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Hydrogen;1
+Final Energy|Industry|Iron and Steel|Gases;Final Energy|Industry|Iron and Steel|Gases|Other;1
+;;
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Biomass;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Coal;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Electricity;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Gas;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Geothermal;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Hydrogen;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Nuclear;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Oil;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Other;1
+Final Energy|Industry|Iron and Steel|Heat;Final Energy|Industry|Iron and Steel|Heat|Solar;1
+;;
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Biomass;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Coal;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Electricity;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Gas;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Nuclear;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Oil;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Other;1
+Final Energy|Industry|Iron and Steel|Hydrogen;Final Energy|Industry|Iron and Steel|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Biomass;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Coal;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Electricity;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Gas;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Hydrogen;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Oil;1
+Final Energy|Industry|Iron and Steel|Liquids;Final Energy|Industry|Iron and Steel|Liquids|Other;1
+;;
+Final Energy|Industry|Iron and Steel|Solids;Final Energy|Industry|Iron and Steel|Solids|Biomass;1
+Final Energy|Industry|Iron and Steel|Solids;Final Energy|Industry|Iron and Steel|Solids|Coal;1
+;;
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Biomass;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Coal;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Electricity;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Gas;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Hydrogen;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Oil;1
+Final Energy|Industry|Liquids;Final Energy|Industry|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Gases;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Heat;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Liquids;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Other;1
+Final Energy|Industry|Non-Ferrous Metals;Final Energy|Industry|Non-Ferrous Metals|Solids;1
+;;
+Final Energy|Industry|Non-Ferrous Metals 2;Final Energy|Industry|Non-Ferrous Metals|Aluminum;1
+Final Energy|Industry|Non-Ferrous Metals 2;Final Energy|Industry|Non-Ferrous Metals|Copper;1
+Final Energy|Industry|Non-Ferrous Metals 2;Final Energy|Industry|Non-Ferrous Metals|Other Metals;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Solids;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Gases|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Geothermal;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Solids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Solids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Aluminum|Solids;Final Energy|Industry|Non-Ferrous Metals|Aluminum|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Copper;Final Energy|Industry|Non-Ferrous Metals|Copper|Solids;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Gases;Final Energy|Industry|Non-Ferrous Metals|Copper|Gases|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Geothermal;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Heat;Final Energy|Industry|Non-Ferrous Metals|Copper|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Copper|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids;Final Energy|Industry|Non-Ferrous Metals|Copper|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Copper|Solids;Final Energy|Industry|Non-Ferrous Metals|Copper|Solids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Copper|Solids;Final Energy|Industry|Non-Ferrous Metals|Copper|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Gases|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Geothermal;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Solids;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Gases|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Geothermal;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Other;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Coal;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Electricity;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Gas;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Oil;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Solids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Solids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Other Metals|Solids;Final Energy|Industry|Non-Ferrous Metals|Other Metals|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Ferrous Metals|Solids;Final Energy|Industry|Non-Ferrous Metals|Solids|Biomass;1
+Final Energy|Industry|Non-Ferrous Metals|Solids;Final Energy|Industry|Non-Ferrous Metals|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Gases;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Heat;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Liquids;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Other;1
+Final Energy|Industry|Non-Metallic Minerals;Final Energy|Industry|Non-Metallic Minerals|Solids;1
+;;
+Final Energy|Industry|Non-Metallic Minerals 2;Final Energy|Industry|Non-Metallic Minerals|Cement;1
+Final Energy|Industry|Non-Metallic Minerals 2;Final Energy|Industry|Non-Metallic Minerals|Other Minerals;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Cement;Final Energy|Industry|Non-Metallic Minerals|Cement|Solids;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Gases;Final Energy|Industry|Non-Metallic Minerals|Cement|Gases|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Geothermal;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Heat;Final Energy|Industry|Non-Metallic Minerals|Cement|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Cement|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids;Final Energy|Industry|Non-Metallic Minerals|Cement|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Cement|Solids;Final Energy|Industry|Non-Metallic Minerals|Cement|Solids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Cement|Solids;Final Energy|Industry|Non-Metallic Minerals|Cement|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Gases|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Geothermal;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Solids;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Gases|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Geothermal;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Heat|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Nuclear;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Other;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Coal;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Electricity;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Gas;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Hydrogen;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Oil;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Liquids|Other;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Solids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Solids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Solids;Final Energy|Industry|Non-Metallic Minerals|Other Minerals|Solids|Coal;1
+;;
+Final Energy|Industry|Non-Metallic Minerals|Solids;Final Energy|Industry|Non-Metallic Minerals|Solids|Biomass;1
+Final Energy|Industry|Non-Metallic Minerals|Solids;Final Energy|Industry|Non-Metallic Minerals|Solids|Coal;1
+;;
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Electricity;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Gases;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Heat;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Hydrogen;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Liquids;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Other;1
+Final Energy|Industry|Other Sector;Final Energy|Industry|Other Sector|Solids;1
+;;
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Biomass;1
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Coal;1
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Electricity;1
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Gas;1
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Hydrogen;1
+Final Energy|Industry|Other Sector|Gases;Final Energy|Industry|Other Sector|Gases|Other;1
+;;
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Biomass;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Coal;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Electricity;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Gas;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Geothermal;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Hydrogen;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Nuclear;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Oil;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Other;1
+Final Energy|Industry|Other Sector|Heat;Final Energy|Industry|Other Sector|Heat|Solar;1
+;;
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Biomass;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Coal;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Electricity;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Gas;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Nuclear;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Oil;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Other;1
+Final Energy|Industry|Other Sector|Hydrogen;Final Energy|Industry|Other Sector|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Biomass;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Coal;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Electricity;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Gas;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Hydrogen;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Oil;1
+Final Energy|Industry|Other Sector|Liquids;Final Energy|Industry|Other Sector|Liquids|Other;1
+;;
+Final Energy|Industry|Other Sector|Solids;Final Energy|Industry|Other Sector|Solids|Biomass;1
+Final Energy|Industry|Other Sector|Solids;Final Energy|Industry|Other Sector|Solids|Coal;1
+;;
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Electricity;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Gases;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Heat;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Hydrogen;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Liquids;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Other;1
+Final Energy|Industry|Plastics;Final Energy|Industry|Plastics|Solids;1
+;;
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Biomass;1
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Coal;1
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Electricity;1
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Gas;1
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Hydrogen;1
+Final Energy|Industry|Plastics|Gases;Final Energy|Industry|Plastics|Gases|Other;1
+;;
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Biomass;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Coal;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Electricity;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Gas;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Geothermal;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Hydrogen;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Nuclear;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Oil;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Other;1
+Final Energy|Industry|Plastics|Heat;Final Energy|Industry|Plastics|Heat|Solar;1
+;;
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Biomass;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Coal;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Electricity;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Gas;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Nuclear;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Oil;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Other;1
+Final Energy|Industry|Plastics|Hydrogen;Final Energy|Industry|Plastics|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Biomass;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Coal;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Electricity;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Gas;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Hydrogen;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Oil;1
+Final Energy|Industry|Plastics|Liquids;Final Energy|Industry|Plastics|Liquids|Other;1
+;;
+Final Energy|Industry|Plastics|Solids;Final Energy|Industry|Plastics|Solids|Biomass;1
+Final Energy|Industry|Plastics|Solids;Final Energy|Industry|Plastics|Solids|Coal;1
+;;
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Electricity;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Gases;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Heat;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Hydrogen;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Liquids;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Other;1
+Final Energy|Industry|Pulp and Paper;Final Energy|Industry|Pulp and Paper|Solids;1
+;;
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Biomass;1
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Coal;1
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Electricity;1
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Gas;1
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Hydrogen;1
+Final Energy|Industry|Pulp and Paper|Gases;Final Energy|Industry|Pulp and Paper|Gases|Other;1
+;;
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Biomass;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Coal;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Electricity;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Gas;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Geothermal;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Hydrogen;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Nuclear;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Oil;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Other;1
+Final Energy|Industry|Pulp and Paper|Heat;Final Energy|Industry|Pulp and Paper|Heat|Solar;1
+;;
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Biomass;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Coal;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Electricity;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Gas;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Nuclear;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Oil;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Other;1
+Final Energy|Industry|Pulp and Paper|Hydrogen;Final Energy|Industry|Pulp and Paper|Hydrogen|Solar;1
+;;
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Biomass;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Coal;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Electricity;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Gas;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Hydrogen;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Oil;1
+Final Energy|Industry|Pulp and Paper|Liquids;Final Energy|Industry|Pulp and Paper|Liquids|Other;1
+;;
+Final Energy|Industry|Pulp and Paper|Solids;Final Energy|Industry|Pulp and Paper|Solids|Biomass;1
+Final Energy|Industry|Pulp and Paper|Solids;Final Energy|Industry|Pulp and Paper|Solids|Coal;1
+;;
+Final Energy|Industry|Solids;Final Energy|Industry|Solids|Biomass;1
+Final Energy|Industry|Solids;Final Energy|Industry|Solids|Coal;1
+;;
+Final Energy|Liquids;Final Energy|Liquids|Biomass;1
+Final Energy|Liquids;Final Energy|Liquids|Coal;1
+Final Energy|Liquids;Final Energy|Liquids|Electricity;1
+Final Energy|Liquids;Final Energy|Liquids|Gas;1
+Final Energy|Liquids;Final Energy|Liquids|Hydrogen;1
+Final Energy|Liquids;Final Energy|Liquids|Oil;1
+Final Energy|Liquids;Final Energy|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Gases;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Heat;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Hydrogen;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Liquids;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Other;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Solids;1
+Final Energy|Non-Energy Use;Final Energy|Non-Energy Use|Waste;1
+;;
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Chemicals;1
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Iron and Steel;1
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Non-Ferrous Metals;1
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Non-Metallic Minerals;1
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Other Sector;1
+Final Energy|Non-Energy Use 2;Final Energy|Non-Energy Use|Plastics;1
+;;
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Gases;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Heat;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Liquids;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Other;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Solids;1
+Final Energy|Non-Energy Use|Chemicals;Final Energy|Non-Energy Use|Chemicals|Waste;1
+;;
+Final Energy|Non-Energy Use|Chemicals 2;Final Energy|Non-Energy Use|Chemicals|Ammonia;1
+Final Energy|Non-Energy Use|Chemicals 2;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;1
+Final Energy|Non-Energy Use|Chemicals 2;Final Energy|Non-Energy Use|Chemicals|Methanol;1
+Final Energy|Non-Energy Use|Chemicals 2;Final Energy|Non-Energy Use|Chemicals|Other Sector;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Other;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Solids;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia;Final Energy|Non-Energy Use|Chemicals|Ammonia|Waste;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases;Final Energy|Non-Energy Use|Chemicals|Ammonia|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Other;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat;Final Energy|Non-Energy Use|Chemicals|Ammonia|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Ammonia|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Solids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Solids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Ammonia|Solids;Final Energy|Non-Energy Use|Chemicals|Ammonia|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Other;1
+Final Energy|Non-Energy Use|Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Other;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Solids;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Waste;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Coal;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Gas;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Coal;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Gas;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Oil;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Other;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Coal;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Gas;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Oil;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Solids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Solids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Solids;Final Energy|Non-Energy Use|Chemicals|High-Value Chemicals|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Chemicals|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Liquids;Final Energy|Non-Energy Use|Chemicals|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Other;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Solids;1
+Final Energy|Non-Energy Use|Chemicals|Methanol;Final Energy|Non-Energy Use|Chemicals|Methanol|Waste;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Gases;Final Energy|Non-Energy Use|Chemicals|Methanol|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Other;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Heat;Final Energy|Non-Energy Use|Chemicals|Methanol|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Methanol|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids;Final Energy|Non-Energy Use|Chemicals|Methanol|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Methanol|Solids;Final Energy|Non-Energy Use|Chemicals|Methanol|Solids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Methanol|Solids;Final Energy|Non-Energy Use|Chemicals|Methanol|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Other;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Solids;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector;Final Energy|Non-Energy Use|Chemicals|Other Sector|Waste;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases;Final Energy|Non-Energy Use|Chemicals|Other Sector|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Other;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat;Final Energy|Non-Energy Use|Chemicals|Other Sector|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Chemicals|Other Sector|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Coal;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Gas;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Oil;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Solids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Solids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Other Sector|Solids;Final Energy|Non-Energy Use|Chemicals|Other Sector|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Chemicals|Solids;Final Energy|Non-Energy Use|Chemicals|Solids|Biomass;1
+Final Energy|Non-Energy Use|Chemicals|Solids;Final Energy|Non-Energy Use|Chemicals|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Biomass;1
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Coal;1
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Electricity;1
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Gas;1
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Gases;Final Energy|Non-Energy Use|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Biomass;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Coal;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Electricity;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Gas;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Oil;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Other;1
+Final Energy|Non-Energy Use|Heat;Final Energy|Non-Energy Use|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Hydrogen;Final Energy|Non-Energy Use|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Gases;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Heat;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Liquids;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Other;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Solids;1
+Final Energy|Non-Energy Use|Iron and Steel;Final Energy|Non-Energy Use|Iron and Steel|Waste;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Biomass;1
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Coal;1
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Electricity;1
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Gas;1
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Iron and Steel|Gases;Final Energy|Non-Energy Use|Iron and Steel|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Biomass;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Coal;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Electricity;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Gas;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Oil;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Other;1
+Final Energy|Non-Energy Use|Iron and Steel|Heat;Final Energy|Non-Energy Use|Iron and Steel|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Iron and Steel|Hydrogen;Final Energy|Non-Energy Use|Iron and Steel|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Coal;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Gas;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Oil;1
+Final Energy|Non-Energy Use|Iron and Steel|Liquids;Final Energy|Non-Energy Use|Iron and Steel|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Iron and Steel|Solids;Final Energy|Non-Energy Use|Iron and Steel|Solids|Biomass;1
+Final Energy|Non-Energy Use|Iron and Steel|Solids;Final Energy|Non-Energy Use|Iron and Steel|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Coal;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Fossil;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Gas;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Oil;1
+Final Energy|Non-Energy Use|Liquids;Final Energy|Non-Energy Use|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Other;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Solids;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals;Final Energy|Non-Energy Use|Non-Ferrous Metals|Waste;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Biomass;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Coal;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Electricity;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Gas;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases;Final Energy|Non-Energy Use|Non-Ferrous Metals|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Biomass;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Coal;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Electricity;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Gas;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Oil;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Other;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat;Final Energy|Non-Energy Use|Non-Ferrous Metals|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen;Final Energy|Non-Energy Use|Non-Ferrous Metals|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Coal;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Gas;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Oil;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Solids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Solids|Biomass;1
+Final Energy|Non-Energy Use|Non-Ferrous Metals|Solids;Final Energy|Non-Energy Use|Non-Ferrous Metals|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Other;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Solids;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals;Final Energy|Non-Energy Use|Non-Metallic Minerals|Waste;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Biomass;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Coal;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Electricity;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Gas;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases;Final Energy|Non-Energy Use|Non-Metallic Minerals|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Biomass;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Coal;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Electricity;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Gas;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Oil;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Other;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat;Final Energy|Non-Energy Use|Non-Metallic Minerals|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen;Final Energy|Non-Energy Use|Non-Metallic Minerals|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Coal;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Gas;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Oil;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Solids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Solids|Biomass;1
+Final Energy|Non-Energy Use|Non-Metallic Minerals|Solids;Final Energy|Non-Energy Use|Non-Metallic Minerals|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Gases;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Heat;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Hydrogen;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Liquids;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Other;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Solids;1
+Final Energy|Non-Energy Use|Other Sector;Final Energy|Non-Energy Use|Other Sector|Waste;1
+;;
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Biomass;1
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Coal;1
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Electricity;1
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Gas;1
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Other Sector|Gases;Final Energy|Non-Energy Use|Other Sector|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Biomass;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Coal;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Electricity;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Gas;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Oil;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Other;1
+Final Energy|Non-Energy Use|Other Sector|Heat;Final Energy|Non-Energy Use|Other Sector|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Other Sector|Hydrogen;Final Energy|Non-Energy Use|Other Sector|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Coal;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Gas;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Oil;1
+Final Energy|Non-Energy Use|Other Sector|Liquids;Final Energy|Non-Energy Use|Other Sector|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Other Sector|Solids;Final Energy|Non-Energy Use|Other Sector|Solids|Biomass;1
+Final Energy|Non-Energy Use|Other Sector|Solids;Final Energy|Non-Energy Use|Other Sector|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Gases;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Heat;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Hydrogen;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Liquids;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Other;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Solids;1
+Final Energy|Non-Energy Use|Plastics;Final Energy|Non-Energy Use|Plastics|Waste;1
+;;
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Biomass;1
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Coal;1
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Electricity;1
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Gas;1
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Hydrogen;1
+Final Energy|Non-Energy Use|Plastics|Gases;Final Energy|Non-Energy Use|Plastics|Gases|Other;1
+;;
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Biomass;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Coal;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Electricity;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Gas;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Geothermal;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Hydrogen;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Nuclear;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Oil;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Other;1
+Final Energy|Non-Energy Use|Plastics|Heat;Final Energy|Non-Energy Use|Plastics|Heat|Solar;1
+;;
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Biomass;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Coal;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Electricity;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Gas;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Nuclear;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Oil;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Other;1
+Final Energy|Non-Energy Use|Plastics|Hydrogen;Final Energy|Non-Energy Use|Plastics|Hydrogen|Solar;1
+;;
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Biomass;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Coal;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Electricity;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Gas;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Hydrogen;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Oil;1
+Final Energy|Non-Energy Use|Plastics|Liquids;Final Energy|Non-Energy Use|Plastics|Liquids|Other;1
+;;
+Final Energy|Non-Energy Use|Plastics|Solids;Final Energy|Non-Energy Use|Plastics|Solids|Biomass;1
+Final Energy|Non-Energy Use|Plastics|Solids;Final Energy|Non-Energy Use|Plastics|Solids|Coal;1
+;;
+Final Energy|Non-Energy Use|Solids;Final Energy|Non-Energy Use|Solids|Biomass;1
+Final Energy|Non-Energy Use|Solids;Final Energy|Non-Energy Use|Solids|Coal;1
+;;
+Final Energy|Other Sector;Final Energy|Other Sector|Electricity;1
+Final Energy|Other Sector;Final Energy|Other Sector|Gases;1
+Final Energy|Other Sector;Final Energy|Other Sector|Heat;1
+Final Energy|Other Sector;Final Energy|Other Sector|Hydrogen;1
+Final Energy|Other Sector;Final Energy|Other Sector|Liquids;1
+Final Energy|Other Sector;Final Energy|Other Sector|Other;1
+Final Energy|Other Sector;Final Energy|Other Sector|Solids;1
+;;
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Biomass;1
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Coal;1
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Electricity;1
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Gas;1
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Hydrogen;1
+Final Energy|Other Sector|Gases;Final Energy|Other Sector|Gases|Other;1
+;;
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Biomass;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Coal;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Electricity;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Gas;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Geothermal;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Hydrogen;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Nuclear;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Oil;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Other;1
+Final Energy|Other Sector|Heat;Final Energy|Other Sector|Heat|Solar;1
+;;
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Biomass;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Coal;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Electricity;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Gas;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Nuclear;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Oil;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Other;1
+Final Energy|Other Sector|Hydrogen;Final Energy|Other Sector|Hydrogen|Solar;1
+;;
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Biomass;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Coal;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Electricity;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Gas;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Hydrogen;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Oil;1
+Final Energy|Other Sector|Liquids;Final Energy|Other Sector|Liquids|Other;1
+;;
+Final Energy|Other Sector|Solids;Final Energy|Other Sector|Solids|Biomass;1
+Final Energy|Other Sector|Solids;Final Energy|Other Sector|Solids|Coal;1
+;;
+Final Energy|Residential;Final Energy|Residential|Electricity;1
+Final Energy|Residential;Final Energy|Residential|Gases;1
+Final Energy|Residential;Final Energy|Residential|Heat;1
+Final Energy|Residential;Final Energy|Residential|Hydrogen;1
+Final Energy|Residential;Final Energy|Residential|Liquids;1
+Final Energy|Residential;Final Energy|Residential|Other;1
+Final Energy|Residential;Final Energy|Residential|Solids;1
+;;
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Electricity;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Gases;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Heat;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Hydrogen;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Liquids;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Other;1
+Final Energy|Residential and Commercial;Final Energy|Residential and Commercial|Solids;1
+;;
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Biomass;1
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Coal;1
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Electricity;1
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Gas;1
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Hydrogen;1
+Final Energy|Residential and Commercial|Gases;Final Energy|Residential and Commercial|Gases|Other;1
+;;
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Biomass;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Coal;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Electricity;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Gas;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Geothermal;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Hydrogen;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Nuclear;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Oil;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Other;1
+Final Energy|Residential and Commercial|Heat;Final Energy|Residential and Commercial|Heat|Solar;1
+;;
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Biomass;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Coal;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Electricity;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Gas;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Nuclear;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Oil;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Other;1
+Final Energy|Residential and Commercial|Hydrogen;Final Energy|Residential and Commercial|Hydrogen|Solar;1
+;;
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Biomass;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Coal;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Electricity;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Gas;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Hydrogen;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Oil;1
+Final Energy|Residential and Commercial|Liquids;Final Energy|Residential and Commercial|Liquids|Other;1
+;;
+Final Energy|Residential and Commercial|Solids;Final Energy|Residential and Commercial|Solids|Biomass;1
+Final Energy|Residential and Commercial|Solids;Final Energy|Residential and Commercial|Solids|Coal;1
+;;
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Biomass;1
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Coal;1
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Electricity;1
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Gas;1
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Hydrogen;1
+Final Energy|Residential|Gases;Final Energy|Residential|Gases|Other;1
+;;
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Biomass;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Coal;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Electricity;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Gas;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Geothermal;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Hydrogen;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Nuclear;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Oil;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Other;1
+Final Energy|Residential|Heat;Final Energy|Residential|Heat|Solar;1
+;;
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Biomass;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Coal;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Electricity;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Gas;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Nuclear;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Oil;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Other;1
+Final Energy|Residential|Hydrogen;Final Energy|Residential|Hydrogen|Solar;1
+;;
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Biomass;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Coal;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Electricity;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Gas;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Hydrogen;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Oil;1
+Final Energy|Residential|Liquids;Final Energy|Residential|Liquids|Other;1
+;;
+Final Energy|Residential|Solids;Final Energy|Residential|Solids|Biomass;1
+Final Energy|Residential|Solids;Final Energy|Residential|Solids|Coal;1
+;;
+Final Energy|Solids;Final Energy|Solids|Biomass;1
+Final Energy|Solids;Final Energy|Solids|Coal;1
+;;
+Final Energy|Transportation;Final Energy|Transportation|Electricity;1
+Final Energy|Transportation;Final Energy|Transportation|Gases;1
+Final Energy|Transportation;Final Energy|Transportation|Heat;1
+Final Energy|Transportation;Final Energy|Transportation|Hydrogen;1
+Final Energy|Transportation;Final Energy|Transportation|Liquids;1
+Final Energy|Transportation;Final Energy|Transportation|Other;1
+Final Energy|Transportation;Final Energy|Transportation|Solids;1
+;;
+Final Energy|Transportation 2;Final Energy|Transportation|Bus;1
+Final Energy|Transportation 2;Final Energy|Transportation|Domestic Aviation;1
+Final Energy|Transportation 2;Final Energy|Transportation|Domestic Shipping;1
+Final Energy|Transportation 2;Final Energy|Transportation|Light-Duty Vehicle;1
+Final Energy|Transportation 2;Final Energy|Transportation|Rail;1
+Final Energy|Transportation 2;Final Energy|Transportation|Truck;1
+;;
+Final Energy|Transportation 3;Final Energy|Transportation|Freight;1
+Final Energy|Transportation 3;Final Energy|Transportation|Passenger;1
+;;
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Electricity;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Gases;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Heat;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Hydrogen;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Liquids;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Other;1
+Final Energy|Transportation (w/ bunkers) 2;Final Energy|Transportation (w/ bunkers)|Solids;1
+;;
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Biomass;1
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Coal;1
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Electricity;1
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Gas;1
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Hydrogen;1
+Final Energy|Transportation (w/ bunkers)|Gases;Final Energy|Transportation (w/ bunkers)|Gases|Other;1
+;;
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Biomass;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Coal;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Electricity;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Gas;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Geothermal;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Hydrogen;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Nuclear;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Oil;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Other;1
+Final Energy|Transportation (w/ bunkers)|Heat;Final Energy|Transportation (w/ bunkers)|Heat|Solar;1
+;;
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Biomass;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Coal;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Electricity;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Gas;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Nuclear;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Oil;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Other;1
+Final Energy|Transportation (w/ bunkers)|Hydrogen;Final Energy|Transportation (w/ bunkers)|Hydrogen|Solar;1
+;;
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Biomass;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Coal;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Electricity;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Gas;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Hydrogen;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Oil;1
+Final Energy|Transportation (w/ bunkers)|Liquids;Final Energy|Transportation (w/ bunkers)|Liquids|Other;1
+;;
+Final Energy|Transportation (w/ bunkers)|Solids;Final Energy|Transportation (w/ bunkers)|Solids|Biomass;1
+Final Energy|Transportation (w/ bunkers)|Solids;Final Energy|Transportation (w/ bunkers)|Solids|Coal;1
+;;
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Electricity;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Gases;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Heat;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Hydrogen;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Liquids;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Other;1
+Final Energy|Transportation|Bus;Final Energy|Transportation|Bus|Solids;1
+;;
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Biomass;1
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Coal;1
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Electricity;1
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Gas;1
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Hydrogen;1
+Final Energy|Transportation|Bus|Gases;Final Energy|Transportation|Bus|Gases|Other;1
+;;
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Biomass;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Coal;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Electricity;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Gas;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Geothermal;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Hydrogen;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Nuclear;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Oil;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Other;1
+Final Energy|Transportation|Bus|Heat;Final Energy|Transportation|Bus|Heat|Solar;1
+;;
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Biomass;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Coal;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Electricity;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Gas;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Nuclear;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Oil;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Other;1
+Final Energy|Transportation|Bus|Hydrogen;Final Energy|Transportation|Bus|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Biomass;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Coal;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Electricity;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Gas;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Hydrogen;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Oil;1
+Final Energy|Transportation|Bus|Liquids;Final Energy|Transportation|Bus|Liquids|Other;1
+;;
+Final Energy|Transportation|Bus|Solids;Final Energy|Transportation|Bus|Solids|Biomass;1
+Final Energy|Transportation|Bus|Solids;Final Energy|Transportation|Bus|Solids|Coal;1
+;;
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Electricity;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Gases;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Heat;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Hydrogen;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Liquids;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Other;1
+Final Energy|Transportation|Domestic Aviation;Final Energy|Transportation|Domestic Aviation|Solids;1
+;;
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Biomass;1
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Coal;1
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Electricity;1
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Gas;1
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Hydrogen;1
+Final Energy|Transportation|Domestic Aviation|Gases;Final Energy|Transportation|Domestic Aviation|Gases|Other;1
+;;
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Biomass;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Coal;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Electricity;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Gas;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Geothermal;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Hydrogen;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Nuclear;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Oil;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Other;1
+Final Energy|Transportation|Domestic Aviation|Heat;Final Energy|Transportation|Domestic Aviation|Heat|Solar;1
+;;
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Biomass;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Coal;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Electricity;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Gas;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Nuclear;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Oil;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Other;1
+Final Energy|Transportation|Domestic Aviation|Hydrogen;Final Energy|Transportation|Domestic Aviation|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Biomass;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Coal;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Electricity;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Gas;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Hydrogen;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Oil;1
+Final Energy|Transportation|Domestic Aviation|Liquids;Final Energy|Transportation|Domestic Aviation|Liquids|Other;1
+;;
+Final Energy|Transportation|Domestic Aviation|Solids;Final Energy|Transportation|Domestic Aviation|Solids|Biomass;1
+Final Energy|Transportation|Domestic Aviation|Solids;Final Energy|Transportation|Domestic Aviation|Solids|Coal;1
+;;
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Electricity;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Gases;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Heat;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Hydrogen;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Liquids;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Other;1
+Final Energy|Transportation|Domestic Shipping;Final Energy|Transportation|Domestic Shipping|Solids;1
+;;
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Biomass;1
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Coal;1
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Electricity;1
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Gas;1
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Hydrogen;1
+Final Energy|Transportation|Domestic Shipping|Gases;Final Energy|Transportation|Domestic Shipping|Gases|Other;1
+;;
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Biomass;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Coal;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Electricity;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Gas;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Geothermal;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Hydrogen;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Nuclear;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Oil;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Other;1
+Final Energy|Transportation|Domestic Shipping|Heat;Final Energy|Transportation|Domestic Shipping|Heat|Solar;1
+;;
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Biomass;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Coal;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Electricity;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Gas;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Nuclear;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Oil;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Other;1
+Final Energy|Transportation|Domestic Shipping|Hydrogen;Final Energy|Transportation|Domestic Shipping|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Biomass;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Coal;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Electricity;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Gas;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Hydrogen;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Oil;1
+Final Energy|Transportation|Domestic Shipping|Liquids;Final Energy|Transportation|Domestic Shipping|Liquids|Other;1
+;;
+Final Energy|Transportation|Domestic Shipping|Solids;Final Energy|Transportation|Domestic Shipping|Solids|Biomass;1
+Final Energy|Transportation|Domestic Shipping|Solids;Final Energy|Transportation|Domestic Shipping|Solids|Coal;1
+;;
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Electricity;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Gases;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Heat;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Hydrogen;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Liquids;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Other;1
+Final Energy|Transportation|Freight;Final Energy|Transportation|Freight|Solids;1
+;;
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Biomass;1
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Coal;1
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Electricity;1
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Gas;1
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Hydrogen;1
+Final Energy|Transportation|Freight|Gases;Final Energy|Transportation|Freight|Gases|Other;1
+;;
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Biomass;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Coal;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Electricity;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Gas;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Geothermal;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Hydrogen;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Nuclear;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Oil;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Other;1
+Final Energy|Transportation|Freight|Heat;Final Energy|Transportation|Freight|Heat|Solar;1
+;;
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Biomass;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Coal;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Electricity;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Gas;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Nuclear;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Oil;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Other;1
+Final Energy|Transportation|Freight|Hydrogen;Final Energy|Transportation|Freight|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Biomass;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Coal;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Electricity;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Gas;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Hydrogen;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Oil;1
+Final Energy|Transportation|Freight|Liquids;Final Energy|Transportation|Freight|Liquids|Other;1
+;;
+Final Energy|Transportation|Freight|Solids;Final Energy|Transportation|Freight|Solids|Biomass;1
+Final Energy|Transportation|Freight|Solids;Final Energy|Transportation|Freight|Solids|Coal;1
+;;
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Biomass;1
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Coal;1
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Electricity;1
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Gas;1
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Hydrogen;1
+Final Energy|Transportation|Gases;Final Energy|Transportation|Gases|Other;1
+;;
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Biomass;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Coal;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Electricity;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Gas;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Geothermal;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Hydrogen;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Nuclear;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Oil;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Other;1
+Final Energy|Transportation|Heat;Final Energy|Transportation|Heat|Solar;1
+;;
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Biomass;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Coal;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Electricity;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Gas;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Nuclear;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Oil;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Other;1
+Final Energy|Transportation|Hydrogen;Final Energy|Transportation|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Electricity;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Gases;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Heat;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Liquids;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Other;1
+Final Energy|Transportation|Light-Duty Vehicle;Final Energy|Transportation|Light-Duty Vehicle|Solids;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Biomass;1
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Coal;1
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Electricity;1
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Gas;1
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Hydrogen;1
+Final Energy|Transportation|Light-Duty Vehicle|Gases;Final Energy|Transportation|Light-Duty Vehicle|Gases|Other;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Biomass;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Coal;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Electricity;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Gas;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Geothermal;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Hydrogen;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Nuclear;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Oil;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Other;1
+Final Energy|Transportation|Light-Duty Vehicle|Heat;Final Energy|Transportation|Light-Duty Vehicle|Heat|Solar;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Biomass;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Coal;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Electricity;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Gas;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Nuclear;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Oil;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Other;1
+Final Energy|Transportation|Light-Duty Vehicle|Hydrogen;Final Energy|Transportation|Light-Duty Vehicle|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Biomass;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Coal;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Electricity;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Gas;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Hydrogen;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Oil;1
+Final Energy|Transportation|Light-Duty Vehicle|Liquids;Final Energy|Transportation|Light-Duty Vehicle|Liquids|Other;1
+;;
+Final Energy|Transportation|Light-Duty Vehicle|Solids;Final Energy|Transportation|Light-Duty Vehicle|Solids|Biomass;1
+Final Energy|Transportation|Light-Duty Vehicle|Solids;Final Energy|Transportation|Light-Duty Vehicle|Solids|Coal;1
+;;
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Biomass;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Coal;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Electricity;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Gas;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Hydrogen;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Oil;1
+Final Energy|Transportation|Liquids;Final Energy|Transportation|Liquids|Other;1
+;;
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Electricity;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Gases;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Heat;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Hydrogen;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Liquids;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Other;1
+Final Energy|Transportation|Passenger;Final Energy|Transportation|Passenger|Solids;1
+;;
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Biomass;1
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Coal;1
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Electricity;1
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Gas;1
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Hydrogen;1
+Final Energy|Transportation|Passenger|Gases;Final Energy|Transportation|Passenger|Gases|Other;1
+;;
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Biomass;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Coal;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Electricity;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Gas;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Geothermal;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Hydrogen;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Nuclear;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Oil;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Other;1
+Final Energy|Transportation|Passenger|Heat;Final Energy|Transportation|Passenger|Heat|Solar;1
+;;
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Biomass;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Coal;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Electricity;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Gas;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Nuclear;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Oil;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Other;1
+Final Energy|Transportation|Passenger|Hydrogen;Final Energy|Transportation|Passenger|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Biomass;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Coal;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Electricity;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Gas;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Hydrogen;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Oil;1
+Final Energy|Transportation|Passenger|Liquids;Final Energy|Transportation|Passenger|Liquids|Other;1
+;;
+Final Energy|Transportation|Passenger|Solids;Final Energy|Transportation|Passenger|Solids|Biomass;1
+Final Energy|Transportation|Passenger|Solids;Final Energy|Transportation|Passenger|Solids|Coal;1
+;;
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Electricity;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Gases;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Heat;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Hydrogen;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Liquids;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Other;1
+Final Energy|Transportation|Rail;Final Energy|Transportation|Rail|Solids;1
+;;
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Biomass;1
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Coal;1
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Electricity;1
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Gas;1
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Hydrogen;1
+Final Energy|Transportation|Rail|Gases;Final Energy|Transportation|Rail|Gases|Other;1
+;;
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Biomass;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Coal;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Electricity;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Gas;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Geothermal;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Hydrogen;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Nuclear;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Oil;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Other;1
+Final Energy|Transportation|Rail|Heat;Final Energy|Transportation|Rail|Heat|Solar;1
+;;
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Biomass;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Coal;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Electricity;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Gas;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Nuclear;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Oil;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Other;1
+Final Energy|Transportation|Rail|Hydrogen;Final Energy|Transportation|Rail|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Biomass;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Coal;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Electricity;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Gas;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Hydrogen;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Oil;1
+Final Energy|Transportation|Rail|Liquids;Final Energy|Transportation|Rail|Liquids|Other;1
+;;
+Final Energy|Transportation|Rail|Solids;Final Energy|Transportation|Rail|Solids|Biomass;1
+Final Energy|Transportation|Rail|Solids;Final Energy|Transportation|Rail|Solids|Coal;1
+;;
+Final Energy|Transportation|Solids;Final Energy|Transportation|Solids|Biomass;1
+Final Energy|Transportation|Solids;Final Energy|Transportation|Solids|Coal;1
+;;
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Electricity;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Gases;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Heat;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Hydrogen;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Liquids;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Other;1
+Final Energy|Transportation|Truck;Final Energy|Transportation|Truck|Solids;1
+;;
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Biomass;1
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Coal;1
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Electricity;1
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Gas;1
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Hydrogen;1
+Final Energy|Transportation|Truck|Gases;Final Energy|Transportation|Truck|Gases|Other;1
+;;
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Biomass;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Coal;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Electricity;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Gas;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Geothermal;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Hydrogen;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Nuclear;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Oil;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Other;1
+Final Energy|Transportation|Truck|Heat;Final Energy|Transportation|Truck|Heat|Solar;1
+;;
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Biomass;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Coal;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Electricity;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Gas;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Nuclear;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Oil;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Other;1
+Final Energy|Transportation|Truck|Hydrogen;Final Energy|Transportation|Truck|Hydrogen|Solar;1
+;;
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Biomass;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Coal;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Electricity;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Gas;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Hydrogen;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Oil;1
+Final Energy|Transportation|Truck|Liquids;Final Energy|Transportation|Truck|Liquids|Other;1
+;;
+Final Energy|Transportation|Truck|Solids;Final Energy|Transportation|Truck|Solids|Biomass;1
+Final Energy|Transportation|Truck|Solids;Final Energy|Transportation|Truck|Solids|Coal;1
+;;
+Forest Area Change;Forest Area Change|Deforestation;1
+Forest Area Change;Forest Area Change|Forest Expansion;1
+;;
+Forest Area Change|Deforestation;Forest Area Change|Deforestation|Primary;1
+Forest Area Change|Deforestation;Forest Area Change|Deforestation|Secondary;1
+;;
+Forest Area Change|Forest Expansion;Forest Area Change|Forest Expansion|Planted;1
+Forest Area Change|Forest Expansion;Forest Area Change|Forest Expansion|Secondary;1
+;;
+Forest Area Change|Forest Expansion|Planted;Forest Area Change|Forest Expansion|Planted|Natural;1
+Forest Area Change|Forest Expansion|Planted;Forest Area Change|Forest Expansion|Planted|Plantation;1
+;;
+Forest Area Change|Forest Expansion|Planted|Natural;Forest Area Change|Forest Expansion|Planted|Natural|Other;1
+Forest Area Change|Forest Expansion|Planted|Natural;Forest Area Change|Forest Expansion|Planted|Natural|Re/Afforestation;1
+;;
+Forest Area Change|Forest Expansion|Planted|Plantation;Forest Area Change|Forest Expansion|Planted|Plantation|Re/Afforestation;1
+Forest Area Change|Forest Expansion|Planted|Plantation;Forest Area Change|Forest Expansion|Planted|Plantation|Timber;1
+;;
+Forestry Demand|Roundwood;Forestry Demand|Roundwood|Industrial Roundwood;1
+Forestry Demand|Roundwood;Forestry Demand|Roundwood|Wood Fuel;1
+;;
+Forestry Demand|Roundwood|Industrial Roundwood;Forestry Demand|Roundwood|Industrial Roundwood|Energy Use;1
+Forestry Demand|Roundwood|Industrial Roundwood;Forestry Demand|Roundwood|Industrial Roundwood|Material Use;1
+;;
+Forestry Production|Roundwood;Forestry Production|Roundwood|Industrial Roundwood;1
+Forestry Production|Roundwood;Forestry Production|Roundwood|Wood Fuel;1
+;;
+Gross Emissions|CO2;Gross Emissions|CO2|AFOLU;1
+Gross Emissions|CO2;Gross Emissions|CO2|Energy and Industrial Processes;1
+;;
+Gross Emissions|CO2|Energy and Industrial Processes;Gross Emissions|CO2|Energy;1
+Gross Emissions|CO2|Energy and Industrial Processes;Gross Emissions|CO2|Industrial Processes;1
+;;
+Gross Emissions|CO2|Energy;Gross Emissions|CO2|Energy|Demand;1
+Gross Emissions|CO2|Energy;Gross Emissions|CO2|Energy|Supply;1
+;;
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Autoproduction;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Electricity;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Gases;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Heat;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Hydrogen;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Liquids;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Other;1
+Gross Emissions|CO2|Energy|Supply;Gross Emissions|CO2|Energy|Supply|Solids;1
+;;
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Biomass;1
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Coal;1
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Electricity;1
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Gas;1
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Hydrogen;1
+Gross Emissions|CO2|Energy|Supply|Gases;Gross Emissions|CO2|Energy|Supply|Gases|Other;1
+;;
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Biomass;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Coal;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Electricity;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Gas;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Geothermal;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Hydrogen;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Nuclear;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Oil;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Other;1
+Gross Emissions|CO2|Energy|Supply|Heat;Gross Emissions|CO2|Energy|Supply|Heat|Solar;1
+;;
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Biomass;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Coal;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Electricity;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Gas;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Nuclear;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Oil;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Other;1
+Gross Emissions|CO2|Energy|Supply|Hydrogen;Gross Emissions|CO2|Energy|Supply|Hydrogen|Solar;1
+;;
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Biomass;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Coal;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Electricity;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Gas;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Hydrogen;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Oil;1
+Gross Emissions|CO2|Energy|Supply|Liquids;Gross Emissions|CO2|Energy|Supply|Liquids|Other;1
+;;
+Gross Emissions|CO2|Energy|Supply|Solids;Gross Emissions|CO2|Energy|Supply|Solids|Biomass;1
+Gross Emissions|CO2|Energy|Supply|Solids;Gross Emissions|CO2|Energy|Supply|Solids|Coal;1
+;;
+Gross Removals|CO2|AFOLU;Gross Removals|CO2|AFOLU|Intentional;1
+Gross Removals|CO2|AFOLU;Gross Removals|CO2|AFOLU|Unintentional;1
+;;
+Investment|Energy Supply;Investment|Energy Supply|Electricity;1
+Investment|Energy Supply;Investment|Energy Supply|Gases;1
+Investment|Energy Supply;Investment|Energy Supply|Heat;1
+Investment|Energy Supply;Investment|Energy Supply|Hydrogen;1
+Investment|Energy Supply;Investment|Energy Supply|Liquids;1
+Investment|Energy Supply;Investment|Energy Supply|Solids;1
+;;
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Biomass;1
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Coal;1
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Electricity;1
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Gas;1
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Hydrogen;1
+Investment|Energy Supply|Gases;Investment|Energy Supply|Gases|Other;1
+;;
+Investment|Energy Supply|Gases 2;Investment|Energy Supply|Gases|w/ CCS;1
+Investment|Energy Supply|Gases 2;Investment|Energy Supply|Gases|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Biomass;Investment|Energy Supply|Gases|Biomass|w/ CCS;1
+Investment|Energy Supply|Gases|Biomass;Investment|Energy Supply|Gases|Biomass|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Coal;Investment|Energy Supply|Gases|Coal|w/ CCS;1
+Investment|Energy Supply|Gases|Coal;Investment|Energy Supply|Gases|Coal|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Electricity;Investment|Energy Supply|Gases|Electricity|w/ CCS;1
+Investment|Energy Supply|Gases|Electricity;Investment|Energy Supply|Gases|Electricity|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Fossil;Investment|Energy Supply|Gases|Fossil|w/ CCS;1
+Investment|Energy Supply|Gases|Fossil;Investment|Energy Supply|Gases|Fossil|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Gas;Investment|Energy Supply|Gases|Gas|w/ CCS;1
+Investment|Energy Supply|Gases|Gas;Investment|Energy Supply|Gases|Gas|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Hydrogen;Investment|Energy Supply|Gases|Hydrogen|w/ CCS;1
+Investment|Energy Supply|Gases|Hydrogen;Investment|Energy Supply|Gases|Hydrogen|w/o CCS;1
+;;
+Investment|Energy Supply|Gases|Other;Investment|Energy Supply|Gases|Other|w/ CCS;1
+Investment|Energy Supply|Gases|Other;Investment|Energy Supply|Gases|Other|w/o CCS;1
+;;
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Biomass;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Coal;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Electricity;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Gas;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Geothermal;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Hydrogen;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Nuclear;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Oil;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Other;1
+Investment|Energy Supply|Heat;Investment|Energy Supply|Heat|Solar;1
+;;
+Investment|Energy Supply|Heat 2;Investment|Energy Supply|Heat|w/ CCS;1
+Investment|Energy Supply|Heat 2;Investment|Energy Supply|Heat|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Biomass;Investment|Energy Supply|Heat|Biomass|w/ CCS;1
+Investment|Energy Supply|Heat|Biomass;Investment|Energy Supply|Heat|Biomass|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Coal;Investment|Energy Supply|Heat|Coal|w/ CCS;1
+Investment|Energy Supply|Heat|Coal;Investment|Energy Supply|Heat|Coal|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Electricity;Investment|Energy Supply|Heat|Electricity|w/ CCS;1
+Investment|Energy Supply|Heat|Electricity;Investment|Energy Supply|Heat|Electricity|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Fossil;Investment|Energy Supply|Heat|Fossil|w/ CCS;1
+Investment|Energy Supply|Heat|Fossil;Investment|Energy Supply|Heat|Fossil|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Gas;Investment|Energy Supply|Heat|Gas|w/ CCS;1
+Investment|Energy Supply|Heat|Gas;Investment|Energy Supply|Heat|Gas|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Geothermal;Investment|Energy Supply|Heat|Geothermal|w/ CCS;1
+Investment|Energy Supply|Heat|Geothermal;Investment|Energy Supply|Heat|Geothermal|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Hydrogen;Investment|Energy Supply|Heat|Hydrogen|w/ CCS;1
+Investment|Energy Supply|Heat|Hydrogen;Investment|Energy Supply|Heat|Hydrogen|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Nuclear;Investment|Energy Supply|Heat|Nuclear|w/ CCS;1
+Investment|Energy Supply|Heat|Nuclear;Investment|Energy Supply|Heat|Nuclear|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Oil;Investment|Energy Supply|Heat|Oil|w/ CCS;1
+Investment|Energy Supply|Heat|Oil;Investment|Energy Supply|Heat|Oil|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Other;Investment|Energy Supply|Heat|Other|w/ CCS;1
+Investment|Energy Supply|Heat|Other;Investment|Energy Supply|Heat|Other|w/o CCS;1
+;;
+Investment|Energy Supply|Heat|Solar;Investment|Energy Supply|Heat|Solar|w/ CCS;1
+Investment|Energy Supply|Heat|Solar;Investment|Energy Supply|Heat|Solar|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Biomass;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Coal;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Electricity;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Gas;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Nuclear;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Oil;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Other;1
+Investment|Energy Supply|Hydrogen;Investment|Energy Supply|Hydrogen|Solar;1
+;;
+Investment|Energy Supply|Hydrogen 2;Investment|Energy Supply|Hydrogen|w/ CCS;1
+Investment|Energy Supply|Hydrogen 2;Investment|Energy Supply|Hydrogen|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Biomass;Investment|Energy Supply|Hydrogen|Biomass|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Biomass;Investment|Energy Supply|Hydrogen|Biomass|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Coal;Investment|Energy Supply|Hydrogen|Coal|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Coal;Investment|Energy Supply|Hydrogen|Coal|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Electricity;Investment|Energy Supply|Hydrogen|Electricity|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Electricity;Investment|Energy Supply|Hydrogen|Electricity|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Fossil;Investment|Energy Supply|Hydrogen|Fossil|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Fossil;Investment|Energy Supply|Hydrogen|Fossil|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Gas;Investment|Energy Supply|Hydrogen|Gas|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Gas;Investment|Energy Supply|Hydrogen|Gas|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Nuclear;Investment|Energy Supply|Hydrogen|Nuclear|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Nuclear;Investment|Energy Supply|Hydrogen|Nuclear|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Oil;Investment|Energy Supply|Hydrogen|Oil|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Oil;Investment|Energy Supply|Hydrogen|Oil|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Other;Investment|Energy Supply|Hydrogen|Other|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Other;Investment|Energy Supply|Hydrogen|Other|w/o CCS;1
+;;
+Investment|Energy Supply|Hydrogen|Solar;Investment|Energy Supply|Hydrogen|Solar|w/ CCS;1
+Investment|Energy Supply|Hydrogen|Solar;Investment|Energy Supply|Hydrogen|Solar|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Biomass;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Coal;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Electricity;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Gas;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Hydrogen;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Oil;1
+Investment|Energy Supply|Liquids;Investment|Energy Supply|Liquids|Other;1
+;;
+Investment|Energy Supply|Liquids 2;Investment|Energy Supply|Liquids|w/ CCS;1
+Investment|Energy Supply|Liquids 2;Investment|Energy Supply|Liquids|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Biomass;Investment|Energy Supply|Liquids|Biomass|w/ CCS;1
+Investment|Energy Supply|Liquids|Biomass;Investment|Energy Supply|Liquids|Biomass|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Coal;Investment|Energy Supply|Liquids|Coal|w/ CCS;1
+Investment|Energy Supply|Liquids|Coal;Investment|Energy Supply|Liquids|Coal|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Electricity;Investment|Energy Supply|Liquids|Electricity|w/ CCS;1
+Investment|Energy Supply|Liquids|Electricity;Investment|Energy Supply|Liquids|Electricity|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Fossil;Investment|Energy Supply|Liquids|Fossil|w/ CCS;1
+Investment|Energy Supply|Liquids|Fossil;Investment|Energy Supply|Liquids|Fossil|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Gas;Investment|Energy Supply|Liquids|Gas|w/ CCS;1
+Investment|Energy Supply|Liquids|Gas;Investment|Energy Supply|Liquids|Gas|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Hydrogen;Investment|Energy Supply|Liquids|Hydrogen|w/ CCS;1
+Investment|Energy Supply|Liquids|Hydrogen;Investment|Energy Supply|Liquids|Hydrogen|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Oil;Investment|Energy Supply|Liquids|Oil|w/ CCS;1
+Investment|Energy Supply|Liquids|Oil;Investment|Energy Supply|Liquids|Oil|w/o CCS;1
+;;
+Investment|Energy Supply|Liquids|Other;Investment|Energy Supply|Liquids|Other|w/ CCS;1
+Investment|Energy Supply|Liquids|Other;Investment|Energy Supply|Liquids|Other|w/o CCS;1
+;;
+Investment|Energy Supply|Solids;Investment|Energy Supply|Solids|Biomass;1
+Investment|Energy Supply|Solids;Investment|Energy Supply|Solids|Coal;1
+;;
+Investment|Energy Supply|Solids 2;Investment|Energy Supply|Solids|w/ CCS;1
+Investment|Energy Supply|Solids 2;Investment|Energy Supply|Solids|w/o CCS;1
+;;
+Investment|Energy Supply|Solids|Biomass;Investment|Energy Supply|Solids|Biomass|w/ CCS;1
+Investment|Energy Supply|Solids|Biomass;Investment|Energy Supply|Solids|Biomass|w/o CCS;1
+;;
+Investment|Energy Supply|Solids|Coal;Investment|Energy Supply|Solids|Coal|w/ CCS;1
+Investment|Energy Supply|Solids|Coal;Investment|Energy Supply|Solids|Coal|w/o CCS;1
+;;
+Land Cover;Land Cover|Built-Up Area;1
+Land Cover;Land Cover|Cropland;1
+Land Cover;Land Cover|Forest;1
+Land Cover;Land Cover|Other Land;1
+Land Cover;Land Cover|Other Natural;1
+Land Cover;Land Cover|Pasture;1
+;;
+Land Cover|Cropland;Land Cover|Cropland|Cereals;1
+Land Cover|Cropland;Land Cover|Cropland|Energy Crops;1
+Land Cover|Cropland;Land Cover|Cropland|Oil Crops;1
+Land Cover|Cropland;Land Cover|Cropland|Other Crops;1
+Land Cover|Cropland;Land Cover|Cropland|Sugar Crops;1
+;;
+Land Cover|Cropland 2;Land Cover|Cropland|Irrigated;1
+Land Cover|Cropland 2;Land Cover|Cropland|Rainfed;1
+;;
+Land Cover|Cropland|Cereals;Land Cover|Cropland|Cereals|Irrigated;1
+Land Cover|Cropland|Cereals;Land Cover|Cropland|Cereals|Rainfed;1
+;;
+Land Cover|Cropland|Energy Crops;Land Cover|Cropland|Energy Crops|Irrigated;1
+Land Cover|Cropland|Energy Crops;Land Cover|Cropland|Energy Crops|Rainfed;1
+;;
+Land Cover|Cropland|Oil Crops;Land Cover|Cropland|Oil Crops|Irrigated;1
+Land Cover|Cropland|Oil Crops;Land Cover|Cropland|Oil Crops|Rainfed;1
+;;
+Land Cover|Cropland|Other Crops;Land Cover|Cropland|Other Crops|Irrigated;1
+Land Cover|Cropland|Other Crops;Land Cover|Cropland|Other Crops|Rainfed;1
+;;
+Land Cover|Cropland|Sugar Crops;Land Cover|Cropland|Sugar Crops|Irrigated;1
+Land Cover|Cropland|Sugar Crops;Land Cover|Cropland|Sugar Crops|Rainfed;1
+;;
+Land Cover|Forest;Land Cover|Forest|Planted;1
+Land Cover|Forest;Land Cover|Forest|Primary;1
+Land Cover|Forest;Land Cover|Forest|Secondary;1
+;;
+Land Cover|Forest|Planted;Land Cover|Forest|Planted|Natural;1
+Land Cover|Forest|Planted;Land Cover|Forest|Planted|Plantation;1
+;;
+Land Cover|Forest|Planted|Natural;Land Cover|Forest|Planted|Natural|Other;1
+Land Cover|Forest|Planted|Natural;Land Cover|Forest|Planted|Natural|Re/Afforestation;1
+;;
+Land Cover|Forest|Planted|Plantation;Land Cover|Forest|Planted|Plantation|Re/Afforestation;1
+Land Cover|Forest|Planted|Plantation;Land Cover|Forest|Planted|Plantation|Timber;1
+;;
+Land Cover|Other Natural;Land Cover|Other Natural|Primary Non-Forest;1
+Land Cover|Other Natural;Land Cover|Other Natural|Recovered;1
+Land Cover|Other Natural;Land Cover|Other Natural|Restored;1
+;;
+Population;Population|Female;1
+Population;Population|Male;1
+;;
+Population 2;Population|Prevalence of Normal Weight;1
+Population 2;Population|Prevalence of Obesity;1
+Population 2;Population|Prevalence of Overweight;1
+Population 2;Population|Prevalence of Underweight;1
+;;
+Population|Female;Population|Female|Age 0-4;1
+Population|Female;Population|Female|Age 10-14;1
+Population|Female;Population|Female|Age 100+;1
+Population|Female;Population|Female|Age 15-19;1
+Population|Female;Population|Female|Age 20-24;1
+Population|Female;Population|Female|Age 25-29;1
+Population|Female;Population|Female|Age 30-34;1
+Population|Female;Population|Female|Age 35-39;1
+Population|Female;Population|Female|Age 40-44;1
+Population|Female;Population|Female|Age 45-49;1
+Population|Female;Population|Female|Age 5-9;1
+Population|Female;Population|Female|Age 50-54;1
+Population|Female;Population|Female|Age 55-59;1
+Population|Female;Population|Female|Age 60-64;1
+Population|Female;Population|Female|Age 65-69;1
+Population|Female;Population|Female|Age 70-74;1
+Population|Female;Population|Female|Age 75-79;1
+Population|Female;Population|Female|Age 80-84;1
+Population|Female;Population|Female|Age 85-89;1
+Population|Female;Population|Female|Age 90-94;1
+Population|Female;Population|Female|Age 95-99;1
+;;
+Population|Female|Age 0-4;Population|Female|Age 0-4|Incomplete Primary Education;1
+Population|Female|Age 0-4;Population|Female|Age 0-4|Lower Secondary Education;1
+Population|Female|Age 0-4;Population|Female|Age 0-4|No Education;1
+Population|Female|Age 0-4;Population|Female|Age 0-4|Post Secondary Education;1
+Population|Female|Age 0-4;Population|Female|Age 0-4|Primary Education;1
+Population|Female|Age 0-4;Population|Female|Age 0-4|Upper Secondary Education;1
+;;
+Population|Female|Age 10-14;Population|Female|Age 10-14|Incomplete Primary Education;1
+Population|Female|Age 10-14;Population|Female|Age 10-14|Lower Secondary Education;1
+Population|Female|Age 10-14;Population|Female|Age 10-14|No Education;1
+Population|Female|Age 10-14;Population|Female|Age 10-14|Post Secondary Education;1
+Population|Female|Age 10-14;Population|Female|Age 10-14|Primary Education;1
+Population|Female|Age 10-14;Population|Female|Age 10-14|Upper Secondary Education;1
+;;
+Population|Female|Age 100+;Population|Female|Age 100+|Incomplete Primary Education;1
+Population|Female|Age 100+;Population|Female|Age 100+|Lower Secondary Education;1
+Population|Female|Age 100+;Population|Female|Age 100+|No Education;1
+Population|Female|Age 100+;Population|Female|Age 100+|Post Secondary Education;1
+Population|Female|Age 100+;Population|Female|Age 100+|Primary Education;1
+Population|Female|Age 100+;Population|Female|Age 100+|Upper Secondary Education;1
+;;
+Population|Female|Age 15-19;Population|Female|Age 15-19|Incomplete Primary Education;1
+Population|Female|Age 15-19;Population|Female|Age 15-19|Lower Secondary Education;1
+Population|Female|Age 15-19;Population|Female|Age 15-19|No Education;1
+Population|Female|Age 15-19;Population|Female|Age 15-19|Post Secondary Education;1
+Population|Female|Age 15-19;Population|Female|Age 15-19|Primary Education;1
+Population|Female|Age 15-19;Population|Female|Age 15-19|Upper Secondary Education;1
+;;
+Population|Female|Age 20-24;Population|Female|Age 20-24|Incomplete Primary Education;1
+Population|Female|Age 20-24;Population|Female|Age 20-24|Lower Secondary Education;1
+Population|Female|Age 20-24;Population|Female|Age 20-24|No Education;1
+Population|Female|Age 20-24;Population|Female|Age 20-24|Post Secondary Education;1
+Population|Female|Age 20-24;Population|Female|Age 20-24|Primary Education;1
+Population|Female|Age 20-24;Population|Female|Age 20-24|Upper Secondary Education;1
+;;
+Population|Female|Age 25-29;Population|Female|Age 25-29|Incomplete Primary Education;1
+Population|Female|Age 25-29;Population|Female|Age 25-29|Lower Secondary Education;1
+Population|Female|Age 25-29;Population|Female|Age 25-29|No Education;1
+Population|Female|Age 25-29;Population|Female|Age 25-29|Post Secondary Education;1
+Population|Female|Age 25-29;Population|Female|Age 25-29|Primary Education;1
+Population|Female|Age 25-29;Population|Female|Age 25-29|Upper Secondary Education;1
+;;
+Population|Female|Age 30-34;Population|Female|Age 30-34|Incomplete Primary Education;1
+Population|Female|Age 30-34;Population|Female|Age 30-34|Lower Secondary Education;1
+Population|Female|Age 30-34;Population|Female|Age 30-34|No Education;1
+Population|Female|Age 30-34;Population|Female|Age 30-34|Post Secondary Education;1
+Population|Female|Age 30-34;Population|Female|Age 30-34|Primary Education;1
+Population|Female|Age 30-34;Population|Female|Age 30-34|Upper Secondary Education;1
+;;
+Population|Female|Age 35-39;Population|Female|Age 35-39|Incomplete Primary Education;1
+Population|Female|Age 35-39;Population|Female|Age 35-39|Lower Secondary Education;1
+Population|Female|Age 35-39;Population|Female|Age 35-39|No Education;1
+Population|Female|Age 35-39;Population|Female|Age 35-39|Post Secondary Education;1
+Population|Female|Age 35-39;Population|Female|Age 35-39|Primary Education;1
+Population|Female|Age 35-39;Population|Female|Age 35-39|Upper Secondary Education;1
+;;
+Population|Female|Age 40-44;Population|Female|Age 40-44|Incomplete Primary Education;1
+Population|Female|Age 40-44;Population|Female|Age 40-44|Lower Secondary Education;1
+Population|Female|Age 40-44;Population|Female|Age 40-44|No Education;1
+Population|Female|Age 40-44;Population|Female|Age 40-44|Post Secondary Education;1
+Population|Female|Age 40-44;Population|Female|Age 40-44|Primary Education;1
+Population|Female|Age 40-44;Population|Female|Age 40-44|Upper Secondary Education;1
+;;
+Population|Female|Age 45-49;Population|Female|Age 45-49|Incomplete Primary Education;1
+Population|Female|Age 45-49;Population|Female|Age 45-49|Lower Secondary Education;1
+Population|Female|Age 45-49;Population|Female|Age 45-49|No Education;1
+Population|Female|Age 45-49;Population|Female|Age 45-49|Post Secondary Education;1
+Population|Female|Age 45-49;Population|Female|Age 45-49|Primary Education;1
+Population|Female|Age 45-49;Population|Female|Age 45-49|Upper Secondary Education;1
+;;
+Population|Female|Age 5-9;Population|Female|Age 5-9|Incomplete Primary Education;1
+Population|Female|Age 5-9;Population|Female|Age 5-9|Lower Secondary Education;1
+Population|Female|Age 5-9;Population|Female|Age 5-9|No Education;1
+Population|Female|Age 5-9;Population|Female|Age 5-9|Post Secondary Education;1
+Population|Female|Age 5-9;Population|Female|Age 5-9|Primary Education;1
+Population|Female|Age 5-9;Population|Female|Age 5-9|Upper Secondary Education;1
+;;
+Population|Female|Age 50-54;Population|Female|Age 50-54|Incomplete Primary Education;1
+Population|Female|Age 50-54;Population|Female|Age 50-54|Lower Secondary Education;1
+Population|Female|Age 50-54;Population|Female|Age 50-54|No Education;1
+Population|Female|Age 50-54;Population|Female|Age 50-54|Post Secondary Education;1
+Population|Female|Age 50-54;Population|Female|Age 50-54|Primary Education;1
+Population|Female|Age 50-54;Population|Female|Age 50-54|Upper Secondary Education;1
+;;
+Population|Female|Age 55-59;Population|Female|Age 55-59|Incomplete Primary Education;1
+Population|Female|Age 55-59;Population|Female|Age 55-59|Lower Secondary Education;1
+Population|Female|Age 55-59;Population|Female|Age 55-59|No Education;1
+Population|Female|Age 55-59;Population|Female|Age 55-59|Post Secondary Education;1
+Population|Female|Age 55-59;Population|Female|Age 55-59|Primary Education;1
+Population|Female|Age 55-59;Population|Female|Age 55-59|Upper Secondary Education;1
+;;
+Population|Female|Age 60-64;Population|Female|Age 60-64|Incomplete Primary Education;1
+Population|Female|Age 60-64;Population|Female|Age 60-64|Lower Secondary Education;1
+Population|Female|Age 60-64;Population|Female|Age 60-64|No Education;1
+Population|Female|Age 60-64;Population|Female|Age 60-64|Post Secondary Education;1
+Population|Female|Age 60-64;Population|Female|Age 60-64|Primary Education;1
+Population|Female|Age 60-64;Population|Female|Age 60-64|Upper Secondary Education;1
+;;
+Population|Female|Age 65-69;Population|Female|Age 65-69|Incomplete Primary Education;1
+Population|Female|Age 65-69;Population|Female|Age 65-69|Lower Secondary Education;1
+Population|Female|Age 65-69;Population|Female|Age 65-69|No Education;1
+Population|Female|Age 65-69;Population|Female|Age 65-69|Post Secondary Education;1
+Population|Female|Age 65-69;Population|Female|Age 65-69|Primary Education;1
+Population|Female|Age 65-69;Population|Female|Age 65-69|Upper Secondary Education;1
+;;
+Population|Female|Age 70-74;Population|Female|Age 70-74|Incomplete Primary Education;1
+Population|Female|Age 70-74;Population|Female|Age 70-74|Lower Secondary Education;1
+Population|Female|Age 70-74;Population|Female|Age 70-74|No Education;1
+Population|Female|Age 70-74;Population|Female|Age 70-74|Post Secondary Education;1
+Population|Female|Age 70-74;Population|Female|Age 70-74|Primary Education;1
+Population|Female|Age 70-74;Population|Female|Age 70-74|Upper Secondary Education;1
+;;
+Population|Female|Age 75-79;Population|Female|Age 75-79|Incomplete Primary Education;1
+Population|Female|Age 75-79;Population|Female|Age 75-79|Lower Secondary Education;1
+Population|Female|Age 75-79;Population|Female|Age 75-79|No Education;1
+Population|Female|Age 75-79;Population|Female|Age 75-79|Post Secondary Education;1
+Population|Female|Age 75-79;Population|Female|Age 75-79|Primary Education;1
+Population|Female|Age 75-79;Population|Female|Age 75-79|Upper Secondary Education;1
+;;
+Population|Female|Age 80-84;Population|Female|Age 80-84|Incomplete Primary Education;1
+Population|Female|Age 80-84;Population|Female|Age 80-84|Lower Secondary Education;1
+Population|Female|Age 80-84;Population|Female|Age 80-84|No Education;1
+Population|Female|Age 80-84;Population|Female|Age 80-84|Post Secondary Education;1
+Population|Female|Age 80-84;Population|Female|Age 80-84|Primary Education;1
+Population|Female|Age 80-84;Population|Female|Age 80-84|Upper Secondary Education;1
+;;
+Population|Female|Age 85-89;Population|Female|Age 85-89|Incomplete Primary Education;1
+Population|Female|Age 85-89;Population|Female|Age 85-89|Lower Secondary Education;1
+Population|Female|Age 85-89;Population|Female|Age 85-89|No Education;1
+Population|Female|Age 85-89;Population|Female|Age 85-89|Post Secondary Education;1
+Population|Female|Age 85-89;Population|Female|Age 85-89|Primary Education;1
+Population|Female|Age 85-89;Population|Female|Age 85-89|Upper Secondary Education;1
+;;
+Population|Female|Age 90-94;Population|Female|Age 90-94|Incomplete Primary Education;1
+Population|Female|Age 90-94;Population|Female|Age 90-94|Lower Secondary Education;1
+Population|Female|Age 90-94;Population|Female|Age 90-94|No Education;1
+Population|Female|Age 90-94;Population|Female|Age 90-94|Post Secondary Education;1
+Population|Female|Age 90-94;Population|Female|Age 90-94|Primary Education;1
+Population|Female|Age 90-94;Population|Female|Age 90-94|Upper Secondary Education;1
+;;
+Population|Female|Age 95-99;Population|Female|Age 95-99|Incomplete Primary Education;1
+Population|Female|Age 95-99;Population|Female|Age 95-99|Lower Secondary Education;1
+Population|Female|Age 95-99;Population|Female|Age 95-99|No Education;1
+Population|Female|Age 95-99;Population|Female|Age 95-99|Post Secondary Education;1
+Population|Female|Age 95-99;Population|Female|Age 95-99|Primary Education;1
+Population|Female|Age 95-99;Population|Female|Age 95-99|Upper Secondary Education;1
+;;
+Population|Male;Population|Male|Age 0-4;1
+Population|Male;Population|Male|Age 10-14;1
+Population|Male;Population|Male|Age 100+;1
+Population|Male;Population|Male|Age 15-19;1
+Population|Male;Population|Male|Age 20-24;1
+Population|Male;Population|Male|Age 25-29;1
+Population|Male;Population|Male|Age 30-34;1
+Population|Male;Population|Male|Age 35-39;1
+Population|Male;Population|Male|Age 40-44;1
+Population|Male;Population|Male|Age 45-49;1
+Population|Male;Population|Male|Age 5-9;1
+Population|Male;Population|Male|Age 50-54;1
+Population|Male;Population|Male|Age 55-59;1
+Population|Male;Population|Male|Age 60-64;1
+Population|Male;Population|Male|Age 65-69;1
+Population|Male;Population|Male|Age 70-74;1
+Population|Male;Population|Male|Age 75-79;1
+Population|Male;Population|Male|Age 80-84;1
+Population|Male;Population|Male|Age 85-89;1
+Population|Male;Population|Male|Age 90-94;1
+Population|Male;Population|Male|Age 95-99;1
+;;
+Population|Male|Age 0-4;Population|Male|Age 0-4|Incomplete Primary Education;1
+Population|Male|Age 0-4;Population|Male|Age 0-4|Lower Secondary Education;1
+Population|Male|Age 0-4;Population|Male|Age 0-4|No Education;1
+Population|Male|Age 0-4;Population|Male|Age 0-4|Post Secondary Education;1
+Population|Male|Age 0-4;Population|Male|Age 0-4|Primary Education;1
+Population|Male|Age 0-4;Population|Male|Age 0-4|Upper Secondary Education;1
+;;
+Population|Male|Age 10-14;Population|Male|Age 10-14|Incomplete Primary Education;1
+Population|Male|Age 10-14;Population|Male|Age 10-14|Lower Secondary Education;1
+Population|Male|Age 10-14;Population|Male|Age 10-14|No Education;1
+Population|Male|Age 10-14;Population|Male|Age 10-14|Post Secondary Education;1
+Population|Male|Age 10-14;Population|Male|Age 10-14|Primary Education;1
+Population|Male|Age 10-14;Population|Male|Age 10-14|Upper Secondary Education;1
+;;
+Population|Male|Age 100+;Population|Male|Age 100+|Incomplete Primary Education;1
+Population|Male|Age 100+;Population|Male|Age 100+|Lower Secondary Education;1
+Population|Male|Age 100+;Population|Male|Age 100+|No Education;1
+Population|Male|Age 100+;Population|Male|Age 100+|Post Secondary Education;1
+Population|Male|Age 100+;Population|Male|Age 100+|Primary Education;1
+Population|Male|Age 100+;Population|Male|Age 100+|Upper Secondary Education;1
+;;
+Population|Male|Age 15-19;Population|Male|Age 15-19|Incomplete Primary Education;1
+Population|Male|Age 15-19;Population|Male|Age 15-19|Lower Secondary Education;1
+Population|Male|Age 15-19;Population|Male|Age 15-19|No Education;1
+Population|Male|Age 15-19;Population|Male|Age 15-19|Post Secondary Education;1
+Population|Male|Age 15-19;Population|Male|Age 15-19|Primary Education;1
+Population|Male|Age 15-19;Population|Male|Age 15-19|Upper Secondary Education;1
+;;
+Population|Male|Age 20-24;Population|Male|Age 20-24|Incomplete Primary Education;1
+Population|Male|Age 20-24;Population|Male|Age 20-24|Lower Secondary Education;1
+Population|Male|Age 20-24;Population|Male|Age 20-24|No Education;1
+Population|Male|Age 20-24;Population|Male|Age 20-24|Post Secondary Education;1
+Population|Male|Age 20-24;Population|Male|Age 20-24|Primary Education;1
+Population|Male|Age 20-24;Population|Male|Age 20-24|Upper Secondary Education;1
+;;
+Population|Male|Age 25-29;Population|Male|Age 25-29|Incomplete Primary Education;1
+Population|Male|Age 25-29;Population|Male|Age 25-29|Lower Secondary Education;1
+Population|Male|Age 25-29;Population|Male|Age 25-29|No Education;1
+Population|Male|Age 25-29;Population|Male|Age 25-29|Post Secondary Education;1
+Population|Male|Age 25-29;Population|Male|Age 25-29|Primary Education;1
+Population|Male|Age 25-29;Population|Male|Age 25-29|Upper Secondary Education;1
+;;
+Population|Male|Age 30-34;Population|Male|Age 30-34|Incomplete Primary Education;1
+Population|Male|Age 30-34;Population|Male|Age 30-34|Lower Secondary Education;1
+Population|Male|Age 30-34;Population|Male|Age 30-34|No Education;1
+Population|Male|Age 30-34;Population|Male|Age 30-34|Post Secondary Education;1
+Population|Male|Age 30-34;Population|Male|Age 30-34|Primary Education;1
+Population|Male|Age 30-34;Population|Male|Age 30-34|Upper Secondary Education;1
+;;
+Population|Male|Age 35-39;Population|Male|Age 35-39|Incomplete Primary Education;1
+Population|Male|Age 35-39;Population|Male|Age 35-39|Lower Secondary Education;1
+Population|Male|Age 35-39;Population|Male|Age 35-39|No Education;1
+Population|Male|Age 35-39;Population|Male|Age 35-39|Post Secondary Education;1
+Population|Male|Age 35-39;Population|Male|Age 35-39|Primary Education;1
+Population|Male|Age 35-39;Population|Male|Age 35-39|Upper Secondary Education;1
+;;
+Population|Male|Age 40-44;Population|Male|Age 40-44|Incomplete Primary Education;1
+Population|Male|Age 40-44;Population|Male|Age 40-44|Lower Secondary Education;1
+Population|Male|Age 40-44;Population|Male|Age 40-44|No Education;1
+Population|Male|Age 40-44;Population|Male|Age 40-44|Post Secondary Education;1
+Population|Male|Age 40-44;Population|Male|Age 40-44|Primary Education;1
+Population|Male|Age 40-44;Population|Male|Age 40-44|Upper Secondary Education;1
+;;
+Population|Male|Age 45-49;Population|Male|Age 45-49|Incomplete Primary Education;1
+Population|Male|Age 45-49;Population|Male|Age 45-49|Lower Secondary Education;1
+Population|Male|Age 45-49;Population|Male|Age 45-49|No Education;1
+Population|Male|Age 45-49;Population|Male|Age 45-49|Post Secondary Education;1
+Population|Male|Age 45-49;Population|Male|Age 45-49|Primary Education;1
+Population|Male|Age 45-49;Population|Male|Age 45-49|Upper Secondary Education;1
+;;
+Population|Male|Age 5-9;Population|Male|Age 5-9|Incomplete Primary Education;1
+Population|Male|Age 5-9;Population|Male|Age 5-9|Lower Secondary Education;1
+Population|Male|Age 5-9;Population|Male|Age 5-9|No Education;1
+Population|Male|Age 5-9;Population|Male|Age 5-9|Post Secondary Education;1
+Population|Male|Age 5-9;Population|Male|Age 5-9|Primary Education;1
+Population|Male|Age 5-9;Population|Male|Age 5-9|Upper Secondary Education;1
+;;
+Population|Male|Age 50-54;Population|Male|Age 50-54|Incomplete Primary Education;1
+Population|Male|Age 50-54;Population|Male|Age 50-54|Lower Secondary Education;1
+Population|Male|Age 50-54;Population|Male|Age 50-54|No Education;1
+Population|Male|Age 50-54;Population|Male|Age 50-54|Post Secondary Education;1
+Population|Male|Age 50-54;Population|Male|Age 50-54|Primary Education;1
+Population|Male|Age 50-54;Population|Male|Age 50-54|Upper Secondary Education;1
+;;
+Population|Male|Age 55-59;Population|Male|Age 55-59|Incomplete Primary Education;1
+Population|Male|Age 55-59;Population|Male|Age 55-59|Lower Secondary Education;1
+Population|Male|Age 55-59;Population|Male|Age 55-59|No Education;1
+Population|Male|Age 55-59;Population|Male|Age 55-59|Post Secondary Education;1
+Population|Male|Age 55-59;Population|Male|Age 55-59|Primary Education;1
+Population|Male|Age 55-59;Population|Male|Age 55-59|Upper Secondary Education;1
+;;
+Population|Male|Age 60-64;Population|Male|Age 60-64|Incomplete Primary Education;1
+Population|Male|Age 60-64;Population|Male|Age 60-64|Lower Secondary Education;1
+Population|Male|Age 60-64;Population|Male|Age 60-64|No Education;1
+Population|Male|Age 60-64;Population|Male|Age 60-64|Post Secondary Education;1
+Population|Male|Age 60-64;Population|Male|Age 60-64|Primary Education;1
+Population|Male|Age 60-64;Population|Male|Age 60-64|Upper Secondary Education;1
+;;
+Population|Male|Age 65-69;Population|Male|Age 65-69|Incomplete Primary Education;1
+Population|Male|Age 65-69;Population|Male|Age 65-69|Lower Secondary Education;1
+Population|Male|Age 65-69;Population|Male|Age 65-69|No Education;1
+Population|Male|Age 65-69;Population|Male|Age 65-69|Post Secondary Education;1
+Population|Male|Age 65-69;Population|Male|Age 65-69|Primary Education;1
+Population|Male|Age 65-69;Population|Male|Age 65-69|Upper Secondary Education;1
+;;
+Population|Male|Age 70-74;Population|Male|Age 70-74|Incomplete Primary Education;1
+Population|Male|Age 70-74;Population|Male|Age 70-74|Lower Secondary Education;1
+Population|Male|Age 70-74;Population|Male|Age 70-74|No Education;1
+Population|Male|Age 70-74;Population|Male|Age 70-74|Post Secondary Education;1
+Population|Male|Age 70-74;Population|Male|Age 70-74|Primary Education;1
+Population|Male|Age 70-74;Population|Male|Age 70-74|Upper Secondary Education;1
+;;
+Population|Male|Age 75-79;Population|Male|Age 75-79|Incomplete Primary Education;1
+Population|Male|Age 75-79;Population|Male|Age 75-79|Lower Secondary Education;1
+Population|Male|Age 75-79;Population|Male|Age 75-79|No Education;1
+Population|Male|Age 75-79;Population|Male|Age 75-79|Post Secondary Education;1
+Population|Male|Age 75-79;Population|Male|Age 75-79|Primary Education;1
+Population|Male|Age 75-79;Population|Male|Age 75-79|Upper Secondary Education;1
+;;
+Population|Male|Age 80-84;Population|Male|Age 80-84|Incomplete Primary Education;1
+Population|Male|Age 80-84;Population|Male|Age 80-84|Lower Secondary Education;1
+Population|Male|Age 80-84;Population|Male|Age 80-84|No Education;1
+Population|Male|Age 80-84;Population|Male|Age 80-84|Post Secondary Education;1
+Population|Male|Age 80-84;Population|Male|Age 80-84|Primary Education;1
+Population|Male|Age 80-84;Population|Male|Age 80-84|Upper Secondary Education;1
+;;
+Population|Male|Age 85-89;Population|Male|Age 85-89|Incomplete Primary Education;1
+Population|Male|Age 85-89;Population|Male|Age 85-89|Lower Secondary Education;1
+Population|Male|Age 85-89;Population|Male|Age 85-89|No Education;1
+Population|Male|Age 85-89;Population|Male|Age 85-89|Post Secondary Education;1
+Population|Male|Age 85-89;Population|Male|Age 85-89|Primary Education;1
+Population|Male|Age 85-89;Population|Male|Age 85-89|Upper Secondary Education;1
+;;
+Population|Male|Age 90-94;Population|Male|Age 90-94|Incomplete Primary Education;1
+Population|Male|Age 90-94;Population|Male|Age 90-94|Lower Secondary Education;1
+Population|Male|Age 90-94;Population|Male|Age 90-94|No Education;1
+Population|Male|Age 90-94;Population|Male|Age 90-94|Post Secondary Education;1
+Population|Male|Age 90-94;Population|Male|Age 90-94|Primary Education;1
+Population|Male|Age 90-94;Population|Male|Age 90-94|Upper Secondary Education;1
+;;
+Population|Male|Age 95-99;Population|Male|Age 95-99|Incomplete Primary Education;1
+Population|Male|Age 95-99;Population|Male|Age 95-99|Lower Secondary Education;1
+Population|Male|Age 95-99;Population|Male|Age 95-99|No Education;1
+Population|Male|Age 95-99;Population|Male|Age 95-99|Post Secondary Education;1
+Population|Male|Age 95-99;Population|Male|Age 95-99|Primary Education;1
+Population|Male|Age 95-99;Population|Male|Age 95-99|Upper Secondary Education;1
+;;
 Primary Energy;Primary Energy|Biomass;1
 Primary Energy;Primary Energy|Coal;1
 Primary Energy;Primary Energy|Gas;1
@@ -371,17 +5871,561 @@ Primary Energy;Primary Energy|Hydro;1
 Primary Energy;Primary Energy|Nuclear;1
 Primary Energy;Primary Energy|Ocean;1
 Primary Energy;Primary Energy|Oil;1
+Primary Energy;Primary Energy|Other;1
+Primary Energy;Primary Energy|Secondary Energy Trade;1
 Primary Energy;Primary Energy|Solar;1
 Primary Energy;Primary Energy|Wind;1
 ;;
-# Primary Energy Fossil;;
 Primary Energy|Fossil;Primary Energy|Coal;1
 Primary Energy|Fossil;Primary Energy|Gas;1
 Primary Energy|Fossil;Primary Energy|Oil;1
 ;;
-# Primary Energy Non-Biomass Renewables;;
 Primary Energy|Non-Biomass Renewables;Primary Energy|Geothermal;1
 Primary Energy|Non-Biomass Renewables;Primary Energy|Hydro;1
 Primary Energy|Non-Biomass Renewables;Primary Energy|Ocean;1
 Primary Energy|Non-Biomass Renewables;Primary Energy|Solar;1
 Primary Energy|Non-Biomass Renewables;Primary Energy|Wind;1
+;;
+Primary Energy|Biomass;Primary Energy|Biomass|Electricity;1
+Primary Energy|Biomass;Primary Energy|Biomass|Gases;1
+Primary Energy|Biomass;Primary Energy|Biomass|Heat;1
+Primary Energy|Biomass;Primary Energy|Biomass|Hydrogen;1
+Primary Energy|Biomass;Primary Energy|Biomass|Liquids;1
+Primary Energy|Biomass;Primary Energy|Biomass|Other;1
+Primary Energy|Biomass;Primary Energy|Biomass|Solids;1
+;;
+Primary Energy|Biomass 2;Primary Energy|Biomass|w/ CCS;1
+Primary Energy|Biomass 2;Primary Energy|Biomass|w/o CCS;1
+;;
+Primary Energy|Biomass 3;Primary Energy|Biomass|1st Generation;1
+Primary Energy|Biomass 3;Primary Energy|Biomass|Energy Crops;1
+Primary Energy|Biomass 3;Primary Energy|Biomass|Residues;1
+;;
+Primary Energy|Biomass 4;Primary Energy|Biomass|Modern;1
+Primary Energy|Biomass 4;Primary Energy|Biomass|Traditional;1
+;;
+Primary Energy|Biomass|Electricity;Primary Energy|Biomass|Electricity|w/ CCS;1
+Primary Energy|Biomass|Electricity;Primary Energy|Biomass|Electricity|w/o CCS;1
+;;
+Primary Energy|Biomass|Gases;Primary Energy|Biomass|Gases|w/ CCS;1
+Primary Energy|Biomass|Gases;Primary Energy|Biomass|Gases|w/o CCS;1
+;;
+Primary Energy|Biomass|Heat;Primary Energy|Biomass|Heat|w/ CCS;1
+Primary Energy|Biomass|Heat;Primary Energy|Biomass|Heat|w/o CCS;1
+;;
+Primary Energy|Biomass|Hydrogen;Primary Energy|Biomass|Hydrogen|w/ CCS;1
+Primary Energy|Biomass|Hydrogen;Primary Energy|Biomass|Hydrogen|w/o CCS;1
+;;
+Primary Energy|Biomass|Liquids;Primary Energy|Biomass|Liquids|w/ CCS;1
+Primary Energy|Biomass|Liquids;Primary Energy|Biomass|Liquids|w/o CCS;1
+;;
+Primary Energy|Biomass|Modern;Primary Energy|Biomass|Modern|w/ CCS;1
+Primary Energy|Biomass|Modern;Primary Energy|Biomass|Modern|w/o CCS;1
+;;
+Primary Energy|Biomass|Residues;Primary Energy|Biomass|Residues|Crop Residues;1
+Primary Energy|Biomass|Residues;Primary Energy|Biomass|Residues|Forest Residues;1
+Primary Energy|Biomass|Residues;Primary Energy|Biomass|Residues|Other Residues;1
+;;
+Primary Energy|Biomass|Solids;Primary Energy|Biomass|Solids|w/ CCS;1
+Primary Energy|Biomass|Solids;Primary Energy|Biomass|Solids|w/o CCS;1
+;;
+Primary Energy|Coal;Primary Energy|Coal|Electricity;1
+Primary Energy|Coal;Primary Energy|Coal|Gases;1
+Primary Energy|Coal;Primary Energy|Coal|Heat;1
+Primary Energy|Coal;Primary Energy|Coal|Hydrogen;1
+Primary Energy|Coal;Primary Energy|Coal|Liquids;1
+Primary Energy|Coal;Primary Energy|Coal|Solids;1
+;;
+Primary Energy|Coal 2;Primary Energy|Coal|w/ CCS;1
+Primary Energy|Coal 2;Primary Energy|Coal|w/o CCS;1
+;;
+Primary Energy|Coal|Electricity;Primary Energy|Coal|Electricity|w/ CCS;1
+Primary Energy|Coal|Electricity;Primary Energy|Coal|Electricity|w/o CCS;1
+;;
+Primary Energy|Coal|Gases;Primary Energy|Coal|Gases|w/ CCS;1
+Primary Energy|Coal|Gases;Primary Energy|Coal|Gases|w/o CCS;1
+;;
+Primary Energy|Coal|Heat;Primary Energy|Coal|Heat|w/ CCS;1
+Primary Energy|Coal|Heat;Primary Energy|Coal|Heat|w/o CCS;1
+;;
+Primary Energy|Coal|Hydrogen;Primary Energy|Coal|Hydrogen|w/ CCS;1
+Primary Energy|Coal|Hydrogen;Primary Energy|Coal|Hydrogen|w/o CCS;1
+;;
+Primary Energy|Coal|Liquids;Primary Energy|Coal|Liquids|w/ CCS;1
+Primary Energy|Coal|Liquids;Primary Energy|Coal|Liquids|w/o CCS;1
+;;
+Primary Energy|Coal|Solids;Primary Energy|Coal|Solids|w/ CCS;1
+Primary Energy|Coal|Solids;Primary Energy|Coal|Solids|w/o CCS;1
+;;
+Primary Energy|Fossil;Primary Energy|Fossil|Electricity;1
+Primary Energy|Fossil;Primary Energy|Fossil|Gases;1
+Primary Energy|Fossil;Primary Energy|Fossil|Heat;1
+Primary Energy|Fossil;Primary Energy|Fossil|Hydrogen;1
+Primary Energy|Fossil;Primary Energy|Fossil|Liquids;1
+Primary Energy|Fossil;Primary Energy|Fossil|Solids;1
+;;
+Primary Energy|Fossil 2;Primary Energy|Fossil|w/ CCS;1
+Primary Energy|Fossil 2;Primary Energy|Fossil|w/o CCS;1
+;;
+Primary Energy|Fossil|Electricity;Primary Energy|Fossil|Electricity|w/ CCS;1
+Primary Energy|Fossil|Electricity;Primary Energy|Fossil|Electricity|w/o CCS;1
+;;
+Primary Energy|Fossil|Gases;Primary Energy|Fossil|Gases|w/ CCS;1
+Primary Energy|Fossil|Gases;Primary Energy|Fossil|Gases|w/o CCS;1
+;;
+Primary Energy|Fossil|Heat;Primary Energy|Fossil|Heat|w/ CCS;1
+Primary Energy|Fossil|Heat;Primary Energy|Fossil|Heat|w/o CCS;1
+;;
+Primary Energy|Fossil|Hydrogen;Primary Energy|Fossil|Hydrogen|w/ CCS;1
+Primary Energy|Fossil|Hydrogen;Primary Energy|Fossil|Hydrogen|w/o CCS;1
+;;
+Primary Energy|Fossil|Liquids;Primary Energy|Fossil|Liquids|w/ CCS;1
+Primary Energy|Fossil|Liquids;Primary Energy|Fossil|Liquids|w/o CCS;1
+;;
+Primary Energy|Fossil|Solids;Primary Energy|Fossil|Solids|w/ CCS;1
+Primary Energy|Fossil|Solids;Primary Energy|Fossil|Solids|w/o CCS;1
+;;
+Primary Energy|Gas;Primary Energy|Gas|Electricity;1
+Primary Energy|Gas;Primary Energy|Gas|Gases;1
+Primary Energy|Gas;Primary Energy|Gas|Heat;1
+Primary Energy|Gas;Primary Energy|Gas|Hydrogen;1
+Primary Energy|Gas;Primary Energy|Gas|Liquids;1
+Primary Energy|Gas;Primary Energy|Gas|Solids;1
+;;
+Primary Energy|Gas 2;Primary Energy|Gas|w/ CCS;1
+Primary Energy|Gas 2;Primary Energy|Gas|w/o CCS;1
+;;
+Primary Energy|Gas|Electricity;Primary Energy|Gas|Electricity|w/ CCS;1
+Primary Energy|Gas|Electricity;Primary Energy|Gas|Electricity|w/o CCS;1
+;;
+Primary Energy|Gas|Gases;Primary Energy|Gas|Gases|w/ CCS;1
+Primary Energy|Gas|Gases;Primary Energy|Gas|Gases|w/o CCS;1
+;;
+Primary Energy|Gas|Heat;Primary Energy|Gas|Heat|w/ CCS;1
+Primary Energy|Gas|Heat;Primary Energy|Gas|Heat|w/o CCS;1
+;;
+Primary Energy|Gas|Hydrogen;Primary Energy|Gas|Hydrogen|w/ CCS;1
+Primary Energy|Gas|Hydrogen;Primary Energy|Gas|Hydrogen|w/o CCS;1
+;;
+Primary Energy|Gas|Liquids;Primary Energy|Gas|Liquids|w/ CCS;1
+Primary Energy|Gas|Liquids;Primary Energy|Gas|Liquids|w/o CCS;1
+;;
+Primary Energy|Gas|Solids;Primary Energy|Gas|Solids|w/ CCS;1
+Primary Energy|Gas|Solids;Primary Energy|Gas|Solids|w/o CCS;1
+;;
+Primary Energy|Oil;Primary Energy|Oil|Electricity;1
+Primary Energy|Oil;Primary Energy|Oil|Gases;1
+Primary Energy|Oil;Primary Energy|Oil|Heat;1
+Primary Energy|Oil;Primary Energy|Oil|Hydrogen;1
+Primary Energy|Oil;Primary Energy|Oil|Liquids;1
+Primary Energy|Oil;Primary Energy|Oil|Solids;1
+;;
+Primary Energy|Oil 2;Primary Energy|Oil|w/ CCS;1
+Primary Energy|Oil 2;Primary Energy|Oil|w/o CCS;1
+;;
+Primary Energy|Oil|Electricity;Primary Energy|Oil|Electricity|w/ CCS;1
+Primary Energy|Oil|Electricity;Primary Energy|Oil|Electricity|w/o CCS;1
+;;
+Primary Energy|Oil|Gases;Primary Energy|Oil|Gases|w/ CCS;1
+Primary Energy|Oil|Gases;Primary Energy|Oil|Gases|w/o CCS;1
+;;
+Primary Energy|Oil|Heat;Primary Energy|Oil|Heat|w/ CCS;1
+Primary Energy|Oil|Heat;Primary Energy|Oil|Heat|w/o CCS;1
+;;
+Primary Energy|Oil|Hydrogen;Primary Energy|Oil|Hydrogen|w/ CCS;1
+Primary Energy|Oil|Hydrogen;Primary Energy|Oil|Hydrogen|w/o CCS;1
+;;
+Primary Energy|Oil|Liquids;Primary Energy|Oil|Liquids|w/ CCS;1
+Primary Energy|Oil|Liquids;Primary Energy|Oil|Liquids|w/o CCS;1
+;;
+Primary Energy|Oil|Solids;Primary Energy|Oil|Solids|w/ CCS;1
+Primary Energy|Oil|Solids;Primary Energy|Oil|Solids|w/o CCS;1
+;;
+Production|Chemicals|High-Value Chemicals;Production|Chemicals|High-Value Chemicals|BTX;1
+Production|Chemicals|High-Value Chemicals;Production|Chemicals|High-Value Chemicals|Ethylene;1
+Production|Chemicals|High-Value Chemicals;Production|Chemicals|High-Value Chemicals|Propylene;1
+;;
+Production|Chemicals|Plastics;Production|Chemicals|Plastics|Primary;1
+Production|Chemicals|Plastics;Production|Chemicals|Plastics|Secondary;1
+;;
+Production|Iron and Steel|Iron;Production|Iron and Steel|Iron|Pig Iron;1
+Production|Iron and Steel|Iron;Production|Iron and Steel|Iron|Sponge Iron;1
+;;
+Production|Iron and Steel|Steel;Production|Iron and Steel|Steel|Primary;1
+Production|Iron and Steel|Steel;Production|Iron and Steel|Steel|Secondary;1
+;;
+Production|Non-Ferrous Metals|Aluminum;Production|Non-Ferrous Metals|Aluminum|Primary;1
+Production|Non-Ferrous Metals|Aluminum;Production|Non-Ferrous Metals|Aluminum|Secondary;1
+;;
+Production|Non-Ferrous Metals|Copper;Production|Non-Ferrous Metals|Copper|Primary;1
+Production|Non-Ferrous Metals|Copper;Production|Non-Ferrous Metals|Copper|Secondary;1
+;;
+Production|Non-Ferrous Metals|Lithium;Production|Non-Ferrous Metals|Lithium|Primary;1
+Production|Non-Ferrous Metals|Lithium;Production|Non-Ferrous Metals|Lithium|Secondary;1
+;;
+Sales|Transportation|Bus;Sales|Transportation|Bus|Battery-Electric;1
+Sales|Transportation|Bus;Sales|Transportation|Bus|Fuel-Cell-Electric;1
+Sales|Transportation|Bus;Sales|Transportation|Bus|Internal Combustion;1
+Sales|Transportation|Bus;Sales|Transportation|Bus|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle;Sales|Transportation|Light-Duty Vehicle|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle;Sales|Transportation|Light-Duty Vehicle|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle;Sales|Transportation|Light-Duty Vehicle|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle;Sales|Transportation|Light-Duty Vehicle|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle 2;Sales|Transportation|Light-Duty Vehicle|Compact Car;1
+Sales|Transportation|Light-Duty Vehicle 2;Sales|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Sales|Transportation|Light-Duty Vehicle 2;Sales|Transportation|Light-Duty Vehicle|Midsize Car;1
+Sales|Transportation|Light-Duty Vehicle 2;Sales|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Sales|Transportation|Light-Duty Vehicle 2;Sales|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Sales|Transportation|Light-Duty Vehicle|Compact Car;Sales|Transportation|Light-Duty Vehicle|Compact Car|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Compact Car;Sales|Transportation|Light-Duty Vehicle|Compact Car|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Compact Car;Sales|Transportation|Light-Duty Vehicle|Compact Car|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle|Compact Car;Sales|Transportation|Light-Duty Vehicle|Compact Car|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle|Large Car and SUV;Sales|Transportation|Light-Duty Vehicle|Large Car and SUV|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Large Car and SUV;Sales|Transportation|Light-Duty Vehicle|Large Car and SUV|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Large Car and SUV;Sales|Transportation|Light-Duty Vehicle|Large Car and SUV|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle|Large Car and SUV;Sales|Transportation|Light-Duty Vehicle|Large Car and SUV|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle|Midsize Car;Sales|Transportation|Light-Duty Vehicle|Midsize Car|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Midsize Car;Sales|Transportation|Light-Duty Vehicle|Midsize Car|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Midsize Car;Sales|Transportation|Light-Duty Vehicle|Midsize Car|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle|Midsize Car;Sales|Transportation|Light-Duty Vehicle|Midsize Car|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle|Subcompact Car;Sales|Transportation|Light-Duty Vehicle|Subcompact Car|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Subcompact Car;Sales|Transportation|Light-Duty Vehicle|Subcompact Car|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Subcompact Car;Sales|Transportation|Light-Duty Vehicle|Subcompact Car|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle|Subcompact Car;Sales|Transportation|Light-Duty Vehicle|Subcompact Car|Plug-in Hybrid;1
+;;
+Sales|Transportation|Light-Duty Vehicle|Two-Wheeler;Sales|Transportation|Light-Duty Vehicle|Two-Wheeler|Battery-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Two-Wheeler;Sales|Transportation|Light-Duty Vehicle|Two-Wheeler|Fuel-Cell-Electric;1
+Sales|Transportation|Light-Duty Vehicle|Two-Wheeler;Sales|Transportation|Light-Duty Vehicle|Two-Wheeler|Internal Combustion;1
+Sales|Transportation|Light-Duty Vehicle|Two-Wheeler;Sales|Transportation|Light-Duty Vehicle|Two-Wheeler|Plug-in Hybrid;1
+;;
+Sales|Transportation|Truck;Sales|Transportation|Truck|Battery-Electric;1
+Sales|Transportation|Truck;Sales|Transportation|Truck|Fuel-Cell-Electric;1
+Sales|Transportation|Truck;Sales|Transportation|Truck|Internal Combustion;1
+Sales|Transportation|Truck;Sales|Transportation|Truck|Plug-in Hybrid;1
+;;
+Secondary Energy|Electricity;Secondary Energy|Electricity|Ammonia;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Biomass;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Coal;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Gas;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Geothermal;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Hydro;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Hydrogen;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Nuclear;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Ocean;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Oil;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Other;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Solar;1
+Secondary Energy|Electricity;Secondary Energy|Electricity|Wind;1
+;;
+Secondary Energy|Electricity|Fossil;Secondary Energy|Electricity|Coal;1
+Secondary Energy|Electricity|Fossil;Secondary Energy|Electricity|Gas;1
+Secondary Energy|Electricity|Fossil;Secondary Energy|Electricity|Oil;1
+;;
+Secondary Energy|Electricity|Non-Biomass Renewables;Secondary Energy|Electricity|Geothermal;1
+Secondary Energy|Electricity|Non-Biomass Renewables;Secondary Energy|Electricity|Hydro;1
+Secondary Energy|Electricity|Non-Biomass Renewables;Secondary Energy|Electricity|Ocean;1
+Secondary Energy|Electricity|Non-Biomass Renewables;Secondary Energy|Electricity|Solar;1
+Secondary Energy|Electricity|Non-Biomass Renewables;Secondary Energy|Electricity|Wind;1
+;;
+Secondary Energy|Electricity|Biomass;Secondary Energy|Electricity|Biomass|w/ CCS;1
+Secondary Energy|Electricity|Biomass;Secondary Energy|Electricity|Biomass|w/o CCS;1
+;;
+Secondary Energy|Electricity|Coal;Secondary Energy|Electricity|Coal|w/ CCS;1
+Secondary Energy|Electricity|Coal;Secondary Energy|Electricity|Coal|w/o CCS;1
+;;
+Secondary Energy|Electricity|Fossil 2;Secondary Energy|Electricity|Fossil|w/ CCS;1
+Secondary Energy|Electricity|Fossil 2;Secondary Energy|Electricity|Fossil|w/o CCS;1
+;;
+Secondary Energy|Electricity|Gas;Secondary Energy|Electricity|Gas|w/ CCS;1
+Secondary Energy|Electricity|Gas;Secondary Energy|Electricity|Gas|w/o CCS;1
+;;
+Secondary Energy|Electricity|Oil;Secondary Energy|Electricity|Oil|w/ CCS;1
+Secondary Energy|Electricity|Oil;Secondary Energy|Electricity|Oil|w/o CCS;1
+;;
+Secondary Energy|Electricity|Solar;Secondary Energy|Electricity|Solar|CSP;1
+Secondary Energy|Electricity|Solar;Secondary Energy|Electricity|Solar|PV;1
+;;
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Agri-PV;1
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Commercial;1
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Floating;1
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Open Land;1
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Other;1
+Secondary Energy|Electricity|Solar|PV;Secondary Energy|Electricity|Solar|PV|Residential;1
+;;
+Secondary Energy|Electricity|Wind;Secondary Energy|Electricity|Wind|Offshore;1
+Secondary Energy|Electricity|Wind;Secondary Energy|Electricity|Wind|Onshore;1
+;;
+Secondary Energy|Gases;Secondary Energy|Gases|Biomass;1
+Secondary Energy|Gases;Secondary Energy|Gases|Coal;1
+Secondary Energy|Gases;Secondary Energy|Gases|Electricity;1
+Secondary Energy|Gases;Secondary Energy|Gases|Gas;1
+Secondary Energy|Gases;Secondary Energy|Gases|Hydrogen;1
+Secondary Energy|Gases;Secondary Energy|Gases|Other;1
+;;
+Secondary Energy|Gases|Fossil;Secondary Energy|Gases|Coal;1
+Secondary Energy|Gases|Fossil;Secondary Energy|Gases|Gas;1
+;;
+Secondary Energy|Gases|Hydrogen;Secondary Energy|Gases|Hydrogen|Biomass;1
+Secondary Energy|Gases|Hydrogen;Secondary Energy|Gases|Hydrogen|Electricity;1
+Secondary Energy|Gases|Hydrogen;Secondary Energy|Gases|Hydrogen|Fossil;1
+Secondary Energy|Gases|Hydrogen;Secondary Energy|Gases|Hydrogen|Other;1
+;;
+Secondary Energy|Heat;Secondary Energy|Heat|Biomass;1
+Secondary Energy|Heat;Secondary Energy|Heat|Coal;1
+Secondary Energy|Heat;Secondary Energy|Heat|Electricity;1
+Secondary Energy|Heat;Secondary Energy|Heat|Gas;1
+Secondary Energy|Heat;Secondary Energy|Heat|Geothermal;1
+Secondary Energy|Heat;Secondary Energy|Heat|Hydrogen;1
+Secondary Energy|Heat;Secondary Energy|Heat|Nuclear;1
+Secondary Energy|Heat;Secondary Energy|Heat|Oil;1
+Secondary Energy|Heat;Secondary Energy|Heat|Other;1
+Secondary Energy|Heat;Secondary Energy|Heat|Solar;1
+;;
+Secondary Energy|Heat|Biomass;Secondary Energy|Heat|Biomass|w/ CCS;1
+Secondary Energy|Heat|Biomass;Secondary Energy|Heat|Biomass|w/o CCS;1
+;;
+Secondary Energy|Heat|Coal;Secondary Energy|Heat|Coal|w/ CCS;1
+Secondary Energy|Heat|Coal;Secondary Energy|Heat|Coal|w/o CCS;1
+;;
+Secondary Energy|Heat|Fossil;Secondary Energy|Heat|Fossil|w/ CCS;1
+Secondary Energy|Heat|Fossil;Secondary Energy|Heat|Fossil|w/o CCS;1
+;;
+Secondary Energy|Heat|Gas;Secondary Energy|Heat|Gas|w/ CCS;1
+Secondary Energy|Heat|Gas;Secondary Energy|Heat|Gas|w/o CCS;1
+;;
+Secondary Energy|Heat|Hydrogen;Secondary Energy|Heat|Hydrogen|Biomass;1
+Secondary Energy|Heat|Hydrogen;Secondary Energy|Heat|Hydrogen|Electricity;1
+Secondary Energy|Heat|Hydrogen;Secondary Energy|Heat|Hydrogen|Fossil;1
+Secondary Energy|Heat|Hydrogen;Secondary Energy|Heat|Hydrogen|Other;1
+;;
+Secondary Energy|Heat|Oil;Secondary Energy|Heat|Oil|w/ CCS;1
+Secondary Energy|Heat|Oil;Secondary Energy|Heat|Oil|w/o CCS;1
+;;
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Biomass;1
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Electricity;1
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Fossil;1
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Nuclear;1
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Other;1
+Secondary Energy|Hydrogen;Secondary Energy|Hydrogen|Solar;1
+;;
+Secondary Energy|Hydrogen|Fossil;Secondary Energy|Hydrogen|Coal;1
+Secondary Energy|Hydrogen|Fossil;Secondary Energy|Hydrogen|Gas;1
+Secondary Energy|Hydrogen|Fossil;Secondary Energy|Hydrogen|Oil;1
+;;
+Secondary Energy|Hydrogen|Biomass;Secondary Energy|Hydrogen|Biomass|w/ CCS;1
+Secondary Energy|Hydrogen|Biomass;Secondary Energy|Hydrogen|Biomass|w/o CCS;1
+;;
+Secondary Energy|Hydrogen|Coal;Secondary Energy|Hydrogen|Coal|w/ CCS;1
+Secondary Energy|Hydrogen|Coal;Secondary Energy|Hydrogen|Coal|w/o CCS;1
+;;
+Secondary Energy|Hydrogen|Fossil 2;Secondary Energy|Hydrogen|Fossil|w/ CCS;1
+Secondary Energy|Hydrogen|Fossil 2;Secondary Energy|Hydrogen|Fossil|w/o CCS;1
+;;
+Secondary Energy|Hydrogen|Gas;Secondary Energy|Hydrogen|Gas|w/ CCS;1
+Secondary Energy|Hydrogen|Gas;Secondary Energy|Hydrogen|Gas|w/o CCS;1
+;;
+Secondary Energy|Hydrogen|Oil;Secondary Energy|Hydrogen|Oil|w/ CCS;1
+Secondary Energy|Hydrogen|Oil;Secondary Energy|Hydrogen|Oil|w/o CCS;1
+;;
+Secondary Energy|Liquids;Secondary Energy|Liquids|Biomass;1
+Secondary Energy|Liquids;Secondary Energy|Liquids|Electricity;1
+Secondary Energy|Liquids;Secondary Energy|Liquids|Fossil;1
+Secondary Energy|Liquids;Secondary Energy|Liquids|Hydrogen;1
+Secondary Energy|Liquids;Secondary Energy|Liquids|Other;1
+;;
+Secondary Energy|Liquids|Fossil;Secondary Energy|Liquids|Gas;1
+Secondary Energy|Liquids|Fossil;Secondary Energy|Liquids|Oil;1
+Secondary Energy|Liquids|Fossil;Secondary Energy|Liquids|Coal;1
+;;
+Secondary Energy|Liquids|Hydrogen;Secondary Energy|Liquids|Hydrogen|Biomass;1
+Secondary Energy|Liquids|Hydrogen;Secondary Energy|Liquids|Hydrogen|Electricity;1
+Secondary Energy|Liquids|Hydrogen;Secondary Energy|Liquids|Hydrogen|Fossil;1
+Secondary Energy|Liquids|Hydrogen;Secondary Energy|Liquids|Hydrogen|Other;1
+;;
+Secondary Energy|Solids;Secondary Energy|Solids|Biomass;1
+Secondary Energy|Solids;Secondary Energy|Solids|Coal;1
+;;
+Stocks|Transportation|Bus;Stocks|Transportation|Bus|Battery-Electric;1
+Stocks|Transportation|Bus;Stocks|Transportation|Bus|Fuel-Cell-Electric;1
+Stocks|Transportation|Bus;Stocks|Transportation|Bus|Internal Combustion;1
+Stocks|Transportation|Bus;Stocks|Transportation|Bus|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle;Stocks|Transportation|Light-Duty Vehicle|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle;Stocks|Transportation|Light-Duty Vehicle|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle;Stocks|Transportation|Light-Duty Vehicle|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle;Stocks|Transportation|Light-Duty Vehicle|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle 2;Stocks|Transportation|Light-Duty Vehicle|Compact Car;1
+Stocks|Transportation|Light-Duty Vehicle 2;Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV;1
+Stocks|Transportation|Light-Duty Vehicle 2;Stocks|Transportation|Light-Duty Vehicle|Midsize Car;1
+Stocks|Transportation|Light-Duty Vehicle 2;Stocks|Transportation|Light-Duty Vehicle|Subcompact Car;1
+Stocks|Transportation|Light-Duty Vehicle 2;Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler;1
+;;
+Stocks|Transportation|Light-Duty Vehicle|Compact Car;Stocks|Transportation|Light-Duty Vehicle|Compact Car|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Compact Car;Stocks|Transportation|Light-Duty Vehicle|Compact Car|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Compact Car;Stocks|Transportation|Light-Duty Vehicle|Compact Car|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle|Compact Car;Stocks|Transportation|Light-Duty Vehicle|Compact Car|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV;Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV;Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV;Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV;Stocks|Transportation|Light-Duty Vehicle|Large Car and SUV|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle|Midsize Car;Stocks|Transportation|Light-Duty Vehicle|Midsize Car|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Midsize Car;Stocks|Transportation|Light-Duty Vehicle|Midsize Car|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Midsize Car;Stocks|Transportation|Light-Duty Vehicle|Midsize Car|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle|Midsize Car;Stocks|Transportation|Light-Duty Vehicle|Midsize Car|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle|Subcompact Car;Stocks|Transportation|Light-Duty Vehicle|Subcompact Car|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Subcompact Car;Stocks|Transportation|Light-Duty Vehicle|Subcompact Car|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Subcompact Car;Stocks|Transportation|Light-Duty Vehicle|Subcompact Car|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle|Subcompact Car;Stocks|Transportation|Light-Duty Vehicle|Subcompact Car|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler;Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler|Battery-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler;Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler|Fuel-Cell-Electric;1
+Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler;Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler|Internal Combustion;1
+Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler;Stocks|Transportation|Light-Duty Vehicle|Two-Wheeler|Plug-in Hybrid;1
+;;
+Stocks|Transportation|Truck;Stocks|Transportation|Truck|Battery-Electric;1
+Stocks|Transportation|Truck;Stocks|Transportation|Truck|Fuel-Cell-Electric;1
+Stocks|Transportation|Truck;Stocks|Transportation|Truck|Internal Combustion;1
+Stocks|Transportation|Truck;Stocks|Transportation|Truck|Plug-in Hybrid;1
+;;
+Trade|Agriculture;Trade|Agriculture|Crops;1
+Trade|Agriculture;Trade|Agriculture|Livestock;1
+Trade|Agriculture;Trade|Agriculture|Residues;1
+;;
+Trade|Agriculture|Crops;Trade|Agriculture|Crops|Cereals;1
+Trade|Agriculture|Crops;Trade|Agriculture|Crops|Energy Crops;1
+Trade|Agriculture|Crops;Trade|Agriculture|Crops|Oil Crops;1
+Trade|Agriculture|Crops;Trade|Agriculture|Crops|Other Crops;1
+Trade|Agriculture|Crops;Trade|Agriculture|Crops|Sugar Crops;1
+;;
+Trade|Agriculture|Livestock;Trade|Agriculture|Livestock|Non-Ruminant;1
+Trade|Agriculture|Livestock;Trade|Agriculture|Livestock|Ruminant;1
+;;
+Trade|Agriculture|Livestock|Non-Ruminant;Trade|Agriculture|Livestock|Non-Ruminant|Eggs;1
+Trade|Agriculture|Livestock|Non-Ruminant;Trade|Agriculture|Livestock|Non-Ruminant|Meat;1
+;;
+Trade|Agriculture|Livestock|Non-Ruminant|Meat;Trade|Agriculture|Livestock|Non-Ruminant|Meat|Pig;1
+Trade|Agriculture|Livestock|Non-Ruminant|Meat;Trade|Agriculture|Livestock|Non-Ruminant|Meat|Poultry;1
+;;
+Trade|Agriculture|Livestock|Ruminant;Trade|Agriculture|Livestock|Ruminant|Dairy;1
+Trade|Agriculture|Livestock|Ruminant;Trade|Agriculture|Livestock|Ruminant|Meat;1
+;;
+Trade|Forestry|Roundwood;Trade|Forestry|Roundwood|Industrial Roundwood;1
+Trade|Forestry|Roundwood;Trade|Forestry|Roundwood|Wood Fuel;1
+;;
+Water Consumption;Water Consumption|Electricity;1
+Water Consumption;Water Consumption|Industrial Water;1
+Water Consumption;Water Consumption|Irrigation;1
+Water Consumption;Water Consumption|Livestock;1
+Water Consumption;Water Consumption|Municipal Water;1
+;;
+Water Consumption|Electricity;Water Consumption|Electricity|Ammonia;1
+Water Consumption|Electricity;Water Consumption|Electricity|Biomass;1
+Water Consumption|Electricity;Water Consumption|Electricity|Coal;1
+Water Consumption|Electricity;Water Consumption|Electricity|Gas;1
+Water Consumption|Electricity;Water Consumption|Electricity|Geothermal;1
+Water Consumption|Electricity;Water Consumption|Electricity|Hydro;1
+Water Consumption|Electricity;Water Consumption|Electricity|Hydrogen;1
+Water Consumption|Electricity;Water Consumption|Electricity|Nuclear;1
+Water Consumption|Electricity;Water Consumption|Electricity|Ocean;1
+Water Consumption|Electricity;Water Consumption|Electricity|Oil;1
+Water Consumption|Electricity;Water Consumption|Electricity|Other;1
+Water Consumption|Electricity;Water Consumption|Electricity|Solar;1
+Water Consumption|Electricity;Water Consumption|Electricity|Wind;1
+;;
+Water Consumption|Electricity|Fossil;Water Consumption|Electricity|Coal;1
+Water Consumption|Electricity|Fossil;Water Consumption|Electricity|Gas;1
+Water Consumption|Electricity|Fossil;Water Consumption|Electricity|Oil;1
+;;
+Water Consumption|Electricity|Biomass;Water Consumption|Electricity|Biomass|w/ CCS;1
+Water Consumption|Electricity|Biomass;Water Consumption|Electricity|Biomass|w/o CCS;1
+;;
+Water Consumption|Electricity|Coal;Water Consumption|Electricity|Coal|w/ CCS;1
+Water Consumption|Electricity|Coal;Water Consumption|Electricity|Coal|w/o CCS;1
+;;
+Water Consumption|Electricity|Fossil;Water Consumption|Electricity|Fossil|w/ CCS;1
+Water Consumption|Electricity|Fossil;Water Consumption|Electricity|Fossil|w/o CCS;1
+;;
+Water Consumption|Electricity|Gas;Water Consumption|Electricity|Gas|w/ CCS;1
+Water Consumption|Electricity|Gas;Water Consumption|Electricity|Gas|w/o CCS;1
+;;
+Water Consumption|Electricity|Oil;Water Consumption|Electricity|Oil|w/ CCS;1
+Water Consumption|Electricity|Oil;Water Consumption|Electricity|Oil|w/o CCS;1
+;;
+Water Consumption|Electricity|Solar;Water Consumption|Electricity|Solar|CSP;1
+Water Consumption|Electricity|Solar;Water Consumption|Electricity|Solar|PV;1
+;;
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Agri-PV;1
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Commercial;1
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Floating;1
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Open Land;1
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Other;1
+Water Consumption|Electricity|Solar|PV;Water Consumption|Electricity|Solar|PV|Residential;1
+;;
+Water Consumption|Electricity|Wind;Water Consumption|Electricity|Wind|Offshore;1
+Water Consumption|Electricity|Wind;Water Consumption|Electricity|Wind|Onshore;1
+;;
+Water Ecosystems;Water Ecosystems|Lakes;1
+Water Ecosystems;Water Ecosystems|Rivers;1
+Water Ecosystems;Water Ecosystems|Wetlands;1
+;;
+Water Ecosystems|Wetlands|Peatlands;Water Ecosystems|Wetlands|Peatlands|Drained;1
+Water Ecosystems|Wetlands|Peatlands;Water Ecosystems|Wetlands|Peatlands|Intact;1
+Water Ecosystems|Wetlands|Peatlands;Water Ecosystems|Wetlands|Peatlands|Rewetted;1
+;;
+Water Withdrawal;Water Withdrawal|Electricity;1
+Water Withdrawal;Water Withdrawal|Industrial Water;1
+Water Withdrawal;Water Withdrawal|Irrigation;1
+Water Withdrawal;Water Withdrawal|Livestock;1
+Water Withdrawal;Water Withdrawal|Municipal Water;1
+;;
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Ammonia;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Biomass;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Coal;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Gas;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Geothermal;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Hydro;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Hydrogen;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Nuclear;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Ocean;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Oil;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Other;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Solar;1
+Water Withdrawal|Electricity;Water Withdrawal|Electricity|Wind;1
+;;
+Water Withdrawal|Electricity|Biomass;Water Withdrawal|Electricity|Biomass|w/ CCS;1
+Water Withdrawal|Electricity|Biomass;Water Withdrawal|Electricity|Biomass|w/o CCS;1
+;;
+Water Withdrawal|Electricity|Coal;Water Withdrawal|Electricity|Coal|w/ CCS;1
+Water Withdrawal|Electricity|Coal;Water Withdrawal|Electricity|Coal|w/o CCS;1
+;;
+Water Withdrawal|Electricity|Fossil;Water Withdrawal|Electricity|Fossil|w/ CCS;1
+Water Withdrawal|Electricity|Fossil;Water Withdrawal|Electricity|Fossil|w/o CCS;1
+;;
+Water Withdrawal|Electricity|Gas;Water Withdrawal|Electricity|Gas|w/ CCS;1
+Water Withdrawal|Electricity|Gas;Water Withdrawal|Electricity|Gas|w/o CCS;1
+;;
+Water Withdrawal|Electricity|Oil;Water Withdrawal|Electricity|Oil|w/ CCS;1
+Water Withdrawal|Electricity|Oil;Water Withdrawal|Electricity|Oil|w/o CCS;1
+;;
+Water Withdrawal|Electricity|Solar;Water Withdrawal|Electricity|Solar|CSP;1
+Water Withdrawal|Electricity|Solar;Water Withdrawal|Electricity|Solar|PV;1
+;;
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Agri-PV;1
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Commercial;1
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Floating;1
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Open Land;1
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Other;1
+Water Withdrawal|Electricity|Solar|PV;Water Withdrawal|Electricity|Solar|PV|Residential;1
+;;
+Water Withdrawal|Electricity|Wind;Water Withdrawal|Electricity|Wind|Offshore;1
+Water Withdrawal|Electricity|Wind;Water Withdrawal|Electricity|Wind|Onshore;1


### PR DESCRIPTION
## Purpose of this PR

Add extensive summation checks for ScenarioMIP based on (a) automatic generation of all variables and their subcategories and (b) manual revision and correction.

Comments:

- FYI @merfort: Previous summation checks are a subset of new summation checks, i.e. all summation checks for emissions are kept. For non-CO2, the existing summation checks are listed at the beginning (with a 2 to separate from additional summation checks below). For CO2, the existing summation checks are integrated into the long list of summation checks further below (because these were already broken into subcategories before).
- FYI @orichters: There was still a long list of almost 100 failed summation checks when testing on a recent mif file, even though I had removed at least 100 errors (e.g. Fossil and Coal appearing in same summation). I guess it will take some time to reduce this further.
- FYI @merfort and @amerfort : Probably a relevant number of failed summation checks has to do with the fact that you have kindly engineered the ScenarioMIP mapping for the last resubmission (which was using REMIND-MAgPIE mifs from Dec 2024), and they will disappear once the ScenarioMIP mapping is adapted for current REMIND-MAgPIE runs. 


## Checklist:
- [ ] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
