### PR TITLE
Fix FE CDR summation checks

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9851744'
+ValidationKey: '9872421'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.48.8
-date-released: '2025-04-10'
+version: 0.48.9
+date-released: '2025-04-11'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.48.8
-Date: 2025-04-10
+Version: 0.48.9
+Date: 2025-04-11
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.48.8**
+R package **piamInterfaces**, version **0.48.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.8, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.9, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -200,9 +200,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-04-10},
+  date = {2025-04-11},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.48.8},
+  note = {Version: 0.48.9},
 }
 ```

--- a/inst/mappings/mapping_ScenarioMIP.csv
+++ b/inst/mappings/mapping_ScenarioMIP.csv
@@ -3004,7 +3004,7 @@ Final Energy|Carbon Management|Hydrogen|Nuclear;EJ/yr;3;Use of hydrogen from nuc
 Final Energy|Carbon Management|Hydrogen|Oil;EJ/yr;3;Use of hydrogen from refined crude oil for carbon management;;;;;;;;
 Final Energy|Carbon Management|Hydrogen|Other;EJ/yr;3;Use of hydrogen from other sources for carbon management;;;;;;;;
 Final Energy|Carbon Management|Hydrogen|Solar;EJ/yr;3;Use of hydrogen from solar energy (e.g. thermochemical water splitting with solar heat) for carbon management;;;;;;;;
-Final Energy|Carbon Management|Liquids;EJ/yr;2;Use of refined liquid fuels including oil products, fuels from gas and coal, synthetic fuels and biofuels for carbon management;;;FE|CDR|EW|+|Diesel;EJ/yr;;additional mapping taken from additional_NAVIGATE, additional_NAVIGATE category: energy (final);R;
+Final Energy|Carbon Management|Liquids;EJ/yr;2;Use of refined liquid fuels including oil products, fuels from gas and coal, synthetic fuels and biofuels for carbon management;;;FE|CDR|+|Liquids;EJ/yr;;additional mapping taken from additional_NAVIGATE, additional_NAVIGATE category: energy (final);R;
 Final Energy|Carbon Management|Liquids|Biomass;EJ/yr;3;Use of liquid fuels from biomass for carbon management;;;;;;;;
 Final Energy|Carbon Management|Liquids|Coal;EJ/yr;3;Use of liquid fuels from coal for carbon management;;;;;;;;
 Final Energy|Carbon Management|Liquids|Electricity;EJ/yr;3;Use of liquid synthetic fuels from electricity, i.e., e-fuels (if hydrogen is not explicitly modeled as an intermediate product) for carbon management;;;;;;;;

--- a/inst/summations/summation_groups_ScenarioMIP.csv
+++ b/inst/summations/summation_groups_ScenarioMIP.csv
@@ -2859,12 +2859,12 @@ Final Energy|Carbon Management;Final Energy|Carbon Management|Carbon Capture and
 Final Energy|Carbon Management;Final Energy|Carbon Management|Direct Air Capture;1
 Final Energy|Carbon Management;Final Energy|Carbon Management|Direct Ocean Capture;1
 Final Energy|Carbon Management;Final Energy|Carbon Management|Enhanced Weathering;1
-Final Energy|Carbon Management;Final Energy|Carbon Management|Hydrogen;1
 Final Energy|Carbon Management;Final Energy|Carbon Management|Ocean Alkalinity Enhancement;1
 ;;
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Electricity;1
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Gases;1
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Heat;1
+Final Energy|Carbon Management 2;Final Energy|Carbon Management|Hydrogen;1
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Liquids;1
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Other;1
 Final Energy|Carbon Management 2;Final Energy|Carbon Management|Solids;1


### PR DESCRIPTION
## Purpose of this PR
Fixes summation checks for `Final Energy|Carbon Management`.


## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
- [x] For REMIND variables, I used `|+|` notation consistently. This can be achieved automatically with [`updatePlusUnit()`](https://github.com/pik-piam/piamInterfaces/blob/master/R/updatePlusUnit.R).

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
