### PR TITLE
Delete incomplete summation check for ScenarioMIP

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '10674912'
+ValidationKey: '10695696'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.52.7
-date-released: '2025-06-17'
+version: 0.52.8
+date-released: '2025-06-18'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.52.7
-Date: 2025-06-17
+Version: 0.52.8
+Date: 2025-06-18
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.52.7**
+R package **piamInterfaces**, version **0.52.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.52.7, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.52.8, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -200,9 +200,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2025-06-17},
+  date = {2025-06-18},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.52.7},
+  note = {Version: 0.52.8},
 }
 ```

--- a/inst/summations/summation_groups_ScenarioMIP.csv
+++ b/inst/summations/summation_groups_ScenarioMIP.csv
@@ -5272,9 +5272,6 @@ Forestry Demand|Roundwood|Industrial Roundwood;Forestry Demand|Roundwood|Industr
 Forestry Production|Roundwood;Forestry Production|Roundwood|Industrial Roundwood;1
 Forestry Production|Roundwood;Forestry Production|Roundwood|Wood Fuel;1
 ;;
-Gross Emissions|CO2;Gross Emissions|CO2|AFOLU;1
-Gross Emissions|CO2;Gross Emissions|CO2|Energy and Industrial Processes;1
-;;
 Gross Emissions|CO2|Energy and Industrial Processes;Gross Emissions|CO2|Energy;1
 Gross Emissions|CO2|Energy and Industrial Processes;Gross Emissions|CO2|Industrial Processes;1
 ;;


### PR DESCRIPTION
## Purpose of this PR

`Gross Emissions|CO2` does not equal the sum of `Gross Emissions|CO2|AFOLU` and `Gross Emissions|CO2|Energy and Industrial Processes`, as other components such as `Waste` are missing. As, `Gross Emissions|CO2|Waste` does not exist in common-definitions, I suggest to delete the check. In the long-run, it would be nice to have a more complete reporting of Gross Emissions and Gross Removals in common-definitions.

@merfort, @flohump  

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [ ] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
- [ ] For REMIND variables, I used `|+|` notation consistently. This can be achieved automatically with [`updatePlusUnit()`](https://github.com/pik-piam/piamInterfaces/blob/master/R/updatePlusUnit.R).

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
