### PR TITLE
summation of electrictiy did not count Oil+CCS

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9725796'
+ValidationKey: '9747423'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.48.2
-date-released: '2025-03-31'
+version: 0.48.3
+date-released: '2025-04-03'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.48.2
-Date: 2025-03-31
+Version: 0.48.3
+Date: 2025-04-03
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.48.2**
+R package **piamInterfaces**, version **0.48.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.2, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.3, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -200,9 +200,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-03-31},
+  date = {2025-04-03},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.48.2},
+  note = {Version: 0.48.3},
 }
 ```

--- a/inst/summations/summation_groups_AR6.csv
+++ b/inst/summations/summation_groups_AR6.csv
@@ -47,7 +47,7 @@ Carbon Sequestration|Feedstocks;Carbon Sequestration|Feedstocks|Fossil;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Afforestation;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Biochar;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Other;1
-Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|S Carbon Management;1
+Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Soil Carbon Management;1
 Agricultural Production|Energy;Agricultural Production|Energy|Crops;1
 Agricultural Production|Energy;Agricultural Production|Energy|Residues;1
 Agricultural Production|Non-Energy;Agricultural Production|Non-Energy|Crops;1
@@ -696,7 +696,7 @@ Capacity|Electricity;Capacity|Electricity|Geothermal;1
 Capacity|Electricity;Capacity|Electricity|Hydro;1
 Capacity|Electricity;Capacity|Electricity|Nuclear;1
 Capacity|Electricity;Capacity|Electricity|Ocean;1
-Capacity|Electricity;Capacity|Electricity|;1
+Capacity|Electricity;Capacity|Electricity|Oil;1
 Capacity|Electricity;Capacity|Electricity|Other;1
 Capacity|Electricity;Capacity|Electricity|Solar;1
 Capacity|Electricity;Capacity|Electricity|Wind;1

--- a/inst/summations/summation_groups_AR6.csv
+++ b/inst/summations/summation_groups_AR6.csv
@@ -47,7 +47,7 @@ Carbon Sequestration|Feedstocks;Carbon Sequestration|Feedstocks|Fossil;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Afforestation;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Biochar;1
 Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Other;1
-Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|Soil Carbon Management;1
+Carbon Sequestration|Land Use;Carbon Sequestration|Land Use|S Carbon Management;1
 Agricultural Production|Energy;Agricultural Production|Energy|Crops;1
 Agricultural Production|Energy;Agricultural Production|Energy|Residues;1
 Agricultural Production|Non-Energy;Agricultural Production|Non-Energy|Crops;1
@@ -696,7 +696,7 @@ Capacity|Electricity;Capacity|Electricity|Geothermal;1
 Capacity|Electricity;Capacity|Electricity|Hydro;1
 Capacity|Electricity;Capacity|Electricity|Nuclear;1
 Capacity|Electricity;Capacity|Electricity|Ocean;1
-Capacity|Electricity;Capacity|Electricity|Oil|w/o CCS;1
+Capacity|Electricity;Capacity|Electricity|;1
 Capacity|Electricity;Capacity|Electricity|Other;1
 Capacity|Electricity;Capacity|Electricity|Solar;1
 Capacity|Electricity;Capacity|Electricity|Wind;1

--- a/tests/testthat/test-checkSummations.R
+++ b/tests/testthat/test-checkSummations.R
@@ -19,7 +19,6 @@ test_that("checkSummations works", {
 
 
   for (summationFile in names(summationsNames())) {
-
     # The current test expects a summation including 'Final Energy|Industry' in the summation
     # file to work. Skip summation file if this requirement is not met.
     sf <- getSummations(summationFile)
@@ -51,7 +50,6 @@ test_that("checkSummations works", {
       }
     })
     test_that(paste("test summationFile with errors using", summationFile), {
-
       # The current test expects a summation including Final Energy|Industry in the summation
       # file to work. Skip it if this requirement is not met for a summation file.
       sf <- getSummations(summationFile)
@@ -92,36 +90,6 @@ test_that("checkSummations works", {
 
   unlink(file.path(tempdir(), c("test.mif", "testerror.mif", "log.txt", "checkSummations.csv")))
 
-  # test usage of same variables multiple times as a child in summation groups ----
-  # Capacity|Electricity|Oil = Capacity|Electricity|Oil|w/o CCS + Capacity|Electricity|Oil|w/ CCS
-  # Capacity|Electricity" = ... + Capacity|Electricity|Nuclear, Capacity|Electricity|Oil|w/o CCS
-  varnames <- paste(c("Capacity|Electricity|Oil", "Capacity|Electricity|Oil|w/o CCS", "Capacity|Electricity|Oil|w/ CCS",
-                      "Capacity|Electricity", "Capacity|Electricity|Nuclear"),
-                    "(EJ/yr)")
-
-  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 5, 7, 2),
-                               names = varnames)
-
-  magclass::getSets(data)[3] <- "variable"
-  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
-    filter(diff != 0)
-  expect_true(nrow(sumChecks) == 0)
-
-  # test usage of different summations for same variable ----
-  # Final Energy = .. + Final Energy|Electricity + Final Energy|Gases
-  # Final Energy 2 = .. + Final Energy|Industry + Final Energy|Transportation
-
-  varnames <- paste(c("Final Energy", "Final Energy|Industry", "Final Energy|Transportation",
-                      "Final Energy|Electricity", "Final Energy|Gases"),
-                    "(EJ/yr)")
-
-  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 6, 7, 3),
-                               names = varnames)
-  magclass::getSets(data)[3] <- "variable"
-  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
-    filter(diff != 0)
-  expect_true(nrow(sumChecks) == 1)
-  expect_true(unique(sumChecks$variable) == "Final Energy 2")
 
   # test extractVariableGroups option, testing a magclass object  ----
   varnames <- paste(c("FE|Industry|Steel", "FE|Industry|Steel|+|Primary", "FE|Industry|Steel|+|Secondary"),
@@ -143,4 +111,46 @@ test_that("checkSummations works", {
 
   expect_warning(checkSummations(filter(qeAR6, 0 > 1), outputDirectory = NULL, summationsFile = "AR6"),
                  "No variable found that matches summationsFile")
+})
+
+test_that("usage of same variables multiple times as a child in summation groups works", {
+  # Emissions|CO2|Energy and Industrial Processes = Emissions|CO2|Industrial Processes + Emissions|CO2|Energy
+  # Emissions|CO2" = ... + Emissions|CO2|Industrial Processes + Emissions|CO2|Energy + Emissions|CO2|Waste
+
+  varnames <- paste(
+    c(
+      "Emissions|CO2|Energy and Industrial Processes", "Emissions|CO2|Industrial Processes",
+      "Emissions|CO2|Energy", "Emissions|CO2|Waste", "Emissions|CO2"
+    ),
+    "(EJ/yr)"
+  )
+
+  data <- magclass::new.magpie(
+    cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 5, 1, 11),
+    names = varnames
+  )
+
+  magclass::getSets(data)[3] <- "variable"
+  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
+    filter(diff != 0)
+  expect_true(nrow(sumChecks) == 0)
+
+})
+
+
+test_that("usage of different summations for same variable works", {
+  # Final Energy = .. + Final Energy|Electricity + Final Energy|Gases
+  # Final Energy 2 = .. + Final Energy|Industry + Final Energy|Transportation
+
+  varnames <- paste(c("Final Energy", "Final Energy|Industry", "Final Energy|Transportation",
+                      "Final Energy|Electricity", "Final Energy|Gases"),
+                    "(EJ/yr)")
+
+  data <- magclass::new.magpie(cells_and_regions = "GLO", years = c(2030), fill = c(10, 5, 6, 7, 3),
+                               names = varnames)
+  magclass::getSets(data)[3] <- "variable"
+  sumChecks <- checkSummations(mifFile = data, outputDirectory = NULL, summationsFile = "AR6") %>%
+    filter(diff != 0)
+  expect_true(nrow(sumChecks) == 1)
+  expect_true(unique(sumChecks$variable) == "Final Energy 2")
 })


### PR DESCRIPTION
## Purpose of this PR

There was a typo in summation checks for electricity capacity (counting Oil only with CCS).

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)


It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
