### PR TITLE
rename optional mapping column weight to piam_weight

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '10736740'
+ValidationKey: '10756998'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.53.0
+version: 0.53.1
 date-released: '2025-06-19'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.53.0
+Version: 0.53.1
 Date: 2025-06-19
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/generateIIASASubmission.R
+++ b/R/generateIIASASubmission.R
@@ -116,10 +116,7 @@ generateIIASASubmission <- function(mifs = ".", # nolint: cyclocomp_linter
         "piam_variable" = removePlus(.data$piam_variable),
         "piam_factor" = ifelse(is.na(.data$piam_factor), 1, as.numeric(.data$piam_factor))
       ) %>%
-      dplyr::bind_rows(tibble("weight" = "NULL")) %>% # add the optional weight column if not present
-      mutate(
-        "piam_weight" = .data$weight
-      ) %>%
+      dplyr::bind_rows(tibble("piam_weight" = "NULL")) %>% # add the optional piam_weight column if not present
       # add interpolation column if not existing
       bind_rows(tibble(interpolation = NA)) %>%
       select("variable", "unit", "piam_variable", "piam_unit",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.53.0**
+R package **piamInterfaces**, version **0.53.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamInterfaces)](https://cran.r-project.org/package=piamInterfaces) [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -45,7 +45,7 @@ Additionally, some mappings use those columns:
 - `tier`: importance of variable, with 1 being most important
 - `comment`: place for internal comments
 - `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
-- `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
+- `piam_weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 ### Editing a mapping
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.53.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2025). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.53.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -203,6 +203,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-06-19},
   year = {2025},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.53.0},
+  note = {Version: 0.53.1},
 }
 ```

--- a/inst/mappings/mapping_AgMIP.csv
+++ b/inst/mappings/mapping_AgMIP.csv
@@ -1,4 +1,4 @@
-variable;unit;piam_variable;piam_unit;piam_factor;weight;comment;source
+variable;unit;piam_variable;piam_unit;piam_factor;piam_weight;comment;source
 CONS.AGR;1000 t dm;Demand|Bioenergy;Mt DM/yr;1000;NULL;;M
 OTHU.AGR;1000 t dm;Demand|Bioenergy;Mt DM/yr;1000;NULL;;M
 CONS.AGR;1000 t dm;Demand|Food;Mt DM/yr;1000;NULL;;M

--- a/tests/testthat/test-generateIIASASubmission.R
+++ b/tests/testthat/test-generateIIASASubmission.R
@@ -139,10 +139,10 @@ test_that("interpolation for ScenarioMIP works as expected", {
       piam_variable = piamVariables,
       piam_unit = rep("PiamUnit", 2),
       piam_factor = c("1", "1000"),
-      weight = piamWeights,
+      piam_weight = piamWeights,
       comment = rep("", 2)
     )
-    if (includeWeightColumn == FALSE) mapping <- mapping %>% select(- "weight")
+    if (includeWeightColumn == FALSE) mapping <- mapping %>% select(- "piam_weight")
     write.csv2(mapping, quote = FALSE, file = file.path(tempdir(), "test_mappings.csv"), row.names = FALSE)
     return(file.path(tempdir(), "test_mappings.csv"))
   }

--- a/tutorial.md
+++ b/tutorial.md
@@ -36,7 +36,7 @@ Additionally, some mappings use those columns:
 - `tier`: importance of variable, with 1 being most important
 - `comment`: place for internal comments
 - `interpolation`: sets the interpolation method for the `variable` (i.e. not `piam_variable`) (currently only supports `linear`). When set to `linear`, adds yearly values between 2005 and 2100 through linear interpolation for the selected output variables.
-- `weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
+- `piam_weight`: calculates a weighted average of multiple entries of `piam_variable`. Provide a different `piam_variable` in this column, and `generateIIASASubmission()` will split the data on the rows which contain weight pointers, resolve these weights into numerical values (via a join operation between the submission and the input data) and then modify the value based on the weighting. This takes place in the private .resolveWeights method.
 
 ### Editing a mapping
 


### PR DESCRIPTION
## Purpose of this PR

rename optional mapping column weight to piam_weight

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
- [x] For REMIND variables, I used `|+|` notation consistently. This can be achieved automatically with [`updatePlusUnit()`](https://github.com/pik-piam/piamInterfaces/blob/master/R/updatePlusUnit.R).

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
