### PR TITLE
only apply interpolation after summation checks 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9872421'
+ValidationKey: '97109090'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.48.9
+version: 0.48.10
 date-released: '2025-04-11'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.48.9
+Version: 0.48.10
 Date: 2025-04-11
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -190,10 +190,6 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
     na.action = naAction
   )
 
-  if (any(mapData$interpolation == "linear", na.rm = TRUE)) {
-    submission <- .interpolate(submission, mapData, timesteps)
-  }
-
   # apply corrections using IIASA template ----
 
   if (!is.null(iiasatemplate) && (file.exists(iiasatemplate) ||
@@ -218,6 +214,12 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
                                 dataDumpFile = paste0(prefix, "_checkSummations.csv"),
                                 plotprefix = paste0(prefix, "_")))
     }
+  }
+
+  # apply interpolation ----
+
+  if (any(mapData$interpolation == "linear", na.rm = TRUE)) {
+    submission <- .interpolate(submission, mapData, timesteps)
   }
 
   # write or return data ----

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.48.9**
+R package **piamInterfaces**, version **0.48.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.9, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.48.10, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -203,6 +203,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-04-11},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.48.9},
+  note = {Version: 0.48.10},
 }
 ```


### PR DESCRIPTION
… when generating submission

## Purpose of this PR

Do not apply summation check on data with interpolated variables. This causes errors for summations where some variables are interpolated and others not for the interpolated years. 

The interpolation is only done after the summation checks. 

This implies that:
1. The summation checks are not supposed to check that interpolation worked as expected.
2. Interpolation is not expected to make sure summations for interpolated years work out. 


## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
- [x] For REMIND variables, I used `|+|` notation consistently. This can be achieved automatically with [`updatePlusUnit()`](https://github.com/pik-piam/piamInterfaces/blob/master/R/updatePlusUnit.R).

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
