### PR TITLE
Adding limes to ecemf mapping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '12784400'
+ValidationKey: '12834828'
 AutocreateReadme: yes
 allowLinterWarnings: no
 AddInReadme: tutorial.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamInterfaces: Project specific interfaces to REMIND / MAgPIE'
-version: 0.62.0
-date-released: '2026-06-16'
+version: 0.62.1
+date-released: '2026-08-03'
 abstract: Project specific interfaces to REMIND / MAgPIE.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamInterfaces
 Title: Project specific interfaces to REMIND / MAgPIE
-Version: 0.62.0
-Date: 2026-06-16
+Version: 0.62.1
+Date: 2026-08-03
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -100,12 +100,12 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
 
   firsterror <- TRUE
   for (sc in scaleConversion) {
-    fails <- template %>%
+    fails <- template |>
                # check whether substitution implies identical units
-               mutate(matches = .data$piam_unit == gsub(sc[[2]], sc[[3]], .data$unit, fixed = TRUE)) %>%
+               mutate(matches = .data$piam_unit == gsub(sc[[2]], sc[[3]], .data$unit, fixed = TRUE)) |>
                # check whether any substitution has actually taken place (excludes all other where piam_unit = unit)
-               mutate(matches = .data$matches & grepl(sc[[2]], .data$unit, fixed = TRUE)) %>%
-               mutate(matches = .data$matches & ! grepl(paste0("/", sc[[2]]), .data$unit, fixed = TRUE)) %>%
+               mutate(matches = .data$matches & grepl(sc[[2]], .data$unit, fixed = TRUE)) |>
+               mutate(matches = .data$matches & ! grepl(paste0("/", sc[[2]]), .data$unit, fixed = TRUE)) |>
                mutate(failed  = ! .data$piam_factor %in% c(sc[[1]], paste0("-", sc[[1]])))
     wrongScale <- filter(fails, .data$failed & .data$matches)
     if (nrow(wrongScale) > 0) {

--- a/R/checkUnitFactor.R
+++ b/R/checkUnitFactor.R
@@ -83,7 +83,11 @@ checkUnitFactor <- function(template, logFile = NULL, failOnUnitMismatch = TRUE)
                           c("1", "TgN/year", "Mt Nr/yr"),
                           c("0.8121", "USDMER05", "US$2017"),
                           c("0.0008121", "bn USD 2005 MER", "million US$2017 MER/yr"),
-                          c("1000", "1000 t dm", "Mt DM/yr")
+                          c("1000", "1000 t dm", "Mt DM/yr"),
+                          c("0.0036", "EJ/yr", "TWh/yr"),
+                          c("0.7092199", "EUR_2020/t CO2", "Eur2024/t CO2"),
+                          c("0.2315", "EUR_2020/GJ", "Eur2024/MWh"),
+                          c("0.001", "EJ/yr", "PJ/yr")
                          )
   if (! isTRUE(unique(lapply(scaleConversion, length)) == 3)) {
     warning("scaleConversion has some parts that have not 3 elements")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project specific interfaces to REMIND / MAgPIE
 
-R package **piamInterfaces**, version **0.62.0**
+R package **piamInterfaces**, version **0.62.1**
 
    [![R build status](https://github.com/pik-piam/piamInterfaces/workflows/check/badge.svg)](https://github.com/pik-piam/piamInterfaces/actions) [![codecov](https://codecov.io/gh/pik-piam/piamInterfaces/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamInterfaces) [![r-universe](https://pik-piam.r-universe.dev/badges/piamInterfaces)](https://pik-piam.r-universe.dev/builds)
 
@@ -174,13 +174,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r
+```r 
 install.packages("piamInterfaces")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r
+```r 
 update.packages()
 ```
 
@@ -192,7 +192,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamInterfaces** in publications use:
 
-Benke F, Richters O (2026). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.62.0, <https://github.com/pik-piam/piamInterfaces>.
+Benke F, Richters O (2026). "piamInterfaces: Project specific interfaces to REMIND / MAgPIE." Version: 0.62.1, <https://github.com/pik-piam/piamInterfaces>.
 
 A BibTeX entry for LaTeX users is
 
@@ -200,9 +200,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamInterfaces: Project specific interfaces to REMIND / MAgPIE},
   author = {Falk Benke and Oliver Richters},
-  date = {2026-06-16},
+  date = {2026-08-03},
   year = {2026},
   url = {https://github.com/pik-piam/piamInterfaces},
-  note = {Version: 0.62.0},
+  note = {Version: 0.62.1},
 }
 ```

--- a/inst/mappings/mapping_ECEMF_LIMES.csv
+++ b/inst/mappings/mapping_ECEMF_LIMES.csv
@@ -1,0 +1,76 @@
+variable;unit;piam_variable;piam_unit;piam_factor;description;comment;internal_comment;source
+Emissions|CO2|Energy|Supply|Electricity;Mt CO2/yr;Emissions|CO2|Energy|Supply|Electricity;Mt CO2/yr;1;;;;L
+Final Energy|Residential and Commercial|Heat;EJ/yr;Final Energy|Heat|District Heating;TWh/yr;0.0036;;;;L
+Primary Energy|Biomass|Electricity;EJ/yr;Primary Energy|Biomass|Electricity;PJ/yr;0.001;;;;L
+Primary Energy|Biomass|Electricity|w/ CCS;EJ/yr;Primary Energy|Biomass|Electricity|w/ CCS;PJ/yr;0.001;;;;L
+Primary Energy|Biomass|Electricity|w/o CCS;EJ/yr;Primary Energy|Biomass|Electricity|w/o CCS;PJ/yr;0.001;;;;L
+Primary Energy|Gas|Electricity;EJ/yr;Primary Energy|Gas|Electricity;PJ/yr;0.001;;;;L
+Primary Energy|Coal|Electricity;EJ/yr;Primary Energy|Coal|Electricity;PJ/yr;0.001;;;;L
+Primary Energy|Oil|Electricity;EJ/yr;Primary Energy|Oil|Electricity;PJ/yr;0.001;;;;L
+Secondary Energy|Electricity;EJ/yr;Secondary Energy|Electricity;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Biomass;EJ/yr;Secondary Energy|Electricity|Biomass;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Biomass|w/ CCS;EJ/yr;Secondary Energy|Electricity|Biomass|w/ CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Biomass|w/o CCS;EJ/yr;Secondary Energy|Electricity|Biomass|w/o CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Coal;EJ/yr;Secondary Energy|Electricity|Coal;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Coal|w/ CCS;EJ/yr;Secondary Energy|Electricity|Coal|w/ CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Coal|w/o CCS;EJ/yr;Secondary Energy|Electricity|Coal|w/o CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Gas;EJ/yr;Secondary Energy|Electricity|Gas;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Gas|w/ CCS;EJ/yr;Secondary Energy|Electricity|Gas|w/ CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Gas|w/o CCS;EJ/yr;Secondary Energy|Electricity|Gas|w/o CCS;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Hydro;EJ/yr;Secondary Energy|Electricity|Hydro;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Nuclear;EJ/yr;Secondary Energy|Electricity|Nuclear;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Oil;EJ/yr;Secondary Energy|Electricity|Oil;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Solar;EJ/yr;Secondary Energy|Electricity|Solar;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Solar|CSP;EJ/yr;Secondary Energy|Electricity|Solar|CSP;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Solar|PV;EJ/yr;Secondary Energy|Electricity|Solar|PV;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Wind;EJ/yr;Secondary Energy|Electricity|Wind;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Wind|Offshore;EJ/yr;Secondary Energy|Electricity|Wind|Offshore;TWh/yr;0.0036;;;;L
+Secondary Energy|Electricity|Wind|Onshore;EJ/yr;Secondary Energy|Electricity|Wind|Onshore;TWh/yr;0.0036;;;;L
+Secondary Energy|Hydrogen|Electricity;EJ/yr;Secondary Energy|Hydrogen|Electricity;TWh/yr;0.0036;;;;L
+Price|Secondary Energy|Electricity;EUR_2020/GJ;Price|Secondary Energy|Electricity;Eur2024/MWh;0.2315;;;;L
+Final Energy|Electricity;EJ/yr;Final Energy|Electricity;TWh/yr;0.0036;;;;L
+Price|Carbon;EUR_2020/t CO2;Price|Carbon|National Climate Target|Power Sector;Eur2024/t CO2;0.7092199;;;;L
+Capacity Additions|Electricity|Biomass;GW/yr;Capacity Additions|Electricity|Biomass;GW/yr;1;;;;L
+Capacity Additions|Electricity|Biomass|w/ CCS;GW/yr;Capacity Additions|Electricity|Biomass|w/ CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Biomass|w/o CCS;GW/yr;Capacity Additions|Electricity|Biomass|w/o CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Coal;GW/yr;Capacity Additions|Electricity|Coal;GW/yr;1;;;;L
+Capacity Additions|Electricity|Coal|w/ CCS;GW/yr;Capacity Additions|Electricity|Coal|w/ CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Coal|w/o CCS;GW/yr;Capacity Additions|Electricity|Coal|w/o CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Gas;GW/yr;Capacity Additions|Electricity|Gas;GW/yr;1;;;;L
+Capacity Additions|Electricity|Gas|w/ CCS;GW/yr;Capacity Additions|Electricity|Gas|w/ CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Gas|w/o CCS;GW/yr;Capacity Additions|Electricity|Gas|w/o CCS;GW/yr;1;;;;L
+Capacity Additions|Electricity|Hydro;GW/yr;Capacity Additions|Electricity|Hydro;GW/yr;1;;;;L
+Capacity Additions|Electricity|Hydrogen;GW/yr;Capacity Additions|Electricity|Hydrogen;GW/yr;1;;;;L
+Capacity Additions|Electricity|Nuclear;GW/yr;Capacity Additions|Electricity|Nuclear;GW/yr;1;;;;L
+Capacity Additions|Electricity|Oil;GW/yr;Capacity Additions|Electricity|Oil;GW/yr;1;;;;L
+Capacity Additions|Electricity|Other;GW/yr;Capacity Additions|Electricity|Other;GW/yr;1;;;;L
+Capacity Additions|Electricity|Solar;GW/yr;Capacity Additions|Electricity|Solar;GW/yr;1;;;;L
+Capacity Additions|Electricity|Solar|CSP;GW/yr;Capacity Additions|Electricity|Solar|CSP;GW/yr;1;;;;L
+Capacity Additions|Electricity|Solar|PV;GW/yr;Capacity Additions|Electricity|Solar|PV;GW/yr;1;;;;L
+Capacity Additions|Electricity|Storage;GW/yr;Capacity Additions|Electricity|Storage;GW/yr;1;;;;L
+Capacity Additions|Electricity|Other;GW/yr;Capacity Additions|Electricity|Waste;GW/yr;1;;;;L
+Capacity Additions|Electricity|Wind;GW/yr;Capacity Additions|Electricity|Wind;GW/yr;1;;;;L
+Capacity Additions|Electricity|Wind|Offshore;GW/yr;Capacity Additions|Electricity|Wind|Offshore;GW/yr;1;;;;L
+Capacity Additions|Electricity|Wind|Onshore;GW/yr;Capacity Additions|Electricity|Wind|Onshore;GW/yr;1;;;;L
+Capacity|Electricity;GW;Capacity|Electricity;GW;1;;;;L
+Capacity|Electricity|Biomass;GW;Capacity|Electricity|Biomass;GW;1;;;;L
+Capacity|Electricity|Biomass|w/ CCS;GW;Capacity|Electricity|Biomass|w/ CCS;GW;1;;;;L
+Capacity|Electricity|Biomass|w/o CCS;GW;Capacity|Electricity|Biomass|w/o CCS;GW;1;;;;L
+Capacity|Electricity|Coal;GW;Capacity|Electricity|Coal;GW;1;;;;L
+Capacity|Electricity|Coal|w/ CCS;GW;Capacity|Electricity|Coal|w/ CCS;GW;1;;;;L
+Capacity|Electricity|Coal|w/o CCS;GW;Capacity|Electricity|Coal|w/o CCS;GW;1;;;;L
+Capacity|Electricity|Gas;GW;Capacity|Electricity|Gas;GW;1;;;;L
+Capacity|Electricity|Gas|w/ CCS;GW;Capacity|Electricity|Gas|w/ CCS;GW;1;;;;L
+Capacity|Electricity|Gas|w/o CCS;GW;Capacity|Electricity|Gas|w/o CCS;GW;1;;;;L
+Capacity|Electricity|Hydro;GW;Capacity|Electricity|Hydro;GW;1;;;;L
+Capacity|Electricity|Hydrogen;GW;Capacity|Electricity|Hydrogen;GW;1;;;;L
+Capacity|Electricity|Nuclear;GW;Capacity|Electricity|Nuclear;GW;1;;;;L
+Capacity|Electricity|Oil;GW;Capacity|Electricity|Oil;GW;1;;;;L
+Capacity|Electricity|Other;GW;Capacity|Electricity|Other;GW;1;;;;L
+Capacity|Electricity|Solar;GW;Capacity|Electricity|Solar;GW;1;;;;L
+Capacity|Electricity|Solar|CSP;GW;Capacity|Electricity|Solar|CSP;GW;1;;;;L
+Capacity|Electricity|Solar|PV;GW;Capacity|Electricity|Solar|PV;GW;1;;;;L
+Capacity|Electricity|Other;GW;Capacity|Electricity|Waste;GW;1;;;;L
+Capacity|Electricity|Wind;GW;Capacity|Electricity|Wind;GW;1;;;;L
+Capacity|Electricity|Wind|Offshore;GW;Capacity|Electricity|Wind|Offshore;GW;1;;;;L
+Capacity|Electricity|Wind|Onshore;GW;Capacity|Electricity|Wind|Onshore;GW;1;;;;L

--- a/inst/sources.csv
+++ b/inst/sources.csv
@@ -5,3 +5,4 @@ M;MAgPIE
 R;REMIND
 S;SDP postprocessing
 T;EDGE-Transport
+L;LIMES


### PR DESCRIPTION
## Purpose of this PR

Adding limes to ecemf mapping.

## Checklist:
- [x] I did not use Excel to open csv files or checked that no side-effects occur (changed values, many new quotation marks, …)
- [x] I added any renamed piam_variable to [`renamed_piam_variables.csv`](https://github.com/pik-piam/piamInterfaces/blob/master/inst/renamed_piam_variables.csv) to guarantee backwards compatibility.
- [x] For REMIND variables, I used `|+|` notation consistently. This can be achieved automatically with [`updatePlusUnit()`](https://github.com/pik-piam/piamInterfaces/blob/master/R/updatePlusUnit.R).

It is recommended to have a look at the [tutorial](https://github.com/pik-piam/piamInterfaces/blob/master/tutorial.md) before submission.
