### PR TITLE
adapt ECEMF to remind2 PR#709 adjusting bunker reporting

### DIFF
--- a/inst/mappings/mapping_ECEMF.csv
+++ b/inst/mappings/mapping_ECEMF.csv
@@ -63,20 +63,16 @@ Emissions|CH4|Energy|Supply;Mt CH4/yr;Emi|CH4|+|Extraction;Mt CH4/yr;1;;;;R
 Emissions|CH4|Industrial Processes;Mt CH4/yr;;;;;;;
 Emissions|CH4|Other;Mt CH4/yr;;;;;;;
 Emissions|CH4|Waste;Mt CH4/yr;Emi|CH4|+|Waste;Mt CH4/yr;1;;;;R
-Emissions|CO2;Mt CO2/yr;Emi|CO2|LULUCF national accounting;Mt CO2/yr;1;;;;R
-Emissions|CO2;Mt CO2/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
+Emissions|CO2;Mt CO2/yr;Emi|CO2|w/ Bunkers|LULUCF national accounting;Mt CO2/yr;1;;;;R
 Emissions|CO2|AFOLU;Mt CO2/yr;Emi|CO2|Land-Use Change|LULUCF national accounting;Mt CO2/yr;1;;;;R
 Emissions|CO2|AFOLU|Agriculture;Mt CO2/yr;;;;;;;
 Emissions|CO2|AFOLU|Land;Mt CO2/yr;Emi|CO2|Land-Use Change|LULUCF national accounting;Mt CO2/yr;1;;;;R
 Emissions|CO2|AFOLU|Land|Negative;Mt CO2/yr;;;;;;;
 Emissions|CO2|AFOLU|Land|Positive;Mt CO2/yr;;;;;;;
 Emissions|CO2|AFOLU|Land|Wetlands;Mt CO2/yr;;;;;;;
-Emissions|CO2|Energy;Mt CO2/yr;Emi|CO2|+|Energy;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy;Mt CO2/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy and Industrial Processes;Mt CO2/yr;Emi|CO2|Energy and Industrial Processes;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy and Industrial Processes;Mt CO2/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|+|Demand;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
+Emissions|CO2|Energy;Mt CO2/yr;Emi|CO2|w/ Bunkers|Energy;Mt CO2/yr;1;;;;R
+Emissions|CO2|Energy and Industrial Processes;Mt CO2/yr;Emi|CO2|w/ Bunkers|Energy and Industrial Processes;Mt CO2/yr;1;;;;R
+Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|w/ Bunkers|Energy|Demand;Mt CO2/yr;1;;;;R
 Emissions|CO2|Energy|Demand|AFOFI;Mt CO2/yr;;;;;;;
 Emissions|CO2|Energy|Demand|Bunkers;Mt CO2/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
 Emissions|CO2|Energy|Demand|Bunkers|International Aviation;Mt CO2/yr;;;;;;;
@@ -86,7 +82,7 @@ Emissions|CO2|Energy|Demand|Industry;Mt CO2/yr;Emi|CO2|Energy|Demand|+|Industry;
 Emissions|CO2|Energy|Demand|Other Sector;Mt CO2/yr;Emi|CO2|Energy|Demand|+|CDR Sector;Mt CO2/yr;1;;;;R
 Emissions|CO2|Energy|Demand|Residential;Mt CO2/yr;;;;;;;
 Emissions|CO2|Energy|Demand|Residential and Commercial;Mt CO2/yr;Emi|CO2|Energy|Demand|+|Buildings;Mt CO2/yr;1;;;;R
-Emissions|CO2|Energy|Demand|Transportation;Mt CO2/yr;Emi|CO2|Energy|Demand|+|Transport;Mt CO2/yr;1;;;;R
+Emissions|CO2|Energy|Demand|Transportation;Mt CO2/yr;Emi|CO2|w/o Bunkers|Energy|Demand|Transport;Mt CO2/yr;1;;;;R
 Emissions|CO2|Energy|Demand|Transportation|Bus;Mt CO2/yr;;;;;;;
 Emissions|CO2|Energy|Demand|Transportation|Domestic Aviation;Mt CO2/yr;;;;;;;
 Emissions|CO2|Energy|Demand|Transportation|Domestic Shipping;Mt CO2/yr;;;;;;;
@@ -110,23 +106,20 @@ Emissions|CO2|Waste;Mt CO2/yr;Emi|CO2|+|Waste;Mt CO2/yr;1;;;;R
 Emissions|CO2|Waste|Biomass;Mt CO2/yr;;;;;;;
 Emissions|CO2|Waste|Fossil;Mt CO2/yr;;;;;;;
 Emissions|F-Gases;Mt CO2e/yr;Emi|GHG|+|F-Gases;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases;Mt CO2e/yr;Emi|GHG|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases;Mt CO2e/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
+Emissions|Kyoto Gases;Mt CO2e/yr;Emi|GHG|w/ Bunkers|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|AFOLU;Mt CO2e/yr;Emi|GHG|+++|Agriculture;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|AFOLU;Mt CO2e/yr;Emi|GHG|Land-Use Change|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|AFOLU|Agriculture;Mt CO2e/yr;Emi|GHG|+++|Agriculture;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|AFOLU|Land;Mt CO2e/yr;Emi|GHG|Land-Use Change|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|Energy;Mt CO2e/yr;Emi|GHG|+++|Energy;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|Energy;Mt CO2e/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
+Emissions|Kyoto Gases|Energy;Mt CO2e/yr;Emi|GHG|w/ Bunkers|Energy;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|Industrial Processes;Mt CO2e/yr;Emi|GHG|+++|Industrial Processes;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|Energy and Industrial Processes;Mt CO2e/yr;Emi|GHG|+++|Energy;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|Energy and Industrial Processes;Mt CO2e/yr;Emi|CO2|Energy|Demand|Transport|International Bunkers;Mt CO2/yr;1;;;;R
+Emissions|Kyoto Gases|Energy and Industrial Processes;Mt CO2e/yr;Emi|GHG|w/ Bunkers|Energy;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|Energy and Industrial Processes;Mt CO2e/yr;Emi|GHG|+++|Industrial Processes;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|Industry and Industrial Processes;Mt CO2e/yr;;;;;;;
 Emissions|Kyoto Gases|Other;Mt CO2e/yr;Emi|GHG|+++|non-ES CDR;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|Waste;Mt CO2e/yr;Emi|GHG|+++|Waste;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|non-CO2;Mt CO2e/yr;Emi|GHG|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
-Emissions|Kyoto Gases|non-CO2;Mt CO2e/yr;Emi|CO2|LULUCF national accounting;Mt CO2/yr;-1;;;;R
+Emissions|Kyoto Gases|non-CO2;Mt CO2e/yr;Emi|GHG|w/o Bunkers|LULUCF national accounting;Mt CO2eq/yr;1;;;;R
+Emissions|Kyoto Gases|non-CO2;Mt CO2e/yr;Emi|CO2|w/o Bunkers|LULUCF national accounting;Mt CO2/yr;-1;;;;R
 Emissions|Kyoto Gases|CH4;Mt CO2e/yr;Emi|GHG|+|CH4;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|N2O;Mt CO2e/yr;Emi|GHG|+|N2O;Mt CO2eq/yr;1;;;;R
 Emissions|Kyoto Gases|F-Gases;Mt CO2e/yr;Emi|GHG|+|F-Gases;Mt CO2eq/yr;1;;;;R
@@ -501,7 +494,7 @@ Final Energy|Transportation|Truck|Liquids|Electricity;EJ/yr;;;;;;;
 Final Energy|Transportation|Truck|Liquids|Fossil;EJ/yr;;;;;;;
 GDP|MER;billion EUR_2020/yr;GDP|MER;billion US$2017/yr;0.9502;;;;R
 GDP|PPP;billion EUR_2020/yr;GDP|PPP;billion US$2017/yr;0.9502;;;;R
-Gross Emissions|CO2;Mt CO2/yr;Emi|CO2|Gross;Mt CO2/yr;1;;;;R
+Gross Emissions|CO2;Mt CO2/yr;Emi|CO2|w/ Bunkers|Gross;Mt CO2/yr;1;;;;R
 Gross Emissions|CO2|Energy;Mt CO2/yr;Emi|CO2|w/ Bunkers|Gross|Energy;Mt CO2/yr;1;;;;R
 Gross Emissions|CO2|Energy and Industrial Processes;Mt CO2/yr;Emi|CO2|w/ Bunkers|Gross|Energy and Industrial Processes;Mt CO2/yr;1;;;;R
 Gross Emissions|CO2|Energy|Demand;Mt CO2/yr;Emi|CO2|w/ Bunkers|Gross|Energy|Demand;Mt CO2/yr;1;;;;R


### PR DESCRIPTION
## Purpose of this PR

- adjust ECEMF mapping because of https://github.com/pik-piam/remind2/pull/709
- the current version of your mapping had the problem of double-counting bunker emissions on the global level
- please carefully check whether that is intended as is and ideally always use the `w/ Bunkers`, `w/o Bunkers` or `w/ Intra-region Bunkers` version of `Emi|GHG*` and `Emi|CO2*` variables